### PR TITLE
fix: /propose post-approval apply flow — human applies, agent cannot

### DIFF
--- a/templates/project/.claude/commands/propose.md
+++ b/templates/project/.claude/commands/propose.md
@@ -16,8 +16,24 @@ Instead of modifying a governance file directly, the agent:
 2. Shows you the full before/after diff in the proposal document
 3. Explains why the change is warranted (symptom, pattern, or lesson)
 4. Waits for your explicit approval before anything is touched
-5. On approval: applies the change and logs it in `memory/ERRORS.md` or
-   `memory/PROGRESS.md` as appropriate
+5. On approval: provides the exact change to apply — **but you apply it**
+
+**Why the agent can't apply it directly:** `pre-tool.sh` blocks writes to all
+governance files unconditionally — including during an approved proposal. This is
+intentional. The governance system protects itself. The human is always the one who
+applies governance changes.
+
+**How to apply after approval:**
+
+Option A — paste in editor:
+> Copy the diff from the proposal file and apply it manually in your editor.
+
+Option B — the agent generates a ready-to-paste block:
+> After you approve, say "show me the apply block". The agent will output the
+> complete file content (not a diff) so you can paste it directly into the file.
+
+After applying: tell the agent it's done. It will log the change in
+`memory/PROGRESS.md` and clean up `/tmp/rig-proposal-[name].md`.
 
 ---
 

--- a/templates/project/.claude/hooks/pre-tool.sh
+++ b/templates/project/.claude/hooks/pre-tool.sh
@@ -28,13 +28,19 @@ if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
 
   # ── THE RIG'S OWN GOVERNANCE FILES (self-protection) ─────────────────────
   # The agent must not rewrite the rules it is supposed to follow.
-  # These paths are protected by default. To intentionally modify a workflow,
-  # rule, or hook, the user must either:
-  #   (a) temporarily comment out the relevant entry below, or
-  #   (b) make the edit manually outside of a Claude Code session.
+  # These paths are protected unconditionally — even after a /propose approval.
   #
-  # The /propose slash command is the approved path for suggesting changes —
-  # it stages a proposal for human review rather than modifying files directly.
+  # APPROVED CHANGE FLOW:
+  #   1. Run /propose — agent writes proposal to /tmp/rig-proposal-[name].md
+  #      and shows the exact before/after diff.
+  #   2. Review and approve the proposal in chat.
+  #   3. The agent cannot apply the change itself (this block stops it).
+  #      Apply it one of two ways:
+  #      (a) Copy the diff from the proposal and paste it manually into the file.
+  #      (b) Open the file in your editor and apply the change.
+  #
+  # This is intentional. The governance system protects itself even during
+  # approved changes — the human is always the one who applies them.
   RIG_PROTECTED=(
     "processes/"
     "rules/"


### PR DESCRIPTION
## Summary

`/propose` step 5 said "on approval: applies the change" — but `pre-tool.sh`'s `RIG_PROTECTED` block would have blocked that exact write. The flow was ambiguous and would have silently failed on first use.

## The fix

This is resolved **by design, not by exception**. The governance system protects itself unconditionally — even during an approved proposal. The human is always the one who applies governance changes. Both files now say this explicitly.

### `pre-tool.sh`
Comment block updated with the full 3-step approved change flow:
1. Run `/propose` → agent writes proposal to `/tmp/rig-proposal-[name].md` with before/after diff
2. Review and approve in chat
3. **You apply it** — paste in editor, or ask agent for a ready-to-paste block

### `propose.md`
Step 5 rewritten:
- Explains *why* the agent can't apply it directly (the hook blocks it — this is intentional)
- Documents two options: paste the diff yourself, or say "show me the apply block" for the full file content
- Adds post-apply step: tell the agent it's done, it logs to PROGRESS.md and cleans up the proposal file

## Why this design is correct

An AI agent that can rewrite its own governance rules — even with human approval — has a weaker trust boundary than one that *cannot*. The human being the mandatory last step in a governance change is a feature. This PR makes that explicit rather than hiding it.

## Test plan

- [ ] Read `pre-tool.sh` comment — verify approved change flow is clearly documented
- [ ] Run `/propose` in a test project — verify step 5 no longer says "agent applies"
- [ ] Attempt to have agent apply a governance change after proposing — verify it's blocked with a helpful message
- [ ] Apply the change manually after approval — verify agent logs it and cleans up proposal file

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
