### PR TITLE
feat: Husky git hooks — secret scanning and AI trailer stripping

### DIFF
--- a/templates/project/.gitleaks.toml
+++ b/templates/project/.gitleaks.toml
@@ -1,0 +1,37 @@
+# .gitleaks.toml
+#
+# Gitleaks configuration for secret scanning.
+# Extends the built-in gitleaks ruleset with project-specific allowlist entries.
+#
+# Docs: https://github.com/gitleaks/gitleaks/blob/master/config/README.md
+
+[extend]
+# Inherit all default gitleaks detection rules.
+useDefault = true
+
+[allowlist]
+description = "Allowlist for known safe patterns"
+
+# Files that intentionally contain placeholder values
+paths = [
+  ".env.example",         # Template file — contains placeholder variable names only
+  ".gitleaks.toml",       # This file — contains pattern examples
+]
+
+# Regex patterns that are safe to commit even if they look like secrets
+regexes = [
+  # Common placeholder values used in example/template files
+  "changeme",
+  "your-secret-here",
+  "replace-me",
+  "example-key",
+  "dev-secret-change-in-production",
+  "dummy",
+  "fake",
+  "test",
+]
+
+# ── Add project-specific allowlist entries below ──────────────────────────────
+# Example: allowlist a specific known-safe string
+# regexTarget = "match"
+# regexes = ["AKIAIOSFODNN7EXAMPLE"]  # AWS example key from docs

--- a/templates/project/.husky/commit-msg
+++ b/templates/project/.husky/commit-msg
@@ -1,0 +1,22 @@
+#!/bin/sh
+# commit-msg
+#
+# Strips AI-generated attribution trailers from the commit message
+# before it is written to the repository.
+#
+# Delegates to filter-commit-message-inplace.sh for the actual filtering.
+# Falls back to inline grep if the filter script is not present.
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+FILTER="${ROOT}/.husky/filter-commit-message-inplace.sh"
+
+if [ -f "$FILTER" ]; then
+  sh "$FILTER" "$1"
+else
+  # Inline fallback — strips the most common trailer patterns
+  FILE="$1"
+  tmp=$(mktemp) || exit 1
+  grep -viE '^[[:space:]]*(co-authored-by|signed-off-by|reviewed-by|acked-by|tested-by|helped-by|on-behalf-of|made-with)[[:space:]]*:' "$FILE" \
+    | sed 's/\r$//' > "$tmp"
+  mv "$tmp" "$FILE"
+fi

--- a/templates/project/.husky/filter-commit-message-inplace.sh
+++ b/templates/project/.husky/filter-commit-message-inplace.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# filter-commit-message-inplace.sh
+#
+# Strips AI-generated attribution trailers and footers from a commit message file.
+# Used by both commit-msg and post-commit hooks.
+#
+# Usage: sh .husky/filter-commit-message-inplace.sh <message-file>
+#
+# Strips:
+#   - Git trailer lines: Co-authored-by, Signed-off-by, Reviewed-by, etc.
+#   - AI tool footer lines: "Generated with Cursor/Claude/Copilot", etc.
+#
+# Why: AI coding tools inject attribution footers into every commit. These
+# clutter the git log and expose which commits were AI-assisted. This script
+# removes them so commit history stays clean and human-authored in tone.
+
+f="$1"
+[ -n "$f" ] && [ -f "$f" ] || exit 0
+
+t=$(mktemp) || exit 1
+
+grep -viE '^[[:space:]]*(co-authored-by|signed-off-by|reviewed-by|acked-by|tested-by|helped-by|on-behalf-of|made-with)[[:space:]]*:' "$f" |
+  grep -viE '^[[:space:]]*([#*>-][[:space:]]*)*[Gg]enerated[[:space:]]+with[[:space:]]+(Cursor|Claude|Copilot|GitHub Copilot)([[:space:]].*)?$' |
+  grep -viE '^[[:space:]]*([#*>-][[:space:]]*)*[Gg]enerated[[:space:]]+by[[:space:]]+(Cursor|Claude|Copilot|GitHub Copilot)([[:space:]].*)?$' |
+  grep -viE '^[[:space:]]*([#*>-][[:space:]]*)*[Cc]ommitted[[:space:]]+with[[:space:]]+(Cursor|Claude|Copilot)([[:space:]].*)?$' |
+  sed 's/\r$//' > "$t"
+
+mv "$t" "$f"

--- a/templates/project/.husky/post-commit
+++ b/templates/project/.husky/post-commit
@@ -1,0 +1,34 @@
+#!/bin/sh
+# post-commit
+#
+# Re-applies trailer stripping after the commit lands.
+# Some git clients (and `git commit --trailer`) re-inject trailers after
+# the commit-msg hook has already run. This hook catches and amends them away.
+#
+# Amends the commit in-place only if the message actually changed.
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+FILTER="${ROOT}/.husky/filter-commit-message-inplace.sh"
+
+tmp=$(mktemp) || exit 0
+orig=$(mktemp) || exit 0
+
+git log -1 --format=%B | sed 's/\r$//' > "$tmp"
+cp "$tmp" "$orig"
+
+if [ -f "$FILTER" ]; then
+  sh "$FILTER" "$tmp"
+else
+  grep -viE '^[[:space:]]*(co-authored-by|signed-off-by|reviewed-by|acked-by|tested-by|helped-by|on-behalf-of|made-with)[[:space:]]*:' "$tmp" \
+    | sed 's/\r$//' > "${tmp}.out"
+  mv "${tmp}.out" "$tmp"
+fi
+
+# Only amend if the message actually changed
+if cmp -s "$orig" "$tmp"; then
+  rm -f "$orig" "$tmp"
+  exit 0
+fi
+
+git commit --amend -F "$tmp" --no-edit 2>/dev/null
+rm -f "$orig" "$tmp"

--- a/templates/project/.husky/pre-commit
+++ b/templates/project/.husky/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/sh
+# pre-commit
+#
+# Scans staged files for secrets before they leave the machine.
+# Blocks the commit if any secrets are detected.
+#
+# Requires gitleaks. Install: brew install gitleaks
+# Config: .gitleaks.toml in the repo root
+#
+# NOTE: Git hooks run with a stripped PATH. Never assume `command -v` will
+# find a binary that works in your interactive shell. Always check known
+# install locations explicitly.
+
+GITLEAKS_BIN=""
+
+if command -v gitleaks >/dev/null 2>&1; then
+  GITLEAKS_BIN="gitleaks"
+elif [ -x "/usr/local/bin/gitleaks" ]; then
+  GITLEAKS_BIN="/usr/local/bin/gitleaks"
+elif [ -x "/opt/homebrew/bin/gitleaks" ]; then
+  GITLEAKS_BIN="/opt/homebrew/bin/gitleaks"
+fi
+
+if [ -n "$GITLEAKS_BIN" ]; then
+  "$GITLEAKS_BIN" protect --staged --config .gitleaks.toml --no-banner
+  if [ $? -ne 0 ]; then
+    echo ""
+    echo "gitleaks blocked this commit — secrets detected in staged files."
+    echo "Review the findings above, remove the secret, and re-stage."
+    echo "If it is a known false positive, add it to .gitleaks.toml allowlist."
+    exit 1
+  fi
+else
+  echo "WARNING: gitleaks not installed — secret scanning skipped."
+  echo "Install it to protect yourself: brew install gitleaks"
+fi


### PR DESCRIPTION
## Summary
Adds the Husky git hooks layer: gitleaks secret scanning on pre-commit, and AI attribution trailer stripping via commit-msg, post-commit, and a shared filter script. These hooks enforce what the security and git-conventions rules only document.

## Changes
- `.husky/pre-commit` — gitleaks scans staged files before any commit. PATH-safe: checks `command -v`, `/usr/local/bin`, and `/opt/homebrew/bin` explicitly because git hooks run with a stripped PATH and `command -v` alone silently skips the scan in some environments.
- `.husky/filter-commit-message-inplace.sh` — shared filter that strips `Co-authored-by`, `Signed-off-by`, `Made-with`, and "Generated with Cursor/Claude/Copilot" patterns, case-insensitively, from a commit message file in-place.
- `.husky/commit-msg` — applies the filter before the commit is written. Falls back to inline grep if the filter script is somehow missing.
- `.husky/post-commit` — re-applies the filter and amends the commit if a git client re-injected trailers after `commit-msg` ran. Only amends when the message actually changed (`cmp -s` check) to avoid unnecessary amend churn.
- `.gitleaks.toml` — extends the gitleaks default ruleset. Allowlists `.env.example` and common placeholder strings (`changeme`, `replace-me`, `dev-secret-change-in-production`, etc.).

## Closes
Closes #11

## Test plan
- Read all four hook scripts for correctness — verified `cmp -s` short-circuit in `post-commit`
- Verified `pre-commit` PATH fallback chain covers Homebrew on both Intel and Apple Silicon
- Confirmed `.gitleaks.toml` allowlist entries don't match real secret patterns

## Notes
The install script (next PR) will run `chmod +x` on all `.husky/` files and set up Husky via `npx husky install` or equivalent. The hooks themselves are plain POSIX shell — no Node dependency.
