### PR TITLE
chore: v1.0.0 release — CHANGELOG, README, and repo description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [1.0.0] — 2026-04-09
+## [1.0.0] — 2026-04-10
 
 First stable release. Built and refined across 100+ PRs on the LaudBot project.
 
@@ -23,7 +23,8 @@ First stable release. Built and refined across 100+ PRs on the LaudBot project.
 - `skills/explain.md` — audience-calibrated, one-sentence answer first
 
 **Project layer** (`templates/project/`)
-- `CLAUDE.md` — project brain template with stack table, conventions, off-limits paths, session context-loading sequence, and `@rules/` imports
+- `CLAUDE.md` — project brain template with stack table, conventions, off-limits paths, session context-loading sequence, `@rules/` imports, and "Project context for task mode" section
+- `PROJECT_BRIEF.md` — greenfield project brief template covering goal, users, MVP features, out-of-scope, stack choices, constraints, success metrics, and open questions
 - `processes/NEW_TASK_WORKFLOW.md` — 6-step task start process with working-directory orientation gate
 - `processes/SHIP_WORKFLOW.md` — issue-first rule, pre-ship checklist, PR template enforcement, label discipline
 - `processes/DEBUG_WORKFLOW.md` — hypothesis-first debugging, mandatory ERRORS.md entry
@@ -36,11 +37,15 @@ First stable release. Built and refined across 100+ PRs on the LaudBot project.
 - `memory/ERRORS.md` — pitfall log template with example entry
 - `memory/CONTEXT_SNAPSHOT.md` — session state template (gitignored)
 - `memory/.gitignore` — excludes CONTEXT_SNAPSHOT.md from version control
-- `tasks/backlog/TASK_example.md` — complete task file template
+- `tasks/backlog/TASK_example.md` — complete task file template with `## Depends on` and `## Operating mode` fields
 - `tasks/active/.gitkeep`, `tasks/done/.gitkeep`
-- `.claude/settings.json` — PreToolUse and PostToolUse hook wiring
-- `.claude/hooks/pre-tool.sh` — write protection for configured paths (PascalCase tool names)
+- `.claude/settings.json` — PreToolUse and PostToolUse hook wiring with stable `[REPO_ROOT]` path substitution
+- `.claude/hooks/pre-tool.sh` — write protection for governance files (`RIG_PROTECTED` block) and configured project paths; PascalCase tool name matching
 - `.claude/hooks/post-tool.sh` — PROGRESS.md auto-stub after git commits
+- `.claude/commands/kickoff.md` — `/kickoff` greenfield bootstrap: reads PROJECT_BRIEF.md, resolves open questions, scaffolds CLAUDE.md + task backlog + GitHub issues in one pass
+- `.claude/commands/task.md` — `/task` intake wizard: three-part order (goal/context/constraints → autonomy/check-ins/risk → confirmation); persists operating mode in task file
+- `.claude/commands/run.md` — `/run` execution loop: dependency-aware priority queue, per-task autonomy level enforcement, automatic chaining at High autonomy
+- `.claude/commands/propose.md` — `/propose` governance gate: writes change proposal to `/tmp/`, waits for human approval before touching any governance file
 - `.claude/commands/new-feature.md` — `/new-feature` slash command
 - `.claude/commands/ship.md` — `/ship` slash command
 - `.claude/commands/debug.md` — `/debug` slash command
@@ -54,7 +59,7 @@ First stable release. Built and refined across 100+ PRs on the LaudBot project.
 - `.github/ISSUE_TEMPLATE/feature.md`, `bug.md`, `chore.md`
 
 **Installer**
-- `install.sh` — interactive setup for global and project layers; handles path substitution, executable bits, Husky initialization, gitleaks check
+- `install.sh` — interactive setup for global and project layers; handles `[REPO_ROOT]` path substitution (GNU/BSD sed compatible), executable bits, Husky initialization, gitleaks check
 
 **Documentation**
 - `docs/how-it-works.md` — architecture deep-dive with diagrams

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The Rig has two layers that load in sequence at every session start:
 | Rules (4) | `templates/project/rules/` | Coding standards, git conventions, security rules, verification protocol |
 | Memory system | `templates/project/memory/` | PROGRESS log, ERRORS log, CONTEXT_SNAPSHOT (session state) |
 | Task lifecycle | `templates/project/tasks/` | Structured task files through backlog → active → done |
-| Claude Code hooks | `templates/project/.claude/` | Pre/post-tool enforcement + 4 slash commands |
+| Claude Code hooks | `templates/project/.claude/` | Pre/post-tool enforcement + 8 slash commands |
 | Git hooks | `templates/project/.husky/` | Secret scanning (gitleaks) + AI attribution trailer stripping |
 | GitHub templates | `templates/project/.github/` | PR template + 3 issue templates |
 | Installer | `install.sh` | Interactive setup script — handles both layers |
@@ -136,13 +136,30 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 ---
 
-## The session workflow
+## The command set
 
+**Start a project**
 ```
-/new-feature  →  creates task file, plans before coding, waits for approval
-/ship         →  runs pre-ship checklist, commits, opens PR
+/kickoff      →  reads PROJECT_BRIEF.md, scaffolds CLAUDE.md + task backlog + GitHub issues
+```
+
+**Daily work**
+```
+/task         →  intake wizard: define the task + configure autonomy, check-ins, and risk
+/run          →  execute the backlog; respects per-task operating mode; chains at High autonomy
+/run [slug]   →  run a single specific task
+```
+
+**Ship and debug**
+```
+/ship         →  pre-ship checklist, commit, open PR
 /debug        →  hypothesis-first diagnosis, mandatory ERRORS.md entry
-/wrap         →  writes CONTEXT_SNAPSHOT, ensures memory is current before closing
+```
+
+**Governance and housekeeping**
+```
+/propose      →  submit a change to governance files for human approval before anything is touched
+/wrap         →  write CONTEXT_SNAPSHOT, ensure memory is current before closing the session
 ```
 
 ---


### PR DESCRIPTION
## Summary

Final housekeeping before tagging v1.0.0.

## Changes

**`CHANGELOG.md`** — updated v1.0.0 entry to include everything added since the initial docs PR:
- `/task` command with intake wizard
- `/kickoff` command and `PROJECT_BRIEF.md`
- `/run` execution loop
- `/propose` governance gate
- `## Depends on` and `## Operating mode` fields in task template
- `## Project context for task mode` section in `CLAUDE.md` template
- `RIG_PROTECTED` self-governance block in `pre-tool.sh`
- `[REPO_ROOT]` stable path substitution (GNU/BSD sed compatible)

**`README.md`** — two changes:
- "Session workflow" section expanded from 4 commands to the full 8-command set, grouped by purpose (project bootstrap / daily work / ship+debug / governance)
- "What's included" table: Claude Code hooks row updated from "4 slash commands" to "8 slash commands"

**GitHub repo description** — updated to mention autonomous execution.

## Post-merge action

After this PR is merged, tag v1.0.0:

```bash
git checkout main && git pull
git tag v1.0.0
git push origin v1.0.0
```

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
