### PR TITLE
fix: husky init failure no longer kills install.sh [#47]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -441,8 +441,14 @@ if [[ "$DO_PROJECT" == true ]]; then
       info "package.json detected."
       if confirm "Initialize Husky? (runs: npx husky install)"; then
         if command -v npx >/dev/null 2>&1; then
-          (cd "$TARGET" && npx husky install)
-          success "Husky initialized"
+          if (cd "$TARGET" && npx husky install); then
+            success "Husky initialized"
+          else
+            warn "Husky initialization failed — run it manually:"
+            echo "    cd $TARGET && npx husky install"
+            echo "  If you see a permission error on node_modules/.bin/husky:"
+            echo "    chmod +x $TARGET/node_modules/.bin/husky"
+          fi
         else
           warn "npx not found — run 'npx husky install' manually in $TARGET"
         fi


### PR DESCRIPTION
## Summary

Husky initialization failure no longer kills `install.sh`. A failed `npx husky install` is now caught and reported with actionable next steps, then the script continues normally.

## Changes

- `install.sh`: wrapped `npx husky install` in an `if` block — failure shows a warning with the manual command and a permission-error hint instead of triggering `set -e` exit

## Closes

Closes #47

## Test plan

- [ ] Simulate failure: `chmod -x node_modules/.bin/husky` in a test project, run installer, confirm warning appears and script continues to completion
- [ ] Confirm `[REPO_ROOT]` and `[Project Name]` substitutions still run after a failed Husky init
- [ ] Confirm gitleaks check and Done summary still appear

## Notes

Reported during a real install of The Rig into the 4Culture.org repo. The `node_modules/.bin/husky` binary had incorrect permissions — a pre-existing issue in that project — which caused exit code 126 and killed the entire install mid-way.
