### PR TITLE
feat: Claude Code hooks and slash commands

### DIFF
--- a/templates/project/.claude/commands/debug.md
+++ b/templates/project/.claude/commands/debug.md
@@ -1,0 +1,33 @@
+# Command: /debug
+
+Trigger this command when something is broken and you need structured diagnosis.
+
+## What this does
+
+Follows `processes/DEBUG_WORKFLOW.md`:
+
+1. Asks you to describe the symptom and what you expected instead
+2. Asks where you've already looked
+3. States a hypothesis before touching any code
+4. Works through: reproduce → isolate → inspect → fix → verify
+5. Logs the bug and root cause in `memory/ERRORS.md`
+
+## Usage
+
+```
+/debug
+```
+
+Claude will ask:
+- What are you seeing?
+- What did you expect to happen?
+- Can you reproduce it consistently?
+- Where have you already looked?
+
+Then it follows DEBUG_WORKFLOW systematically — hypothesis first, smallest fix, mandatory log entry.
+
+## Notes
+
+- No code is touched until the bug can be reproduced (Step 1 of DEBUG_WORKFLOW)
+- If the fix requires a larger refactor, a minimal patch is applied first and a separate task is opened for the refactor
+- Every `/debug` session ends with an ERRORS.md entry — even if the bug turns out to be trivial

--- a/templates/project/.claude/commands/new-feature.md
+++ b/templates/project/.claude/commands/new-feature.md
@@ -1,0 +1,32 @@
+# Command: /new-feature
+
+Trigger this command to kick off a new feature task end-to-end.
+
+## What this does
+
+Follows `processes/NEW_TASK_WORKFLOW.md` from the beginning:
+
+1. Asks you for the feature name and one-sentence goal
+2. Creates a task file in `tasks/backlog/` using the task template
+3. Confirms the goal and files to touch
+4. Writes the implementation plan into the task file under `## Approach`
+5. Waits for your approval before writing any code
+
+## Usage
+
+```
+/new-feature
+```
+
+Claude will ask:
+- What's the feature name?
+- What's the one-sentence goal?
+- Any files that are off-limits or out of scope for this task?
+
+Then it creates the task file and follows `NEW_TASK_WORKFLOW.md` from Step 1.
+
+## Notes
+
+- A GitHub issue must be created before any code is written (Step 0 of SHIP_WORKFLOW)
+- The task file is not staged until it has been moved to `tasks/done/`
+- If a task file already exists in `tasks/active/`, ask whether to resume it instead

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -1,0 +1,32 @@
+# Command: /ship
+
+Trigger this command when you're ready to commit and close out a task.
+
+## What this does
+
+Follows `processes/SHIP_WORKFLOW.md`:
+
+1. Identifies the active task file and confirms which task is being shipped
+2. Runs through the pre-ship checklist (acceptance criteria, no debug code, no secrets, verification)
+3. Shows you the proposed commit message and waits for approval
+4. Commits, moves the task file to `tasks/done/`, updates `memory/PROGRESS.md`
+5. Opens the PR using the project's PR template
+
+## Usage
+
+```
+/ship
+```
+
+Claude will confirm:
+- Which task is being shipped
+- The commit message it will use (conventional format, references the issue)
+- Any checklist items that look incomplete or ambiguous
+
+It then waits for your explicit **"go ahead"** before committing.
+
+## Notes
+
+- The GitHub issue must already exist before `/ship` is run (see SHIP_WORKFLOW Step 0)
+- Labels are applied at PR creation time — Claude will prompt if none are specified
+- The task file is staged only from `tasks/done/`, never from `tasks/active/`

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -1,0 +1,32 @@
+# Command: /wrap
+
+Trigger this command before ending a session or when approaching a context limit.
+
+## What this does
+
+Performs the session-end housekeeping that prevents state loss between sessions:
+
+1. Writes (overwrites) `memory/CONTEXT_SNAPSHOT.md` with full current project state
+2. Ensures `memory/PROGRESS.md` is up to date — expands any auto-stubbed entries
+3. Checks `memory/ERRORS.md` — prompts you to log anything unexpected from this session
+4. Reports what's in `tasks/active/` so you know what's in flight
+5. Surfaces the next priority from `tasks/backlog/` and asks: "What's next?"
+
+## Usage
+
+```
+/wrap
+```
+
+Run this:
+- Before closing Claude Code for the day
+- When the conversation is getting long and you want a clean handoff point
+- Before switching to a different task or project
+- Any time you want to ensure a future session can pick up exactly where you left off
+
+## Notes
+
+- `CONTEXT_SNAPSHOT.md` is gitignored — it lives on disk only, never committed
+- Always **overwrite** the snapshot, never append to it; it represents current state, not history
+- History belongs in `PROGRESS.md`; the snapshot is purely for session continuity
+- If a task is in progress but not done, note its exact state in the snapshot so the next session can resume without re-reading the whole conversation

--- a/templates/project/.claude/hooks/post-tool.sh
+++ b/templates/project/.claude/hooks/post-tool.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# post-tool.sh
+#
+# Runs after Claude Code executes any tool.
+# Wired via .claude/settings.json.
+#
+# Claude Code passes:
+#   $1  — tool name (PascalCase: Write, Edit, Bash, Read, Glob, Grep, etc.)
+#   stdin — tool result as JSON
+
+TOOL="$1"
+RESULT=$(cat)
+
+# ── Repo root — dynamic, never hardcoded ─────────────────────────────────────
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -z "$REPO" ]]; then
+  exit 0  # Not in a git repo, nothing to do
+fi
+
+PROGRESS_FILE="$REPO/memory/PROGRESS.md"
+SESSION_LOG="/tmp/the-rig-session.log"
+
+# ── Session log ───────────────────────────────────────────────────────────────
+echo "[$(date +%H:%M:%S)] POST $TOOL" >> "$SESSION_LOG"
+
+# ── Auto-stub PROGRESS.md after git commits ───────────────────────────────────
+# After any Bash tool call, check whether a new commit just landed.
+# If so, append a dated stub entry to PROGRESS.md so the record exists even
+# if Claude forgets to update it during wrap-up. Claude expands the stub later.
+#
+# Heuristic: git commit output always contains a short hash in brackets,
+# e.g. "[feat/auth abc1234] feat(auth): add token validation [#12]"
+if [[ "$TOOL" == "Bash" ]]; then
+
+  if echo "$RESULT" | grep -qE '\[[a-f0-9]{7,}\]'; then
+    COMMIT_MSG=$(git -C "$REPO" log -1 --format="%s" 2>/dev/null)
+    COMMIT_HASH=$(git -C "$REPO" log -1 --format="%h" 2>/dev/null)
+    COMMIT_DATE=$(date +%Y-%m-%d)
+
+    if [[ -n "$COMMIT_MSG" && -n "$COMMIT_HASH" ]]; then
+
+      # Only append if this hash isn't already logged (idempotent)
+      if ! grep -q "$COMMIT_HASH" "$PROGRESS_FILE" 2>/dev/null; then
+
+        STUB="\n## $COMMIT_DATE — $COMMIT_MSG [$COMMIT_HASH]\n_Auto-logged by post-tool hook. Expand this entry during wrap-up._\n\n---"
+
+        # Insert after the first --- separator in PROGRESS.md
+        TMP=$(mktemp)
+        awk -v stub="$STUB" '/^---$/ && !done { print; printf "%s\n", stub; done=1; next } 1' \
+          "$PROGRESS_FILE" > "$TMP" && mv "$TMP" "$PROGRESS_FILE"
+
+        echo "[$(date +%H:%M:%S)] PROGRESS stub: $COMMIT_HASH $COMMIT_MSG" >> "$SESSION_LOG"
+      fi
+    fi
+  fi
+fi
+
+exit 0

--- a/templates/project/.claude/hooks/pre-tool.sh
+++ b/templates/project/.claude/hooks/pre-tool.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# pre-tool.sh
+#
+# Runs before Claude Code executes any tool.
+# Exit 0 to allow the tool call. Exit 1 to block it (stderr is shown to Claude).
+#
+# Claude Code passes:
+#   $1  — tool name (PascalCase: Write, Edit, Bash, Read, Glob, Grep, etc.)
+#   stdin — tool input as JSON
+#
+# IMPORTANT: Tool names are PascalCase. Using snake_case (write_file, edit_file)
+# will cause this script to silently never block anything. This was a real bug
+# in production for 30+ PRs before it was caught.
+
+TOOL="$1"
+INPUT=$(cat)
+
+# ── Session log ──────────────────────────────────────────────────────────────
+# Logs every tool call with a timestamp. Useful for debugging agent behaviour.
+# Comment out if too noisy.
+echo "[$(date +%H:%M:%S)] PRE  $TOOL" >> /tmp/the-rig-session.log
+
+# ── Block writes to protected paths ──────────────────────────────────────────
+if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
+
+  # Extract the target file path from the JSON input
+  PATH_ARG=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+  # ── Configure your project's protected paths here ────────────────────────
+  # These paths cannot be written to by the agent under any circumstances.
+  # Use partial paths — anything containing the string will be blocked.
+  # Examples:
+  #   ".env.production"   — production environment file
+  #   "migrations/"       — database migrations (run manually, not by agent)
+  #   "data/approved/"    — curated data files managed by humans
+  BLOCKED_PATHS=(
+    ".env.production"
+    # "migrations/"
+    # "data/approved/"
+  )
+  # ─────────────────────────────────────────────────────────────────────────
+
+  for blocked in "${BLOCKED_PATHS[@]}"; do
+    if [[ "$PATH_ARG" == *"$blocked"* ]]; then
+      echo "Blocked: '$PATH_ARG' matches protected path '$blocked'" >&2
+      echo "This path is off-limits. Edit it manually if a change is truly needed." >&2
+      exit 1
+    fi
+  done
+fi
+
+exit 0

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/pre-tool.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/post-tool.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds the Claude Code hooks layer and four slash commands. Hooks are the enforcement layer — they make certain failures physically impossible rather than just discouraged. The slash commands reduce friction on the three most common workflows and add `/wrap` for session-end housekeeping.

## Changes
- `.claude/settings.json` — wires `PreToolUse` and `PostToolUse` to run on all tool calls. Uses `git rev-parse --show-toplevel` for the hook path so no machine-specific paths are hardcoded.
- `.claude/hooks/pre-tool.sh` — blocks `Write` and `Edit` to configured `BLOCKED_PATHS`. **Includes the fix for the most costly bug from the LaudBot pilot**: tool names are `PascalCase` (`Write`, `Edit`), not `snake_case`. The original used `snake_case` and silently never fired for 30+ PRs.
- `.claude/hooks/post-tool.sh` — detects git commits in Bash output via a short-hash-in-brackets heuristic. Auto-stubs a dated entry in `PROGRESS.md` immediately after any commit so the log is never silently skipped. Idempotent, repo root resolved dynamically.
- `.claude/commands/new-feature.md` — `/new-feature` triggers `NEW_TASK_WORKFLOW`
- `.claude/commands/ship.md` — `/ship` triggers `SHIP_WORKFLOW`
- `.claude/commands/debug.md` — `/debug` triggers `DEBUG_WORKFLOW`
- `.claude/commands/wrap.md` — `/wrap` is new (identified as missing in the pilot). Writes `CONTEXT_SNAPSHOT.md`, ensures `PROGRESS.md` is current, surfaces next priority before session end.

## Closes
Closes #9

## Test plan
- Verified `settings.json` JSON is valid
- Confirmed both hook scripts use `PascalCase` tool names throughout
- Confirmed `post-tool.sh` uses `git rev-parse --show-toplevel` (not a hardcoded path)
- Read all four command files — each references the correct workflow document

## Notes
The `BLOCKED_PATHS` in `pre-tool.sh` ships with only `.env.production` enabled by default. `migrations/` and `data/approved/` are commented out as examples — project-specific paths that users uncomment or replace for their own setup.
