### PR TITLE
fix: self-governance gaps and hook path reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ For scaffolding a new project (global layer already installed):
 ./install.sh --project-only
 ```
 
+For a **brand new project from scratch**:
+```bash
+mkdir my-project && cd my-project
+git init
+# Then from the the-rig directory:
+./install.sh --project-only
+# Point the installer at your new my-project/ directory when prompted.
+```
+
 ---
 
 ## How it works at session start

--- a/install.sh
+++ b/install.sh
@@ -220,17 +220,37 @@ if [[ "$DO_PROJECT" == true ]]; then
     copy_file "$src_file" "$dest_file"
   done < <(find "$PROJECT_TEMPLATES" -type f -print0)
 
-  # ── Substitute project name in CLAUDE.md ─────────────────────────────────
+  # ── Substitute placeholders ───────────────────────────────────────────────
+  # Resolve the absolute path to the target directory for settings.json.
+  # This avoids the fragility of $(git rev-parse ...) being evaluated in an
+  # unknown shell environment when Claude Code invokes the hook.
+  TARGET_ABS="$(cd "$TARGET" && pwd)"
+
+  # Portable in-place sed: GNU sed uses -i ""; macOS BSD sed uses -i ''
+  sed_inplace() {
+    local pattern="$1"
+    local file="$2"
+    if sed --version 2>/dev/null | grep -q GNU; then
+      sed -i "$pattern" "$file"
+    else
+      sed -i '' "$pattern" "$file"
+    fi
+  }
+
   TARGET_CLAUDE="$TARGET/CLAUDE.md"
   if [[ -f "$TARGET_CLAUDE" ]]; then
-    # In-place replacement — macOS sed needs a backup extension
-    if sed --version 2>/dev/null | grep -q GNU; then
-      sed -i "s/\\[Project Name\\]/${PROJECT_NAME}/g" "$TARGET_CLAUDE"
-    else
-      # macOS BSD sed
-      sed -i '' "s/\\[Project Name\\]/${PROJECT_NAME}/g" "$TARGET_CLAUDE"
-    fi
-    success "Substituted project name in CLAUDE.md"
+    sed_inplace "s/\\[Project Name\\]/${PROJECT_NAME}/g" "$TARGET_CLAUDE"
+    success "Substituted [Project Name] in CLAUDE.md"
+  fi
+
+  # Substitute [REPO_ROOT] in settings.json with the absolute project path.
+  # The placeholder avoids shell-evaluation issues when Claude Code runs hooks.
+  TARGET_SETTINGS="$TARGET/.claude/settings.json"
+  if [[ -f "$TARGET_SETTINGS" ]]; then
+    # Escape forward slashes in the path for sed
+    ESCAPED_PATH="${TARGET_ABS//\//\\/}"
+    sed_inplace "s/\\[REPO_ROOT\\]/${ESCAPED_PATH}/g" "$TARGET_SETTINGS"
+    success "Substituted [REPO_ROOT] in .claude/settings.json → $TARGET_ABS"
   fi
 
   # ── Set executable bits on hook scripts ───────────────────────────────────

--- a/templates/project/.claude/commands/propose.md
+++ b/templates/project/.claude/commands/propose.md
@@ -1,0 +1,66 @@
+# Command: /propose
+
+Use this command when you believe a change to The Rig's governance files would
+improve the system. Governance files — `processes/`, `rules/`, `.husky/`, `CLAUDE.md`,
+and `.claude/hooks/` — are protected from direct writes by `pre-tool.sh`.
+
+This command is the approved path for proposing changes to them.
+
+---
+
+## What this does
+
+Instead of modifying a governance file directly, the agent:
+
+1. Writes the proposed change to `/tmp/rig-proposal-[name].md`
+2. Shows you the full before/after diff in the proposal document
+3. Explains why the change is warranted (symptom, pattern, or lesson)
+4. Waits for your explicit approval before anything is touched
+5. On approval: applies the change and logs it in `memory/ERRORS.md` or
+   `memory/PROGRESS.md` as appropriate
+
+---
+
+## Usage
+
+```
+/propose
+```
+
+Claude will ask:
+- Which file needs changing?
+- What is the proposed change? (show the exact diff)
+- Why is this change warranted? (what failure or pattern prompted it?)
+
+Then it writes the proposal to `/tmp/rig-proposal-[name].md` and presents it
+for your review. **No governance file is touched until you say "apply it".**
+
+---
+
+## When to use it
+
+Use `/propose` when you've noticed:
+- A step in a workflow that consistently gets skipped or causes confusion
+- A rule that's either too strict or not strict enough for this project
+- A hook behaviour that needs adjustment
+- A pattern in `memory/ERRORS.md` that should be codified as a rule
+
+---
+
+## When NOT to use it
+
+Do not use `/propose` for:
+- Application code changes — edit those directly
+- Memory files (`PROGRESS.md`, `ERRORS.md`, `CONTEXT_SNAPSHOT.md`) — update those directly
+- Task files — manage those directly
+- Project documentation (`docs/`, `README.md`) — edit those directly
+
+Only governance files require the proposal gate.
+
+---
+
+## Notes
+
+This is how The Rig improves itself: not silently, not unilaterally, but through
+a deliberate proposal → review → apply cycle that keeps the human in the loop on
+any change to how the system functions.

--- a/templates/project/.claude/hooks/pre-tool.sh
+++ b/templates/project/.claude/hooks/pre-tool.sh
@@ -26,9 +26,35 @@ if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
   # Extract the target file path from the JSON input
   PATH_ARG=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
 
-  # ── Configure your project's protected paths here ────────────────────────
-  # These paths cannot be written to by the agent under any circumstances.
-  # Use partial paths — anything containing the string will be blocked.
+  # ── THE RIG'S OWN GOVERNANCE FILES (self-protection) ─────────────────────
+  # The agent must not rewrite the rules it is supposed to follow.
+  # These paths are protected by default. To intentionally modify a workflow,
+  # rule, or hook, the user must either:
+  #   (a) temporarily comment out the relevant entry below, or
+  #   (b) make the edit manually outside of a Claude Code session.
+  #
+  # The /propose slash command is the approved path for suggesting changes —
+  # it stages a proposal for human review rather than modifying files directly.
+  RIG_PROTECTED=(
+    "processes/"
+    "rules/"
+    ".husky/"
+    "CLAUDE.md"
+    ".claude/hooks/"
+  )
+
+  for protected in "${RIG_PROTECTED[@]}"; do
+    if [[ "$PATH_ARG" == *"$protected"* ]]; then
+      echo "Blocked: '$PATH_ARG' is a The Rig governance file." >&2
+      echo "The agent must not modify its own rules directly." >&2
+      echo "Use /propose to stage a change for human review, or edit manually." >&2
+      exit 1
+    fi
+  done
+
+  # ── PROJECT-SPECIFIC PROTECTED PATHS ─────────────────────────────────────
+  # Add paths that should never be written by the agent in this project.
+  # Substring matching — any file path containing the string will be blocked.
   # Examples:
   #   ".env.production"   — production environment file
   #   "migrations/"       — database migrations (run manually, not by agent)
@@ -38,7 +64,6 @@ if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
     # "migrations/"
     # "data/approved/"
   )
-  # ─────────────────────────────────────────────────────────────────────────
 
   for blocked in "${BLOCKED_PATHS[@]}"; do
     if [[ "$PATH_ARG" == *"$blocked"* ]]; then

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/pre-tool.sh\""
+            "command": "bash [REPO_ROOT]/.claude/hooks/pre-tool.sh"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/post-tool.sh\""
+            "command": "bash [REPO_ROOT]/.claude/hooks/post-tool.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Three correctness fixes that address the gaps identified in the pre-v1.0.0 review: the agent could rewrite its own governance files, there was no permission gate for proposing governance changes, and the hook path in `settings.json` relied on fragile shell evaluation.

## Changes

**`pre-tool.sh` — self-protection block**
Added a `RIG_PROTECTED` array (separate from the user-configured `BLOCKED_PATHS`) that blocks writes to `processes/`, `rules/`, `.husky/`, `CLAUDE.md`, and `.claude/hooks/`. The agent cannot silently rewrite the rules it follows. Error message explicitly points to `/propose` as the approved path.

**`/propose` slash command (new)**
When the agent identifies a change worth making to a governance file, it writes a before/after proposal to `/tmp/rig-proposal-[name].md` and waits for explicit human approval before touching any file. This is the mechanical permission gate the "never make architectural decisions silently" hard rule only implied. Includes clear guidance on what it covers (governance files) and what it doesn't (application code, memory files, task files).

**`settings.json` — `[REPO_ROOT]` placeholder**
Replaced `$(git rev-parse --show-toplevel)` with a `[REPO_ROOT]` placeholder. `install.sh` resolves the absolute path at install time and substitutes it — same pattern as `[PROFILE_PATH]` and `[Project Name]`. The installed file always contains a concrete absolute path. No runtime shell evaluation required.

**`install.sh` — substitution improvements**
Extracted `sed_inplace()` helper (removes duplicate GNU/BSD sed detection). Added `[REPO_ROOT]` substitution step. Verified substitution logic handles path separators correctly.

**`README.md`** — added brand-new-project-from-scratch flow to quickstart.

## Closes
Closes #19

## Test plan
- `bash -n install.sh` — syntax check passes
- Verified `sed` path substitution logic manually: `/Users/testuser/code/my-project` → escapes correctly → substitutes cleanly
- Read `propose.md` — verified it covers all governance paths protected by `pre-tool.sh`
- Confirmed `RIG_PROTECTED` entries match the actual governance file locations

## Notes
After this merges: cleanup PR (git tag v1.0.0, repo description update, mark as public).
