### PR TITLE
feat: process workflow files — new-task, ship, debug, post-merge

### DIFF
--- a/templates/project/processes/DEBUG_WORKFLOW.md
+++ b/templates/project/processes/DEBUG_WORKFLOW.md
@@ -1,0 +1,92 @@
+# DEBUG_WORKFLOW
+
+> Follow this when something is broken and the cause is not obvious.
+> The most common debugging mistake is fixing before understanding.
+> This workflow forces understanding first.
+
+---
+
+## When to follow this workflow
+
+- When a test fails and you don't immediately know why
+- When runtime behavior doesn't match expectations
+- When the user says "why is this broken" or "this isn't working"
+
+---
+
+## Step 1 — Reproduce first
+
+**Do not touch any code until you can reproduce the bug reliably.**
+
+If you cannot reproduce it:
+- Describe what you tried to the user
+- Ask for additional context (environment, steps, error output)
+- Do not invent a fix for a phantom bug
+
+A bug you can't reproduce is a hypothesis, not a bug.
+
+---
+
+## Step 2 — Isolate
+
+Narrow down where the problem lives:
+
+- Which layer: UI / API / service / database / external dependency?
+- Which module or function?
+- Does it happen always, or only under specific conditions?
+- What changed recently that could have caused this?
+
+**State your hypothesis explicitly before looking at code.**
+
+Saying "I think X is happening because Y" commits you to a theory and makes it
+easier to notice when the evidence contradicts it.
+
+---
+
+## Step 3 — Inspect, don't guess
+
+Read the relevant code. Verify:
+
+- What inputs are actually arriving (add temporary logging if needed, remove before committing)
+- What the code is actually doing vs. what you assumed
+- Whether the bug is in this code or in something it calls
+
+Do not form a fix until you have confirmed the root cause by reading the code.
+
+---
+
+## Step 4 — Fix
+
+Make the **smallest possible change** that resolves the confirmed root cause.
+
+Rules:
+- Do not refactor while fixing — one concern at a time
+- Do not fix unrelated issues discovered during investigation — log them in `memory/ERRORS.md`
+- If the proper fix requires a larger refactor, apply a minimal patch first, then open a
+  separate task for the refactor
+
+---
+
+## Step 5 — Verify the fix
+
+- Reproduce the original failure scenario — confirm the bug is gone
+- Run related tests
+- Check for regressions in adjacent functionality
+- If you added temporary logging in Step 3, remove it now
+
+---
+
+## Step 6 — Log it
+
+Add an entry to `memory/ERRORS.md`:
+
+```markdown
+## [YYYY-MM-DD] — [Short title]
+
+**Symptom**: What was observed / what broke
+**Root cause**: What was actually wrong
+**Fix**: What change resolved it
+**Watch for**: Related areas that could have the same issue
+```
+
+Every bug logged here is a bug that cannot bite twice.

--- a/templates/project/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/processes/NEW_TASK_WORKFLOW.md
@@ -1,0 +1,111 @@
+# NEW_TASK_WORKFLOW
+
+> Follow this process every time you start a new task. No exceptions.
+> The discipline of planning before coding is the whole point.
+
+---
+
+## When to follow this workflow
+
+- When the user says "start a task", "let's work on X", or "pick up the next task"
+- When pulling a task from `tasks/backlog/`
+- When resuming an interrupted task from `tasks/active/`
+
+---
+
+## Step 0 — Confirm your working directory
+
+Before touching any file, identify the main repo root and confirm all edits will target it.
+
+> **Why this matters:** Claude Code runs sessions inside hidden git worktrees at paths like
+> `.claude/worktrees/<session-name>/`. File edits written there are **invisible** to the
+> user's git client (Sourcetree, GitKraken, Tower, etc.). This has caused entire sessions
+> worth of work to be silently discarded. Always work in the main repo.
+
+```bash
+# Identify the main repo root
+git rev-parse --show-toplevel
+```
+
+- All `Write` and `Edit` tool calls must use **absolute paths** under the main repo root
+- All `git` commands must target the main repo: `git -C <repo-root> <command>`
+- Never create branches, commits, or files inside the `.claude/worktrees/` path
+
+---
+
+## Step 1 — Orient
+
+Read these files before anything else, in this order:
+
+1. `memory/CONTEXT_SNAPSHOT.md` — current state, decisions in flight, known footguns
+2. `memory/PROGRESS.md` — what has shipped and when
+3. `memory/ERRORS.md` — pitfalls to avoid
+4. The task file in `tasks/active/` or `tasks/backlog/`
+
+**If no task file exists:** stop and ask the user to create one before proceeding.
+Do not invent a task file unilaterally.
+
+---
+
+## Step 2 — Confirm understanding
+
+Before writing a plan, state back to the user in 2–3 sentences:
+
+- What the task is asking for
+- Which files you expect to touch
+- Any risks, ambiguities, or open questions you see
+
+**Wait for the user's confirmation** before proceeding to Step 3.
+
+If you have a clarifying question, ask exactly one. Do not stack questions.
+
+---
+
+## Step 3 — Plan
+
+Write a numbered implementation plan into the task file under `## Approach`.
+
+Requirements for a valid plan:
+- File-level granularity — not just "update the service", but "edit `services/llm/base.py` to add X"
+- Explicit about what is NOT changing (reduces scope creep)
+- Any dependency ordering called out (step A must complete before step B)
+
+**Wait for the user's approval on the plan** before writing any code.
+
+---
+
+## Step 4 — Implement
+
+Work through the plan one step at a time.
+
+- After each meaningful step, briefly confirm what was done before moving to the next
+- If you hit something unexpected, **surface it** — do not silently work around it
+- Do not refactor unrelated code while implementing
+- Do not fix unrelated bugs — log them in `memory/ERRORS.md` and move on
+
+---
+
+## Step 5 — Verify
+
+Before declaring done:
+
+- Run available tests; fix failures before proceeding
+- Walk through each acceptance criterion in the task file and confirm it is met
+- Do a quick self-review: does the output do what was asked and **nothing more**?
+
+---
+
+## Step 6 — Wrap up
+
+In this order:
+
+1. Update the task file: change `**Status**` to `done`, fill in `## Done notes`
+2. Move the task file from `tasks/active/` → `tasks/done/`
+3. Update `memory/PROGRESS.md` with a one-line summary of what was built
+4. Log any new pitfalls or surprises in `memory/ERRORS.md`
+5. Commit with a conventional commit message referencing the task name and issue number
+6. Follow `SHIP_WORKFLOW.md` to open the PR
+
+> **Staging note:** Stage the task file **only after** it has been moved to `tasks/done/`.
+> Never commit a task file from `tasks/active/` — it creates a confusing history where
+> the "in-progress" and "completed" states both appear in the same PR.

--- a/templates/project/processes/POST_MERGE_WORKFLOW.md
+++ b/templates/project/processes/POST_MERGE_WORKFLOW.md
@@ -1,0 +1,93 @@
+# POST_MERGE_WORKFLOW
+
+> Run this immediately after a PR is merged to main.
+> Takes about 5 minutes. Keeps the system clean for the next session.
+
+---
+
+## When to follow this workflow
+
+- After the user says "merged" or confirms a PR has landed
+- After any PR merges to main, regardless of size
+
+---
+
+## Step 1 — Pull latest main
+
+```bash
+git checkout main && git pull origin main
+```
+
+Confirm the expected commit is at HEAD before proceeding.
+
+---
+
+## Step 2 — Update PROGRESS.md
+
+Add an entry at the **top** of `memory/PROGRESS.md` (below the header):
+
+```markdown
+## [YYYY-MM-DD] — [PR title or one-line summary]
+
+- [bullet: what was built]
+- [bullet: what was verified]
+- PR #N merged — branch: type/description
+```
+
+---
+
+## Step 3 — Move the task file
+
+1. Move the completed task file: `tasks/active/TASK_[name].md` → `tasks/done/TASK_[name].md`
+2. Update its `**Status**` field to `done`
+3. Verify `tasks/active/` is clean — only `.gitkeep` should remain if all tasks are done
+
+---
+
+## Step 4 — Overwrite CONTEXT_SNAPSHOT.md
+
+Rewrite `memory/CONTEXT_SNAPSHOT.md` with the current state of the project.
+**Never delete this file — always overwrite it.**
+
+The snapshot must include:
+
+- Where the project stands right now (one paragraph)
+- Full list of merged PRs (add the just-merged PR)
+- Any open PRs
+- What comes next, in priority order
+- Key decisions that must carry forward to the next session
+- Known footguns and environment quirks
+- Tech debt worth tracking
+
+This file is **gitignored** — it lives on disk only, read at session start.
+
+---
+
+## Step 5 — Check ERRORS.md
+
+If anything unexpected happened during the task or the merge process, log it now.
+Do not defer — the detail is freshest immediately after the work.
+
+---
+
+## Step 6 — Housekeeping commit
+
+If `PROGRESS.md` updates and the task file move were not already committed
+as part of the PR:
+
+```bash
+git checkout -b chore/post-merge-[N]
+git add memory/PROGRESS.md tasks/done/TASK_[name].md
+git commit -m "chore: post-merge housekeeping for PR #N"
+git push -u origin chore/post-merge-[N]
+# Then open a small PR or push directly per your team's convention
+```
+
+---
+
+## Step 7 — Surface what's next
+
+Read the updated `CONTEXT_SNAPSHOT.md` and state the next priority.
+Ask the user: **"What's next?"**
+
+Do not begin the next task until the user confirms.

--- a/templates/project/processes/SHIP_WORKFLOW.md
+++ b/templates/project/processes/SHIP_WORKFLOW.md
@@ -1,0 +1,133 @@
+# SHIP_WORKFLOW
+
+> Follow this process before every commit that closes a task and before every PR.
+> Skipping steps here is how bugs, secrets, and broken builds reach production.
+
+---
+
+## When to follow this workflow
+
+- When you are ready to commit and close a task
+- When opening a pull request
+
+---
+
+## Step 0 — Create the GitHub issue first
+
+**Before writing any code, create the GitHub issue.**
+
+The commit message must reference the issue number: `feat(scope): description [#N]`.
+If you create the issue after the commit, you cannot reference it honestly — the
+number belongs in the commit, not as a retroactive edit.
+
+```bash
+gh issue create --title "..." --body-file /tmp/issue-body.md --label "type: feat"
+```
+
+Note the issue number. It goes in every commit on this branch.
+
+---
+
+## Step 1 — Pre-ship checklist
+
+Work through this list before staging anything:
+
+- [ ] All acceptance criteria in the task file are met
+- [ ] No `console.log`, `print()`, or other debug statements left in code
+- [ ] No commented-out code (we have git history)
+- [ ] No hardcoded secrets, tokens, or credentials
+- [ ] Error cases handled — not just the happy path
+- [ ] If the PR touches `Dockerfile`, `requirements.txt`, `package.json`, or the service layer:
+      in-container verification has been run per `rules/verification.md`
+- [ ] After any Docker verification step: `git status --short` checked — volume mounts
+      can generate untracked files that must be committed or gitignored
+
+---
+
+## Step 2 — Self-review
+
+Read the full diff. Ask:
+
+- Does this do what the task asked and **nothing more**?
+- Is there anything that could fail in production that didn't fail locally?
+- Are there side effects on other features?
+- Would a reviewer understand why each change was made?
+
+If any answer gives you pause, fix it before committing.
+
+---
+
+## Step 3 — Commit
+
+Use conventional commit format:
+
+```
+type(scope): short description [#N]
+
+Body: explain WHY, not what. The diff shows what.
+```
+
+Valid types: `feat` | `fix` | `refactor` | `test` | `docs` | `chore` | `style` | `perf` | `devops`
+
+Write the commit message to a temp file to avoid shell quoting issues:
+
+```bash
+cat > /tmp/commit-msg.txt << 'EOF'
+feat(scope): description [#N]
+
+Body explaining the why.
+EOF
+git commit -F /tmp/commit-msg.txt
+```
+
+---
+
+## Step 4 — Update memory
+
+In this order:
+
+1. Move task file from `tasks/active/` → `tasks/done/`
+2. Update `memory/PROGRESS.md` — add entry at top with what shipped
+3. Overwrite `memory/CONTEXT_SNAPSHOT.md` — full current state, never delete
+4. If anything surprised you during the task, log it in `memory/ERRORS.md`
+
+---
+
+## Step 5 — Open the PR
+
+Use the PR template **exactly**. Five sections: Summary, Changes, Closes, Test plan, Notes.
+
+```bash
+cat > /tmp/pr-body.md << 'EOF'
+## Summary
+
+## Changes
+-
+
+## Closes
+Closes #N
+
+## Test plan
+
+## Notes
+EOF
+gh pr create --title "..." --body-file /tmp/pr-body.md --base main --label "type: feat"
+```
+
+**Apply labels at creation time.** Never retroactively. Required labels:
+- One `type:` label matching the commit type
+- One or more `area:` labels for the layers touched
+
+---
+
+## Step 6 — Housekeeping commit (if needed)
+
+If the memory updates and task file move were not included in the implementation commit,
+make a follow-up housekeeping commit on the same branch:
+
+```bash
+git add memory/PROGRESS.md tasks/done/TASK_[name].md
+git commit -m "chore: post-task housekeeping [#N]"
+```
+
+This commit goes on the same PR branch before the PR is merged.


### PR DESCRIPTION
## Summary
Adds the four process workflow files — the operational heart of The Rig. These encode the discipline learned across 100+ PRs of real AI-assisted development: when to plan, how to ship safely, how to debug without guessing, and how to close out a session without losing state.

## Changes
- `NEW_TASK_WORKFLOW.md` — 6-step task start process. Includes the working-directory orientation step (Step 0) that prevents the worktree footgun — the most painful bug discovered during the LaudBot pilot.
- `SHIP_WORKFLOW.md` — Issue-first rule, pre-ship checklist (including Docker verification gate), self-review, label-at-creation-time enforcement, housekeeping commit pattern.
- `DEBUG_WORKFLOW.md` — Hypothesis-first debugging: state the theory before reading code, smallest possible fix, mandatory ERRORS.md entry.
- `POST_MERGE_WORKFLOW.md` — Full post-merge sequence: pull → PROGRESS update → task file move → CONTEXT_SNAPSHOT overwrite → ERRORS check → next priority.

All four files are fully generalized — no LaudBot-specific references.

## Closes
Closes #3

## Test plan
- Read each file cover to cover — checked for internal consistency and no project-specific leakage
- Verified all four files are self-contained: a new agent following them cold gets correct behaviour

## Notes
These files ship at `templates/project/processes/`. The install script (coming in a later PR) will copy them into the user's target project.
