### PR TITLE
fix: install.sh project name sanitization and [REPO_ROOT] footgun docs

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -114,6 +114,24 @@ Every component in this system exists because something went wrong without it. T
 
 ---
 
+## 11. Moving the project directory broke Claude Code hooks silently
+
+**Symptom**: Pre-tool and post-tool hooks stopped firing after renaming or moving the project directory. No error was shown — file writes to protected paths went through without any block message.
+
+**Root cause**: `install.sh` bakes the absolute project path into `.claude/settings.json` at install time via the `[REPO_ROOT]` placeholder substitution. The hook commands look like `bash /Users/you/projects/old-name/.claude/hooks/pre-tool.sh`. After a move or rename, that path no longer exists — the hook script silently fails to launch, and Claude Code treats this as a passing hook (exit 0 by default).
+
+**Fix**: Re-run the installer after moving the project:
+```bash
+cd the-rig && ./install.sh --project-only
+```
+Choose **Overwrite** or **Merge** strategy. The installer will substitute the new absolute path into `settings.json`.
+
+Alternatively, edit `.claude/settings.json` directly and update the hook command paths to the new location.
+
+**Watch for**: Any time you rename, move, or reorganize a project directory where The Rig is installed. Check `/tmp/the-rig-session.log` — if hooks are firing, you'll see timestamped `PRE` entries. If the log is empty or stale, hooks aren't running.
+
+---
+
 ## 10. useSearchParams() broke the standalone Next.js build
 
 **Symptom**: `next build` completed successfully in development. The production standalone build failed with a static generation error pointing to a page that used `useSearchParams()`.

--- a/install.sh
+++ b/install.sh
@@ -320,6 +320,15 @@ if [[ "$DO_PROJECT" == true ]]; then
   read -r -p "    Name [${DEFAULT_PROJECT_NAME}]: " PROJECT_NAME_INPUT
   PROJECT_NAME="${PROJECT_NAME_INPUT:-$DEFAULT_PROJECT_NAME}"
 
+  # Sanitize project name for safe sed substitution.
+  # Strip characters that are sed metacharacters or shell-special in this context.
+  # Allow: letters, digits, spaces, hyphens, underscores, periods.
+  PROJECT_NAME="$(echo "$PROJECT_NAME" | tr -dc 'A-Za-z0-9 ._-')"
+  if [[ -z "$PROJECT_NAME" ]]; then
+    PROJECT_NAME="$(basename "$TARGET")"
+    warn "Project name contained only invalid characters — using directory name: $PROJECT_NAME"
+  fi
+
   echo ""
 
   # ── COMPONENT SELECTION ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two safety fixes before v1.1.0.

## `install.sh` — project name sanitization

**Problem:** If a user types a project name containing `/`, `\`, `&`, or other sed metacharacters, the `sed` substitution that writes the name into `CLAUDE.md` would silently corrupt the file or throw an error with no clear message.

**Fix:** Strip any character that isn't a letter, digit, space, hyphen, underscore, or period before the substitution. If the result is empty (user entered only invalid characters), fall back to the directory name with a warning.

```bash
PROJECT_NAME="$(echo "$PROJECT_NAME" | tr -dc 'A-Za-z0-9 ._-')"
```

## `docs/lessons-learned.md` — lesson #11: directory move breaks hooks silently

**Problem:** After moving or renaming a project directory, Claude Code hooks stop firing completely. No error is shown — writes to protected paths go through without any block. The hook command in `settings.json` contains a hardcoded absolute path baked in at install time; if the directory moves, the script path doesn't exist and the hook exits silently.

**Fix documented:** Re-run `./install.sh --project-only` after the move. Choose Overwrite or Merge — the installer substitutes the new path. Or edit `settings.json` directly.

**Watch-for:** Check `/tmp/the-rig-session.log` — if hooks are running, you'll see timestamped `PRE` entries. Empty or stale log = hooks not firing.

## Test plan

- [ ] Enter project name `My/Project&Tools` in installer — verify it's sanitized to `MyProjectTools` (or equivalent valid chars)
- [ ] Enter project name `/\\&` — verify fallback to directory name fires with warning
- [ ] Enter a normal project name — verify behaviour unchanged
- [ ] Read lesson #11 in lessons-learned.md — verify symptom/fix/watch-for are clear

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
