### PR TITLE
docs: update how-it-works, customizing, and README for v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,22 +82,19 @@ cd the-rig
 # 2. Run the installer
 ./install.sh
 
-# The installer will:
-# - Copy ~/.claude/CLAUDE.md (global identity)
-# - Copy skill files to ~/.claude/skills/
-# - Create your personal profile template
-# - Scaffold the project layer into any target directory
-# - Set executable bits on all hook scripts
-# - Optionally initialize Husky
+# The installer will ask:
+# - How to handle collisions (skip / overwrite / merge / interactive)
+# - Which components to install (all, or choose)
+# - Where your personal profile should live
+# - Which project directory to scaffold into
 
 # 3. Fill in your personal profile
 $EDITOR ~/.your-ai-contexts/PROFILE.md
 
-# 4. Fill in the project CLAUDE.md
-$EDITOR your-project/CLAUDE.md
-
-# 5. Open Claude Code in your project
-# The agent now loads full context automatically at session start.
+# 4. Open Claude Code in your project and run /kickoff
+# /kickoff reads PROJECT_BRIEF.md, resolves open questions,
+# fills in CLAUDE.md, generates a task backlog, and opens
+# GitHub issues — all in one pass.
 ```
 
 For first-time global setup only:

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -10,9 +10,11 @@ How to adapt The Rig for your stack, team size, and workflow preferences.
 |---|---|---|
 | `CLAUDE.md` (global) | Stack defaults, personal sections | Hard rules, memory discipline, working style |
 | `CLAUDE.md` (project) | Everything — it's project-specific | — |
+| `PROJECT_BRIEF.md` | All of it — fill in your project | — |
 | `rules/coding-standards.md` | All of it — fill in your stack's conventions | Structure (sections by runtime) |
 | `rules/security.md` | Project-specific additions section | Non-negotiables (top of file) |
-| `.claude/hooks/pre-tool.sh` | `BLOCKED_PATHS` array | Tool name casing (`Write`, `Edit`) |
+| `.claude/hooks/pre-tool.sh` | `BLOCKED_PATHS` array | `RIG_PROTECTED` block, tool name casing (`Write`, `Edit`) |
+| `.claude/commands/task.md` | Autonomy/check-in/risk default levels | Wizard structure and operating mode persistence |
 | `.husky/filter-commit-message-inplace.sh` | Add patterns for other AI tools | Existing patterns |
 | `.gitleaks.toml` | Allowlist entries | `useDefault = true` |
 | Processes | Scope and step details | Core sequence and gate logic |
@@ -22,13 +24,18 @@ How to adapt The Rig for your stack, team size, and workflow preferences.
 ## Adapting for your language stack
 
 ### Python-only project
-In `rules/coding-standards.md`: delete the TypeScript section, fill in Python conventions fully. Adjust imports section for your actual toolchain (Black, isort, mypy, etc.).
+In `rules/coding-standards.md`: delete the TypeScript section, fill in Python
+conventions fully. Adjust imports section for your actual toolchain (Black, isort,
+mypy, etc.).
 
 ### Node/TypeScript-only project
-Delete the Python section. Expand the TypeScript section with your framework conventions (React, Express, etc.).
+Delete the Python section. Expand the TypeScript section with your framework
+conventions (React, Express, etc.).
 
 ### Go, Rust, Ruby, or any other language
-The `coding-standards.md` template uses `[Runtime 1]` / `[Runtime 2]` as placeholder headings — rename them to your languages and fill in the conventions. The structure (naming, types, docs, general rules) applies to any typed language.
+The `coding-standards.md` template uses `[Runtime 1]` / `[Runtime 2]` as placeholder
+headings — rename them to your languages and fill in the conventions. The structure
+(naming, types, docs, general rules) applies to any typed language.
 
 ---
 
@@ -45,13 +52,45 @@ BLOCKED_PATHS=(
 )
 ```
 
-The matching is substring-based — any file path containing the string will be blocked. Keep entries specific enough to not accidentally block legitimate paths.
+The matching is substring-based — any file path containing the string will be blocked.
+Keep entries specific enough to not accidentally block legitimate paths.
+
+The `RIG_PROTECTED` block above `BLOCKED_PATHS` protects The Rig's own governance files.
+Don't modify it directly — use `/propose` instead.
+
+---
+
+## Adjusting the intake wizard defaults
+
+`/task` defaults to **Medium autonomy / Normal check-ins / Balanced risk**. If your
+workflow consistently runs at a different spice level, update the defaults in
+`templates/project/.claude/commands/task.md`:
+
+```markdown
+Default: **3 — High (Autonomous)**
+```
+
+You can also update `tasks/backlog/TASK_example.md` — the `## Operating mode` table
+is pre-filled with defaults. Change those values and every new task starts with your
+preferred settings.
+
+---
+
+## Configuring protected paths for /propose
+
+The governance gate in `/propose` mirrors the `RIG_PROTECTED` list in `pre-tool.sh`.
+If you add new governance files that should require a proposal before modification,
+add them to both places:
+
+1. `pre-tool.sh` → `RIG_PROTECTED` array
+2. `commands/propose.md` → "When to use it" section
 
 ---
 
 ## Adding more slash commands
 
-Create a new `.md` file in `.claude/commands/`. The filename becomes the command name. Structure follows the existing commands: what it does, usage, steps, notes.
+Create a new `.md` file in `.claude/commands/`. The filename becomes the command name.
+Structure follows the existing commands: what it does, usage, steps, notes.
 
 Example — `/review-pr`:
 
@@ -73,7 +112,8 @@ Runs the code-review skill against the current diff.
 
 ## Adjusting the pre-ship checklist
 
-Edit `processes/SHIP_WORKFLOW.md` Step 1. Add or remove checklist items to match your project's requirements. Common additions:
+Edit `processes/SHIP_WORKFLOW.md` Step 1. Add or remove checklist items to match your
+project's requirements. Common additions:
 
 - Accessibility check for UI changes
 - Migration review gate for database changes
@@ -86,19 +126,26 @@ Edit `processes/SHIP_WORKFLOW.md` Step 1. Add or remove checklist items to match
 
 The Rig was designed for solo or small-team use. For larger teams:
 
-**Global layer**: Each engineer installs their own global layer. The personal profile is individual — don't share it. The `CLAUDE.md` global template should be the same across the team (standardized hard rules and working style).
+**Global layer**: Each engineer installs their own global layer. The personal profile
+is individual — don't share it. The `CLAUDE.md` global template should be the same
+across the team (standardized hard rules and working style).
 
-**Project layer**: Commit the project layer to the repo (everything under `.claude/`, `processes/`, `rules/`, `memory/`, `tasks/`, `.husky/`, `.github/`). Every team member gets the same rules and workflows.
+**Project layer**: Commit the project layer to the repo. Every team member gets the
+same rules and workflows.
 
-**Memory files**: `PROGRESS.md` and `ERRORS.md` are committed and shared — everyone sees the same build history and pitfall log. `CONTEXT_SNAPSHOT.md` is gitignored and machine-local — each engineer has their own.
+**Memory files**: `PROGRESS.md` and `ERRORS.md` are committed and shared — everyone
+sees the same build history and pitfall log. `CONTEXT_SNAPSHOT.md` is gitignored and
+machine-local — each engineer has their own.
 
-**Task files**: One task per `tasks/active/` file per engineer. Use naming conventions to avoid collisions: `TASK_[engineer-initials]-[feature].md`.
+**Task files**: One task per `tasks/active/` file per engineer. Use naming conventions
+to avoid collisions: `TASK_[engineer-initials]-[feature].md`.
 
 ---
 
 ## Using without Husky (non-Node projects)
 
-The Husky hooks are POSIX shell scripts that work independently of Husky. You can wire them directly:
+The Husky hooks are POSIX shell scripts that work independently of Husky. You can
+wire them directly:
 
 ```bash
 # Copy hooks to .git/hooks/
@@ -111,13 +158,18 @@ cp .husky/filter-commit-message-inplace.sh .husky/
 chmod +x .git/hooks/pre-commit .git/hooks/commit-msg .git/hooks/post-commit
 ```
 
-The `.git/hooks/` approach works for any project regardless of language. The downside: hooks in `.git/hooks/` are not committed to the repo, so teammates must set them up manually. Husky solves this by checking in hooks to `.husky/` and auto-installing them via `prepare` script in `package.json`.
+The `.git/hooks/` approach works for any project regardless of language. The downside:
+hooks in `.git/hooks/` are not committed to the repo, so teammates must set them up
+manually. Husky solves this by checking in hooks to `.husky/` and auto-installing them
+via `prepare` script in `package.json`.
 
 ---
 
 ## Disabling the AI trailer stripping
 
-If you want co-author credits to appear in your history (e.g., you're building a team project where attribution matters), comment out or remove the `commit-msg` and `post-commit` hooks from `.husky/`.
+If you want co-author credits to appear in your history (e.g., you're building a team
+project where attribution matters), comment out or remove the `commit-msg` and
+`post-commit` hooks from `.husky/`.
 
 The `pre-commit` (gitleaks) is independent and unaffected.
 
@@ -125,7 +177,9 @@ The `pre-commit` (gitleaks) is independent and unaffected.
 
 ## Replacing gitleaks with another secret scanner
 
-Edit `.husky/pre-commit`. Replace the gitleaks block with your scanner of choice. The hook structure (check for binary → run scanner → block on non-zero exit) works for any scanner that exits non-zero on detection.
+Edit `.husky/pre-commit`. Replace the gitleaks block with your scanner of choice.
+The hook structure (check for binary → run scanner → block on non-zero exit) works
+for any scanner that exits non-zero on detection.
 
 Common alternatives: `trufflehog`, `git-secrets`, `detect-secrets`.
 
@@ -133,7 +187,9 @@ Common alternatives: `trufflehog`, `git-secrets`, `detect-secrets`.
 
 ## Adding a decisions log
 
-The memory system has `PROGRESS.md` (what shipped) and `ERRORS.md` (what went wrong), but not a structured decisions log. If your project benefits from explicit decision records, add `memory/DECISIONS.md`:
+The memory system has `PROGRESS.md` (what shipped) and `ERRORS.md` (what went wrong),
+but not a structured decisions log. If your project benefits from explicit decision
+records, add `memory/DECISIONS.md`:
 
 ```markdown
 # Decisions log
@@ -148,3 +204,23 @@ The memory system has `PROGRESS.md` (what shipped) and `ERRORS.md` (what went wr
 ```
 
 Reference it in the project `CLAUDE.md` context-loading sequence.
+
+---
+
+## Upgrading The Rig
+
+When a new version of The Rig is released, pull the latest from the repo and re-run
+the installer against your project:
+
+```bash
+cd the-rig && git pull
+./install.sh --project-only
+```
+
+Choose **Merge** as the collision strategy. This will:
+- Add any new template files that don't exist yet
+- Smart-merge `.claude/settings.json` (new hooks added without overwriting yours)
+- Skip all existing files (your customizations are preserved)
+
+After upgrading, review the CHANGELOG for any manual steps — some releases may
+require updating `rules/` or `processes/` files that the merge strategy skips.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -60,7 +60,9 @@ The Rig solves this at three levels:
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-The global layer is loaded first, automatically, by Claude Code. It provides universal context. The project layer is read during orientation and provides project-specific context.
+The global layer is loaded first, automatically, by Claude Code. It provides
+universal context. The project layer is read during orientation and provides
+project-specific context.
 
 ---
 
@@ -82,8 +84,9 @@ CLAUDE.md instructs: read ./CLAUDE.md
      │  Project identity, stack, conventions
      │
      ▼
-CLAUDE.md instructs: read ./memory/PROGRESS.md
-     │  Where the project stands — full build history
+CLAUDE.md instructs: check memory/CONTEXT_SNAPSHOT.md
+     │  If it exists → sufficient for orientation. Load it and stop.
+     │  If absent or stale → load PROGRESS.md (last 20 entries only)
      │
      ▼
 CLAUDE.md instructs: read ./memory/ERRORS.md
@@ -102,8 +105,8 @@ Agent is oriented. Hooks are live. Ready to work.
      │
      ▼
 /wrap — session end
-     │  Writes CONTEXT_SNAPSHOT.md
-     │  Ensures PROGRESS.md is current
+     │  Writes CONTEXT_SNAPSHOT.md (full current state)
+     │  Ensures PROGRESS.md is current; trims if > 20 entries
      └─ Surfaces next priority
 ```
 
@@ -113,23 +116,24 @@ Agent is oriented. Hooks are live. Ready to work.
 
 Three files, three purposes:
 
+### CONTEXT_SNAPSHOT.md
+- **The primary orientation file** — written at session end via `/wrap`
+- **Gitignored** — lives on disk only, never committed
+- Contains: project state, open PRs, backlog priority, key decisions, known footguns, environment notes
+- When it exists, the agent reads *only this* at session start. PROGRESS.md is skipped.
+- What allows a new session to orient in seconds rather than minutes
+
 ### PROGRESS.md
-- Append-only build log
-- One entry per PR merge (format: date, summary, bullets, PR number)
-- Auto-stubbed by `post-tool.sh` after every git commit — the stub exists even if the agent forgets to write the narrative
+- Append-only build log, one entry per meaningful unit of work
+- Auto-stubbed by `post-tool.sh` after every git commit — stub exists even if the agent forgets
 - Most recent entry at the top
+- **Trim convention:** capped at 20 entries. `/wrap` moves older entries to `PROGRESS_archive.md` (gitignored, disk-only) when the cap is exceeded. Keeps session startup cost low indefinitely.
 
 ### ERRORS.md
 - Pitfall log — every non-obvious bug logged with structured format
 - Never deleted, only appended
 - Format: Symptom → Root cause → Fix → Watch for
 - The most valuable file in the system — it's institutional memory
-
-### CONTEXT_SNAPSHOT.md
-- Session state — overwritten (never deleted) at session end via `/wrap`
-- **Gitignored** — lives on disk only, never committed
-- Contains: project state paragraph, full PR list, open PRs, backlog priority order, key decisions, known footguns, environment notes
-- What allows a new session to orient in seconds rather than minutes
 
 ---
 
@@ -140,7 +144,7 @@ Four workflow files that define step-by-step behaviour at each phase:
 ### NEW_TASK_WORKFLOW
 ```
 Step 0: Confirm working directory (main repo, not worktree)
-Step 1: Orient (read SNAPSHOT → PROGRESS → ERRORS → task file)
+Step 1: Orient (read SNAPSHOT → PROGRESS if needed → ERRORS → task file)
 Step 2: Confirm understanding — restate goal, files, risks. Wait for approval.
 Step 3: Plan — write numbered plan into task file. Wait for approval.
 Step 4: Implement — one step at a time, surface surprises
@@ -192,10 +196,10 @@ Every tool call
      │
      ├─► pre-tool.sh (PreToolUse)
      │     Logs call to /tmp/the-rig-session.log
-     │     If tool is Write or Edit:
-     │       Extract file_path from JSON input
-     │       Check against BLOCKED_PATHS array
-     │       Exit 1 (block) if match found
+     │     Checks RIG_PROTECTED: blocks writes to governance files
+     │     (processes/, rules/, .husky/, CLAUDE.md, .claude/hooks/)
+     │     Checks BLOCKED_PATHS: blocks project-specific protected paths
+     │     Exit 1 (block) if match found
      │
      └─► post-tool.sh (PostToolUse)
            Logs completion to session log
@@ -206,7 +210,10 @@ Every tool call
                Append dated stub to PROGRESS.md (idempotent)
 ```
 
-**Critical implementation note:** Tool names in Claude Code are `PascalCase` (`Write`, `Edit`, `Bash`). Using `snake_case` (`write_file`, `edit_file`) causes the hooks to silently never fire. This was the most costly silent bug in the pilot — it ran undetected for 30+ PRs.
+**Critical implementation note:** Tool names in Claude Code are `PascalCase`
+(`Write`, `Edit`, `Bash`). Using `snake_case` (`write_file`, `edit_file`) causes
+the hooks to silently never fire. This was the most costly silent bug in the pilot —
+it ran undetected for 30+ PRs.
 
 ### Git hooks (`.husky/`)
 
@@ -234,28 +241,65 @@ git commit
 ## The task lifecycle
 
 ```
-tasks/backlog/TASK_name.md    ← created during planning
+tasks/backlog/TASK_name.md    ← created by /task or /kickoff
         │
-        │  (user starts work)
+        │  (user starts work via /run or /task)
         ▼
 tasks/active/TASK_name.md     ← Status: active
-        │
+        │                        ## Operating mode set (autonomy/check-ins/risk)
         │  (implementation complete, tests pass)
         ▼
 tasks/done/TASK_name.md       ← Status: done, Done notes filled in
 ```
 
-**Staging rule:** The task file is never staged in the implementation commit. It's staged only from `tasks/done/` in a separate housekeeping commit. Committing from `tasks/active/` creates a confusing history where in-progress and completed states appear in the same PR.
+**Staging rule:** The task file is never staged in the implementation commit. It's
+staged only from `tasks/done/` in a separate housekeeping commit.
 
 ---
 
-## The slash commands
+## The command set
 
-Four commands that map to the process workflows:
+Eight slash commands covering the full development lifecycle:
 
+### Project bootstrap
 | Command | Triggers | Key behaviour |
 |---|---|---|
-| `/new-feature` | `NEW_TASK_WORKFLOW` | Creates task file, plans before coding, waits for approval |
-| `/ship` | `SHIP_WORKFLOW` | Pre-ship checklist, shows commit message, waits for "go ahead" |
+| `/kickoff` | `NEW_TASK_WORKFLOW` | Reads `PROJECT_BRIEF.md`, confirms understanding, scaffolds `CLAUDE.md` + task backlog + GitHub issues in one pass |
+
+### Daily work
+| Command | Triggers | Key behaviour |
+|---|---|---|
+| `/task` | `NEW_TASK_WORKFLOW` | Three-part intake wizard: goal → autonomy/check-ins/risk configuration → confirmation. Persists operating mode in task file. |
+| `/run` | Task execution loop | Surveys backlog, builds dependency-aware priority queue, executes tasks respecting per-task operating mode. Chains automatically at High autonomy. |
+
+### Ship and debug
+| Command | Triggers | Key behaviour |
+|---|---|---|
+| `/ship` | `SHIP_WORKFLOW` | Pre-ship checklist, conventional commit, opens PR |
 | `/debug` | `DEBUG_WORKFLOW` | Hypothesis before code, mandatory ERRORS.md entry |
-| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, surfaces next priority |
+
+### Governance and housekeeping
+| Command | Triggers | Key behaviour |
+|---|---|---|
+| `/propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
+| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, trims if > 20 entries, surfaces next priority |
+| `/new-feature` | `NEW_TASK_WORKFLOW` | Original task entry point — creates task file, plans before coding, waits for approval |
+
+---
+
+## The autonomy system
+
+`/task` and `/run` support per-task operating mode configuration:
+
+| Setting | Options |
+|---|---|
+| **Autonomy** | 🌶 Low (Guided) · 🌶🌶 Medium (Supervised) · 🌶🌶🌶 High (Autonomous) |
+| **Check-ins** | Verbose · Normal · Quiet |
+| **Risk tolerance** | Conservative · Balanced · Aggressive |
+
+The configuration is written to `## Operating mode` in the task file and persists
+across sessions. `/run` reads the stored mode and executes accordingly — chaining
+tasks without interruption at High autonomy, pausing between tasks at Medium and Low.
+
+Governance (protected paths, `/propose` gate, pre-ship checklist) applies at all
+autonomy levels. "High Autonomous" means fewer interruptions, not fewer safeguards.


### PR DESCRIPTION
## Summary

Three docs were materially outdated after the v1.0.0 → v1.1.0 additions. This PR brings them current.

## `docs/how-it-works.md`

- **Session lifecycle diagram**: rewritten to show CONTEXT_SNAPSHOT-first loading. PROGRESS.md is now shown as a conditional load (only when snapshot is absent/stale), matching the behaviour introduced in PR #32.
- **Slash commands table**: expanded from 4 commands to all 8, grouped by purpose. The old table listed only `/new-feature`, `/ship`, `/debug`, `/wrap` — missing `/task`, `/kickoff`, `/run`, `/propose`.
- **Memory system section**: CONTEXT_SNAPSHOT promoted to first position as the primary orientation file. PROGRESS.md trim convention documented.
- **New section**: "The autonomy system" — explains `/task` intake wizard and `/run` chaining behaviour.

## `docs/customizing.md`

- `PROJECT_BRIEF.md` added to customization table
- New section: adjusting intake wizard defaults (autonomy/check-in/risk levels)
- New section: configuring `/propose` governance gate
- `RIG_PROTECTED` block called out explicitly as off-limits for direct edits
- New section: **upgrade path** — re-run installer with Merge strategy after pulling latest

## `README.md`

- Quickstart updated: step 4 now says "run `/kickoff`" instead of "edit CLAUDE.md manually"
- Installer step updated to mention collision strategy + component selection prompts

## Test plan

- [ ] Read the session lifecycle diagram in `how-it-works.md` — verify it matches actual CLAUDE.md load sequence
- [ ] Count commands in the slash commands table — should be 8
- [ ] Verify customizing.md "upgrade path" section matches actual install.sh Merge behaviour
- [ ] Verify README quickstart step 4 mentions /kickoff

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
