### PR TITLE
feat: rules files — coding standards, git conventions, security, verification

### DIFF
--- a/templates/project/rules/coding-standards.md
+++ b/templates/project/rules/coding-standards.md
@@ -1,0 +1,81 @@
+# Coding standards
+
+> This file defines the conventions for every runtime in this project.
+> Add a section for each language or framework you use.
+> The agent reads this during every implementation task.
+
+---
+
+## How to use this file
+
+Duplicate the template section below for each runtime in your stack.
+Fill in the conventions that apply. Delete examples that don't fit.
+The agent will follow whatever you write here — be specific.
+
+---
+
+## [Runtime 1 — e.g. Python / FastAPI]
+
+### Naming
+- Variables, functions, methods: `snake_case`
+- Classes: `PascalCase`
+- Constants and module-level config: `SCREAMING_SNAKE_CASE`
+- Files and modules: `snake_case`
+- [Model/schema fields]: `snake_case`
+
+### Types
+- Type hints required on all function signatures (parameters and return types)
+- No untyped `dict` passed between functions — define a model or TypedDict
+- [Add language-specific type rules here]
+
+### Documentation
+- [Docstring style — e.g. Google-style on all non-trivial functions]
+- One-liner acceptable for simple functions
+- No docstrings on private helpers that are self-explanatory
+
+### General
+- Max 40 lines per function. If longer, extract.
+- Max 3 parameters per function. If more, use a data class or model.
+- Pure functions preferred — no side effects unless necessary.
+- Always handle the error case explicitly — never bare `except:` or equivalent.
+- Group imports: stdlib → third-party → internal. Blank line between groups.
+- No wildcard imports.
+
+---
+
+## [Runtime 2 — e.g. TypeScript / Next.js]
+
+### Naming
+- Variables and functions: `camelCase`
+- Components and classes: `PascalCase`
+- Constants: `SCREAMING_SNAKE_CASE`
+- Files: `kebab-case` (except components: `PascalCase.[ext]`)
+- Be descriptive — `getUserById` not `getUser`, `isLoading` not `loading`
+
+### Types
+- No `any` without a comment explaining why
+- Prefer `interface` for object shapes, `type` for unions and primitives
+- No untyped props — all component props must have a defined interface
+
+### Comments
+- JSDoc on all exported functions and components
+- Comment the *why*, not the *what*
+
+### General
+- Max 40 lines per function. If longer, extract.
+- Prefer `const` over `let`. Never `var`.
+- No magic numbers — name your constants.
+- No commented-out code in commits — delete it.
+- Absolute imports preferred over relative (configure in `tsconfig.json` or equivalent).
+- Group imports: external → internal → styles. Blank line between groups.
+- No wildcard imports.
+
+---
+
+## Both runtimes
+
+- Delete dead code. We have git history.
+- No `console.log`, `print()`, or equivalent debug statements in committed code.
+- Error handling: never swallow silently. Always log with enough context to debug.
+- User-facing errors: human readable — never expose stack traces or internal details.
+- No hardcoded credentials, tokens, or secrets — always use environment variables.

--- a/templates/project/rules/git-conventions.md
+++ b/templates/project/rules/git-conventions.md
@@ -1,0 +1,67 @@
+# Git conventions
+
+---
+
+## Branch naming
+
+```
+feat/short-description        # new feature
+fix/short-description         # bug fix
+chore/short-description       # tooling, deps, config, maintenance
+refactor/short-description    # code change with no behaviour change
+docs/short-description        # documentation only
+devops/short-description      # CI/CD, Docker, infra, release
+```
+
+Keep branch names lowercase, hyphen-separated, under 50 characters.
+
+---
+
+## Commit message format
+
+Follows [Conventional Commits](https://www.conventionalcommits.org/).
+
+```
+type(scope): short description [#N]
+
+Optional body explaining WHY, not what. The diff shows what.
+```
+
+**Types:** `feat` | `fix` | `chore` | `refactor` | `docs` | `test` | `perf` | `devops`
+
+**Scope:** the area of the codebase affected (e.g. `auth`, `api`, `ui`, `db`, `hooks`)
+
+**Issue reference:** `[#N]` at the end of the subject line. Required when a GitHub issue exists.
+
+### Examples
+
+```
+feat(auth): add invite token acceptance flow [#12]
+fix(api): handle null user on profile fetch [#18]
+chore(deps): upgrade next to 14.2.1
+docs(readme): add quickstart section [#31]
+devops(ci): add Docker build step to GitHub Actions [#7]
+```
+
+---
+
+## Rules
+
+- **Issue before commit.** Create the GitHub issue before writing code. The issue number must be in the commit message — not added retroactively.
+- **Commit after each meaningful unit of work.** Not at end of day. Not after five unrelated changes.
+- **Never commit directly to `main` or `master`.** Always branch.
+- **Never force-push to shared branches.**
+- **Reference issue numbers in commits** when a GitHub issue exists: `feat(scope): description [#N]`
+- Each commit must leave the repo in a working state (linting and tests pass).
+
+---
+
+## PR checklist
+
+- [ ] Issue created before any code was written
+- [ ] Tests added or updated (note if test framework not yet set up)
+- [ ] `memory/PROGRESS.md` updated if completing a task
+- [ ] No `console.log`, `print()`, or debug statements left in
+- [ ] Self-reviewed diff before opening PR
+- [ ] No secrets or credentials in staged files
+- [ ] Labels applied at PR creation time

--- a/templates/project/rules/security.md
+++ b/templates/project/rules/security.md
@@ -1,0 +1,69 @@
+# Security rules
+
+> These are non-negotiable. The agent must follow them regardless of context or time pressure.
+> Document any project-specific additions in the section at the bottom.
+
+---
+
+## Non-negotiables — the agent must never do these
+
+- **Never log secrets, tokens, passwords, or PII.** Not in application logs, not in debug output, not in commit messages.
+- **Never hardcode credentials.** All secrets come from environment variables. No exceptions.
+- **Never expose internal error details in API responses.** Return a human-readable message. Log the detail server-side.
+- **Never trust client-supplied data without validation.** Validate and sanitise at every system boundary.
+- **Never build raw SQL strings.** Always use parameterised queries or the ORM.
+- **Never commit `.env` files.** Verify `.gitignore` covers them before every commit.
+
+---
+
+## Auth
+
+- Always verify session tokens or JWTs server-side on protected routes. Never trust the client's claim.
+- Never store sensitive data in `localStorage` — use `httpOnly` cookies or server-side session.
+- Rate-limit all auth endpoints before any public-facing deployment.
+- Store invite or one-time tokens as hashes — never plaintext.
+
+---
+
+## API
+
+- Validate and sanitise all inputs at the boundary (request body, query params, headers).
+- Return `404` (not `403`) when a resource exists but the requester cannot access it — do not leak resource existence.
+- Always check ownership before allowing read or write on user-scoped resources.
+
+---
+
+## Dependencies
+
+- Flag any new dependency before adding it — discuss the tradeoff first.
+- No packages with known high or critical CVEs without explicit sign-off.
+- Run `npm audit` or equivalent before any production deploy.
+
+---
+
+## Environment
+
+- `.env` files must be in `.gitignore` — verify before every commit.
+- Use separate secrets for dev, staging, and production. Never reuse across environments.
+- Provide a `.env.example` with all required variable names and placeholder values — no real secrets.
+
+---
+
+## If a secret appears in context
+
+If a key, token, or password appears in the conversation or a file during a session:
+
+1. Flag it immediately.
+2. Do not include it in any commit, log, or output.
+3. Prompt the user to rotate it — even if it only appeared locally.
+
+---
+
+## Project-specific additions
+
+> Add rules here that are specific to this project's data model, compliance requirements,
+> or privacy policy. Examples:
+>
+> - "The `[path]` directory is read-only — never write to it."
+> - "Never surface [data type] in API responses."
+> - "All [entity] records must be soft-deleted, never hard-deleted."

--- a/templates/project/rules/verification.md
+++ b/templates/project/rules/verification.md
@@ -1,0 +1,75 @@
+# Verification rules
+
+> Defines when and how to verify code before committing.
+> Applied in addition to the pre-ship checklist in `processes/SHIP_WORKFLOW.md`.
+
+---
+
+## When in-container verification is required
+
+Run an in-container smoke test before committing whenever a PR touches **any** of:
+
+- `docker-compose.yml` or any `Dockerfile`
+- Dependency manifests: `requirements.txt`, `package.json`, `pyproject.toml`, `Gemfile`, etc.
+- Any service-layer module (code that other modules import at startup)
+- Any new module that runs at application boot
+
+The reason: linting and diff review cannot catch import errors, missing packages, or
+Docker layer issues. These only surface when the container actually starts.
+
+---
+
+## Minimum smoke test
+
+```bash
+# 1. Confirm the image builds cleanly
+docker compose build [service-name]
+
+# 2. Confirm the stack boots and the health endpoint responds
+docker compose up -d
+sleep 4
+curl -sf http://localhost:[PORT]/health || (echo "Health check failed" && exit 1)
+docker compose down
+
+# 3. For logic changes — run an in-container assertion
+docker compose run --rm [service] [runtime] -c "[assertion]"
+# Examples:
+#   docker compose run --rm backend python -c "from app.main import app; print('ok')"
+#   docker compose run --rm backend python -m pytest tests/unit/ -q
+```
+
+Adapt the health endpoint path and port to your project.
+
+---
+
+## Document it in the commit message
+
+The commit body must include a line describing what was verified:
+
+```
+- Verified in-container: image builds, /health 200, import check passes
+```
+
+---
+
+## After Docker verification — check for untracked files
+
+Docker volume mounts can generate new files inside the container that appear in
+the host working directory. Always run:
+
+```bash
+git status --short
+```
+
+after any Docker verification step. Commit or `.gitignore` any untracked files
+before opening the PR.
+
+---
+
+## When in-container verification is NOT required
+
+- Changes to docs, task files, memory files, or rules only
+- Frontend-only changes that don't touch `package.json` or any `Dockerfile`
+- Pure type annotation or comment changes with no logic
+
+In these cases, a diff review is sufficient.


### PR DESCRIPTION
## Summary
Adds the four rules files — the "always true" layer of The Rig. Unlike processes (step-by-step workflows), rules are referenced continuously during implementation and define the conventions every agent session must follow.

## Changes
- `coding-standards.md` — Language-agnostic structure with fill-in sections per runtime. Avoids the LaudBot mistake of hardcoding Python+TypeScript conventions into a general template.
- `git-conventions.md` — Conventional commits, issue-before-commit rule, branch naming, PR checklist. Includes `devops` as a declared commit type (it was being used in LaudBot before it was formally declared).
- `security.md` — Non-negotiables (no raw SQL, no hardcoded secrets, no PII in logs), auth and API hardening rules, environment hygiene, and a project-specific additions section for per-project overrides.
- `verification.md` — In-container smoke test protocol for any PR touching Docker, dependencies, or the service layer. Includes the untracked-files check after Docker operations (a real footgun from the pilot).

## Closes
Closes #5

## Test plan
- Read each file for internal consistency and checked for LaudBot-specific leakage
- Confirmed `coding-standards.md` is stack-agnostic with clear placeholder markers
- Verified `security.md` project-specific additions section is clearly delimited

## Notes
`coding-standards.md` ships with example conventions for two runtimes. Users replace the `[Runtime 1]` / `[Runtime 2]` headers and fill in their own stack's rules — or delete sections that don't apply.
