### PR TITLE
chore: v1.1.0 release — CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.1.0] — 2026-04-10
+
+### Added
+
+- `docs/customizing.md`: upgrade path section — re-run installer with Merge strategy to pick up new template files without overwriting customizations
+- `docs/lessons-learned.md`: lesson #11 — moving/renaming the project directory after install breaks Claude Code hooks silently; documents fix (re-run installer) and watch-for (check session log)
+
+### Changed
+
+- `install.sh`: collision strategy is now selected once upfront (Interactive / Skip / Overwrite / Merge) rather than per-file prompt. Overwrite mode backs up originals to `.rig-backup/<timestamp>/`. Merge mode smart-merges `.claude/settings.json` via Python 3, deduplicating by command string — idempotent and safe to run twice.
+- `install.sh`: component selection added — choose all or select individual groups (memory, tasks, processes, rules, hooks, commands, git hooks, GitHub templates, CLAUDE.md, PROJECT_BRIEF.md)
+- `install.sh`: project name input sanitized before `sed` substitution — strips metacharacters that would corrupt `CLAUDE.md`
+- `templates/global/CLAUDE.md`: CONTEXT_SNAPSHOT-first context load — PROGRESS.md is only loaded when snapshot is absent or stale; scoped to last 20 entries when loaded
+- `templates/project/CLAUDE.md`: same CONTEXT_SNAPSHOT-first load instruction
+- `templates/project/.claude/commands/wrap.md`: PROGRESS.md trim step added — when entry count exceeds 20, offers to move oldest entries to `PROGRESS_archive.md` (gitignored, disk-only); always confirmed, never automatic
+- `templates/project/.claude/commands/propose.md`: post-approval apply flow clarified — agent cannot apply changes to governance files directly (pre-tool.sh blocks it unconditionally); human applies via editor paste or "show me the apply block" shortcut
+- `templates/project/.claude/hooks/pre-tool.sh`: approved change flow documented in RIG_PROTECTED comment block
+- `templates/project/memory/PROGRESS.md`: trim convention documented
+- `templates/project/memory/.gitignore`: `PROGRESS_archive.md` added
+- `docs/how-it-works.md`: session lifecycle diagram updated for CONTEXT_SNAPSHOT-first load; slash commands table expanded from 4 to all 8, grouped by purpose; autonomy system section added
+- `docs/customizing.md`: PROJECT_BRIEF.md added to customization table; intake wizard defaults section added; /propose governance gate section added; upgrade path section added
+- `README.md`: quickstart step 4 updated from "fill in CLAUDE.md manually" to "run /kickoff"; installer step updated to reflect collision strategy and component selection
+
+---
+
 ## [1.0.0] — 2026-04-10
 
 First stable release. Built and refined across 100+ PRs on the LaudBot project.


### PR DESCRIPTION
## Summary

CHANGELOG update for v1.1.0. Merge this last, after #36, #37, and #38.

After merging, tag the release:
```bash
git checkout main && git pull
git tag v1.1.0
git push origin v1.1.0
```

## Changes since v1.0.0 (documented in this CHANGELOG entry)

| Area | Change |
|---|---|
| Installer | Collision strategy (Interactive/Skip/Overwrite/Merge), component selection, project name sanitization |
| Token economy | CONTEXT_SNAPSHOT-first context load in both CLAUDE.md templates; PROGRESS.md trim in `/wrap` |
| Governance | `/propose` post-approval flow clarified; `pre-tool.sh` comment updated |
| Docs | `how-it-works.md` rewritten for 8 commands + new lifecycle; `customizing.md` updated with new commands, PROJECT_BRIEF, upgrade path; README quickstart updated |
| Safety | `[REPO_ROOT]` directory-move footgun added to `lessons-learned.md` |

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
