### PR TITLE
feat: /kickoff command and PROJECT_BRIEF.md for greenfield bootstrapping

### DIFF
--- a/templates/project/.claude/commands/kickoff.md
+++ b/templates/project/.claude/commands/kickoff.md
@@ -1,0 +1,181 @@
+# Command: /kickoff
+
+Trigger this command to bootstrap a brand new project from scratch.
+
+`/kickoff` is the greenfield entry point. It reads your `PROJECT_BRIEF.md`, confirms
+it understands what's being built, resolves open questions, then scaffolds everything
+needed to start shipping: a filled-in `CLAUDE.md`, an initial task backlog, and GitHub
+issues for the first milestone.
+
+Use `/task` for day-to-day work on an established project. Use `/kickoff` once, at
+the start, before there's anything to `/task` on.
+
+---
+
+## Before running /kickoff
+
+`PROJECT_BRIEF.md` must exist and be filled in. The agent needs a real brief to work
+from — it cannot scaffold a project from a blank template.
+
+If `PROJECT_BRIEF.md` doesn't exist yet, run `/kickoff` anyway. The agent will create
+it from the template and ask you to fill it in, then stop and wait.
+
+---
+
+## Kickoff flow
+
+### Step 0 — Check for PROJECT_BRIEF.md
+
+Look for `PROJECT_BRIEF.md` in the repo root.
+
+**If missing:** Create it from `templates/project/PROJECT_BRIEF.md`. Tell the user:
+
+> "I've created `PROJECT_BRIEF.md` in the repo root. Fill it in and run `/kickoff`
+> again when it's ready. The more specific you are, the better the scaffold."
+
+Stop here. Do not proceed until the brief exists and has real content (not just
+placeholder text).
+
+**If it exists but still contains placeholder text** (look for `[` characters in
+value positions): point out which sections are incomplete and ask the user to fill
+them in before continuing.
+
+---
+
+### Step 1 — Read and reflect
+
+Read `PROJECT_BRIEF.md` in full. Then state back to the user:
+
+> "Here's what I understand about [Project Name]:
+>
+> **What it is:** [one sentence from the brief]
+> **Who it's for:** [primary user]
+> **MVP scope:** [bullet list of MVP features]
+> **Stack:** [confirmed stack choices, or what you'll recommend for blanks]
+> **Key constraints:** [timeline, must-integrates, must-nots — or 'none']
+>
+> **Open questions I'll need to resolve before scaffolding:**
+> [List any unanswered questions from the brief, plus any the agent spots —
+> e.g. ambiguous auth model, unclear data ownership, missing API dependencies]
+>
+> Does this match your intent? Any corrections before I proceed?"
+
+Wait for confirmation or corrections. Incorporate any feedback before moving forward.
+
+---
+
+### Step 2 — Resolve open questions
+
+For each open question (from the brief + any the agent identified):
+- Offer a concrete recommendation with a one-sentence rationale
+- Ask the user to confirm, override, or defer
+
+Keep this tight. One question at a time. If the user defers a question, note it as
+a future task — don't block scaffolding on it.
+
+Record all decisions in `PROJECT_BRIEF.md` under the relevant section (or under
+`## Open questions` with the answer noted inline).
+
+---
+
+### Step 3 — Confirm the build plan
+
+Present the full scaffolding plan before touching any files:
+
+> "Here's what I'm about to scaffold:
+>
+> **1. Fill in `CLAUDE.md`** — project description, stack table, conventions, run commands
+> **2. Create initial task backlog** — [N] tasks in `tasks/backlog/` covering the MVP features:
+>    - `[task-slug]` — [one-line description]
+>    - [...]
+> **3. Open GitHub issues** — one issue per task, labelled and ready to work from
+> **4. Update `memory/PROGRESS.md`** — log the kickoff as the starting entry
+>
+> Say **go** to scaffold, or adjust the plan."
+
+Wait for explicit go-ahead.
+
+---
+
+### Step 4 — Scaffold
+
+Execute the build plan in order. For each item, confirm completion before moving to
+the next.
+
+#### 4a. Fill in CLAUDE.md
+
+Replace every placeholder in `CLAUDE.md` with real content from the brief:
+- Project name and description
+- Stack table (all rows filled — no blanks)
+- `## Project context for task mode` section (entry points, key services, gotchas)
+- `## Key conventions` (at minimum: naming, where LLM/DB/auth calls live)
+- `## How to run locally` (real commands, not `[command]`)
+- `## Off-limits` (at minimum: `.husky/`, `.claude/worktrees/`, `.github/`)
+
+Do not leave any `[PLACEHOLDER]` lines in the final file.
+
+#### 4b. Generate task backlog
+
+For each MVP feature in the brief, create a task file in `tasks/backlog/` using the
+task template. Each task file must have:
+- A meaningful slug (e.g. `feat-user-auth.md`, `feat-dashboard-ui.md`)
+- `## Goal` — the user-facing outcome this task delivers
+- `## Context` — how it fits into the MVP
+- `## Acceptance criteria` — at least 3 specific, testable conditions
+- `## Operating mode` — default to Medium / Normal / Balanced (dev can adjust via `/task`)
+- `## Approach` — a preliminary implementation plan (can be light at this stage)
+
+Order tasks by dependency: foundational work (auth, data layer, core models) before
+features that build on them.
+
+#### 4c. Open GitHub issues
+
+For each task file, open a GitHub issue:
+- Title: matches the task goal
+- Body: copy the `## Goal`, `## Context`, and `## Acceptance criteria` from the task file
+- Labels: `type: feat` + the most relevant area label
+- Update the task file's `## GitHub issue` field with the issue number
+
+#### 4d. Update memory/PROGRESS.md
+
+Append a dated entry:
+
+```
+## [YYYY-MM-DD] — Project kickoff
+
+- Ran /kickoff from PROJECT_BRIEF.md
+- Filled in CLAUDE.md with real project content
+- Generated [N] tasks in tasks/backlog/
+- Opened GitHub issues #[X]–#[Y]
+- Stack confirmed: [one-line summary]
+- Open decisions deferred: [list, or 'none']
+```
+
+---
+
+### Step 5 — Hand off
+
+After scaffolding is complete:
+
+> "Kickoff complete. Here's where things stand:
+>
+> - `CLAUDE.md` is filled in — The Rig is oriented on your project
+> - [N] tasks are in `tasks/backlog/` — ordered by dependency
+> - GitHub issues #[X]–#[Y] are open and labelled
+>
+> Suggested first move: run `/task` and pick up `[first-task-slug]` — that's the
+> foundation everything else builds on.
+>
+> Anything to adjust before you start?"
+
+---
+
+## Notes
+
+- `/kickoff` is a one-time command. Running it again on an established project will
+  likely overwrite things. If you want to re-scaffold after a major pivot, archive
+  the existing `CLAUDE.md` and `tasks/` first.
+- The task backlog generated here is a starting point, not a contract. Adjust
+  priorities, split tasks, or add new ones freely as the project develops.
+- All governance rules apply during scaffolding. Protected paths, the `/propose`
+  gate, and secret handling are all still active.

--- a/templates/project/PROJECT_BRIEF.md
+++ b/templates/project/PROJECT_BRIEF.md
@@ -1,0 +1,94 @@
+# Project Brief: [Project Name]
+
+> Fill this in before running `/kickoff`. The agent reads this file to understand
+> what it's building. Be specific — vague briefs produce vague scaffolding.
+> Delete placeholder lines once filled. Delete sections that genuinely don't apply.
+
+---
+
+## What is this?
+
+**One-liner:** [What does this product do? Complete this sentence: "A tool that helps [who] [do what]."]
+
+**Problem statement:** [What problem exists today, and who has it? 2–4 sentences max.]
+
+**Solution:** [What does this product do to solve that problem? What's the core value proposition?]
+
+---
+
+## Who is it for?
+
+**Primary user:** [Job title or role — e.g. "Solo developer managing client projects"]
+
+**Secondary user (if any):** [e.g. "End users of the apps the developer builds"]
+
+**Scale at launch:** [e.g. "Single user (me)", "Small team (< 10)", "Public SaaS"]
+
+---
+
+## MVP features
+
+> List only what's needed for a usable v1. Ruthlessly exclude nice-to-haves.
+
+- [ ] [Feature 1 — one sentence, user-facing outcome]
+- [ ] [Feature 2]
+- [ ] [Feature 3]
+- [ ] [Feature 4]
+
+---
+
+## Out of scope for v1
+
+> Listing what you're NOT building is just as important as what you are.
+
+- [Thing that would be great but isn't needed to ship]
+- [Feature that's v2 territory]
+- [Integration that can wait]
+
+---
+
+## Stack
+
+> Fill in your choices. Leave blank if you want the agent to recommend.
+
+| Layer | Choice |
+|---|---|
+| Backend | [e.g. FastAPI / Python 3.12, or "recommend"] |
+| Frontend | [e.g. Next.js / React, or "none", or "recommend"] |
+| Database | [e.g. PostgreSQL, MongoDB, SQLite, or "recommend"] |
+| Auth | [e.g. JWT, OAuth via Auth0, magic link, invite-only, or "recommend"] |
+| Hosting | [e.g. Fly.io, Vercel + Railway, AWS, or "TBD"] |
+| Testing | [e.g. pytest + Vitest, or "TBD"] |
+
+---
+
+## Constraints
+
+**Timeline:** [Hard deadline, or "none"]
+
+**Budget:** [If relevant — e.g. "free tier only", "$X/month infra budget"]
+
+**Must integrate with:** [Existing systems, APIs, or data sources this must connect to]
+
+**Must NOT use:** [Technologies, services, or approaches that are off-limits and why]
+
+**Existing code:** [Link or path to any existing code this builds on, or "greenfield"]
+
+---
+
+## Success metrics
+
+> How will you know v1 is a success? Be specific enough to test.
+
+- [e.g. "Can create an account and complete core workflow in < 2 minutes"]
+- [e.g. "All API endpoints return < 200ms under normal load"]
+- [e.g. "Works on mobile without horizontal scrolling"]
+
+---
+
+## Open questions
+
+> Things you haven't decided yet. The agent will help you resolve these during kickoff.
+
+- [ ] [e.g. "Should users be able to share projects with others in v1?"]
+- [ ] [e.g. "Do we need offline support?"]


### PR DESCRIPTION
## Summary

Adds `/kickoff` — the greenfield entry point for bootstrapping a new project with The Rig.

`/task` handles individual units of work on an established project. `/kickoff` handles the moment before that: blank repo, stack decisions unmade, no backlog, nothing to `/task` on yet. Run it once, at the start.

## What it does

1. **Checks for `PROJECT_BRIEF.md`** — if missing or still full of placeholders, creates it from the template and waits for the dev to fill it in
2. **Reads and reflects** — states back what it understood, flags gaps, confirms before proceeding
3. **Resolves open questions** — offers concrete recommendations for anything left blank in the brief; defers and logs anything the dev isn't ready to decide
4. **Confirms the build plan** — lists exactly what it's about to scaffold before touching any files
5. **Scaffolds in one pass:**
   - Fills in `CLAUDE.md` with real content (no placeholders left)
   - Generates task files in `tasks/backlog/` from MVP features, ordered by dependency
   - Opens GitHub issues for each task
   - Seeds `memory/PROGRESS.md` with the kickoff entry
6. **Hands off** — tells the dev what to run next (`/task` on the first dependency)

## Files changed

| File | Change |
|---|---|
| `templates/project/.claude/commands/kickoff.md` | New — full kickoff command |
| `templates/project/PROJECT_BRIEF.md` | New — project brief template |

## Design notes

- `PROJECT_BRIEF.md` is a hard gate — `/kickoff` won't scaffold until it has real content. This prevents the agent from making up a project shape from a blank template.
- All governance still applies during scaffolding. Protected paths, `/propose` gate, secret handling — all active.
- `/kickoff` is intentionally a one-time command. There's a note in the file warning against re-running it on an established project.

## Test plan

- [ ] Run `/kickoff` in a repo with no `PROJECT_BRIEF.md` — verify it creates the template and stops
- [ ] Run `/kickoff` with a brief that has unfilled placeholders — verify it identifies and flags them
- [ ] Run `/kickoff` with a fully filled brief — verify it reads back understanding correctly before scaffolding
- [ ] Confirm `CLAUDE.md` is fully filled in after scaffolding (no `[PLACEHOLDER]` remaining)
- [ ] Confirm task files are created in `tasks/backlog/` with correct structure
- [ ] Confirm GitHub issues are opened and task files updated with issue numbers

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
