### PR TITLE
chore(release): v1.2.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.2.0] — 2026-04-19
+
 ### Added
 
 - **`.rig/` subdirectory**: `memory/`, `processes/`, `rules/`, and `tasks/` are now installed under `.rig/` in the target project (e.g. `.rig/memory/PROGRESS.md`, `.rig/tasks/active/`). Keeps the project root clean — The Rig's files are clearly separated from application code.


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` CHANGELOG section to v1.2.0. No code changes — CHANGELOG only.

## Changes

- CHANGELOG.md: `[Unreleased]` → `[1.2.0] — 2026-04-19`

## Closes

Part of release tagging for v1.2.0 (covers PRs #43 and #45)

## Test plan

- [ ] CHANGELOG shows v1.2.0 at the top
- [ ] `[Unreleased]` section is empty/ready for future changes

## Notes

After this merges, tag `v1.2.0` on main.
