### PR TITLE
fix: token economy — lazy PROGRESS.md load and auto-trim on wrap

### DIFF
--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -17,9 +17,12 @@ At the start of any session, silently read in this order:
 1. This file
 2. `[PROFILE_PATH]` — your personal and professional context
 3. The project's `./CLAUDE.md` (if present)
-4. `./memory/PROGRESS.md` (if present)
-5. `./memory/ERRORS.md` (if present)
-6. `./tasks/active/` (if present) — understand the current task
+4. `./memory/CONTEXT_SNAPSHOT.md` — **if this exists, it is sufficient for orientation.
+   Stop here unless the task requires deeper history.**
+5. `./memory/PROGRESS.md` — only if `CONTEXT_SNAPSHOT.md` is absent or more than
+   one session old. Load the most recent entries only (last 20 `##` sections).
+6. `./memory/ERRORS.md` (if present)
+7. `./tasks/active/` (if present) — understand the current task
 
 Do not summarise these back to me unless asked.
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -8,9 +8,10 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 
 1. Writes (overwrites) `memory/CONTEXT_SNAPSHOT.md` with full current project state
 2. Ensures `memory/PROGRESS.md` is up to date — expands any auto-stubbed entries
-3. Checks `memory/ERRORS.md` — prompts you to log anything unexpected from this session
-4. Reports what's in `tasks/active/` so you know what's in flight
-5. Surfaces the next priority from `tasks/backlog/` and asks: "What's next?"
+3. **Trims `memory/PROGRESS.md`** if it has grown beyond 20 entries (see Trim step below)
+4. Checks `memory/ERRORS.md` — prompts you to log anything unexpected from this session
+5. Reports what's in `tasks/active/` so you know what's in flight
+6. Surfaces the next priority from `tasks/backlog/` and asks: "What's next?"
 
 ## Usage
 
@@ -24,9 +25,33 @@ Run this:
 - Before switching to a different task or project
 - Any time you want to ensure a future session can pick up exactly where you left off
 
+## Trim step — PROGRESS.md
+
+After updating `PROGRESS.md`, count the number of `## ` entry headers in the file.
+
+**If the count is 20 or fewer:** nothing to do.
+
+**If the count exceeds 20:** tell the user:
+
+> "`PROGRESS.md` has [N] entries. I'll move the oldest [N-20] to
+> `memory/PROGRESS_archive.md` to keep session startup lean. The archive is
+> gitignored — history is preserved locally but won't be loaded at session start.
+> Trim now?"
+
+If the user confirms:
+1. Identify the oldest entries (bottom of the file, since entries are newest-first)
+2. Prepend them to `memory/PROGRESS_archive.md` (create if absent)
+3. Remove them from `memory/PROGRESS.md`, leaving the 20 most recent entries
+4. Confirm: "`PROGRESS.md` trimmed to 20 entries. Archive: `memory/PROGRESS_archive.md`"
+
+Never trim without confirmation. Never delete entries — only move them.
+
+---
+
 ## Notes
 
 - `CONTEXT_SNAPSHOT.md` is gitignored — it lives on disk only, never committed
+- `PROGRESS_archive.md` is also gitignored — full history on disk, not in the repo
 - Always **overwrite** the snapshot, never append to it; it represents current state, not history
-- History belongs in `PROGRESS.md`; the snapshot is purely for session continuity
+- History belongs in `PROGRESS.md` (recent) and `PROGRESS_archive.md` (older); the snapshot is for session continuity only
 - If a task is in progress but not done, note its exact state in the snapshot so the next session can resume without re-reading the whole conversation

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -100,12 +100,12 @@ docker compose up
 
 When starting a new session, read in this order:
 
-1. `memory/CONTEXT_SNAPSHOT.md` — current state (fastest orientation)
-2. `memory/PROGRESS.md` — full build history
+1. `memory/CONTEXT_SNAPSHOT.md` — **if this exists, it is sufficient for orientation.
+   Stop here unless the task requires deeper history.**
+2. `memory/PROGRESS.md` — only if `CONTEXT_SNAPSHOT.md` is absent or more than one
+   session old. Load the most recent entries only (last 20 `##` sections).
 3. `memory/ERRORS.md` — known pitfalls
 4. `tasks/active/` — current in-flight task(s)
-
-If `CONTEXT_SNAPSHOT.md` does not exist, fall back to `PROGRESS.md` as primary orientation.
 
 ---
 

--- a/templates/project/memory/.gitignore
+++ b/templates/project/memory/.gitignore
@@ -2,3 +2,7 @@
 # It may contain sensitive environment notes and in-flight decisions.
 # It lives on disk only — read at session start, never committed.
 CONTEXT_SNAPSHOT.md
+
+# PROGRESS_archive.md holds older entries trimmed from PROGRESS.md.
+# Archive is disk-only: useful for manual reference but not loaded at session start.
+PROGRESS_archive.md

--- a/templates/project/memory/PROGRESS.md
+++ b/templates/project/memory/PROGRESS.md
@@ -3,6 +3,11 @@
 > Running log of completed work. Most recent entry at the top.
 > Updated at the end of every task and after every PR merge.
 > The post-tool hook auto-stubs an entry after each git commit — expand it during wrap-up.
+>
+> **Trim convention:** keep the 20 most recent entries in this file.
+> When `/wrap` detects more than 20 entries, it moves the oldest to
+> `memory/PROGRESS_archive.md` (gitignored — disk only, never committed).
+> This keeps session startup cost low while preserving full history locally.
 
 ---
 


### PR DESCRIPTION
## Summary

Two targeted fixes to reduce token burn per session without changing how The Rig works.

## Problem

A Cursor analysis of a real user's `~/.claude/` directory found:
- `memory/PROGRESS.md` had grown to **27KB** and was being loaded unconditionally on every session start
- The global `CLAUDE.md` context load sequence loaded CONTEXT_SNAPSHOT *and* PROGRESS.md regardless of whether the snapshot was current
- Result: every session paid full context-load cost even for small tasks, even when a fresh snapshot already existed

## Fix 1 — CONTEXT_SNAPSHOT-first loading

Both `templates/global/CLAUDE.md` and `templates/project/CLAUDE.md` now explicitly treat a fresh `CONTEXT_SNAPSHOT.md` as sufficient for orientation:

> "If this exists, it is sufficient for orientation. Stop here unless the task requires deeper history."

`PROGRESS.md` is only loaded when CONTEXT_SNAPSHOT is absent or stale, and even then the instruction scopes it to the last 20 entries — not the full file.

**Impact:** A session with a current snapshot no longer pays the PROGRESS.md load cost at all.

## Fix 2 — `/wrap` trims PROGRESS.md when it exceeds 20 entries

`/wrap` now includes a trim step: counts `## ` headers in `PROGRESS.md`, and if the count exceeds 20, offers to move the oldest entries to `memory/PROGRESS_archive.md`.

- Archive is gitignored (disk only — history preserved locally, not committed)
- Trim is always **confirmed by the user** before anything moves
- Entries are moved, never deleted

This permanently caps the active `PROGRESS.md` regardless of project age.

## Files changed

| File | Change |
|---|---|
| `templates/global/CLAUDE.md` | Strengthen CONTEXT_SNAPSHOT-first load instruction |
| `templates/project/CLAUDE.md` | Same |
| `templates/project/.claude/commands/wrap.md` | Add trim step with confirmation flow |
| `templates/project/memory/PROGRESS.md` | Document trim convention |
| `templates/project/memory/.gitignore` | Add `PROGRESS_archive.md` |

## Test plan

- [ ] Session with a fresh CONTEXT_SNAPSHOT: verify agent does not load PROGRESS.md
- [ ] Session without CONTEXT_SNAPSHOT: verify agent loads PROGRESS.md (last 20 entries)
- [ ] Run `/wrap` on a PROGRESS.md with ≤ 20 entries: no trim prompt
- [ ] Run `/wrap` on a PROGRESS.md with 25 entries: trim prompt appears, shows correct count
- [ ] Confirm trim: verify PROGRESS.md has 20 entries, PROGRESS_archive.md has 5, no entries lost
- [ ] Decline trim: verify nothing changes
- [ ] Run `/wrap` twice on same file: second run correctly counts post-trim entries

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
