### PR TITLE
fix: skip TASK_example.md in /run; Co-authored-by only strips AI tools [#49][#50]

### DIFF
--- a/templates/project/.claude/commands/run.md
+++ b/templates/project/.claude/commands/run.md
@@ -29,7 +29,10 @@ start working through them.
 
 ### Step 1 — Survey the backlog
 
-Read all files in `.rig/tasks/backlog/` and `.rig/tasks/active/`. For each task, extract:
+Read all files in `.rig/tasks/backlog/` and `.rig/tasks/active/`. Skip any file named
+`TASK_example.md` — it is the task template, not a real task.
+
+For each task, extract:
 - Task slug (filename without `.md`)
 - Status
 - Priority (`P0`–`P3`)

--- a/templates/project/.husky/filter-commit-message-inplace.sh
+++ b/templates/project/.husky/filter-commit-message-inplace.sh
@@ -7,19 +7,26 @@
 # Usage: sh .husky/filter-commit-message-inplace.sh <message-file>
 #
 # Strips:
-#   - Git trailer lines: Co-authored-by, Signed-off-by, Reviewed-by, etc.
+#   - Co-authored-by: lines that reference AI tools (Claude, Cursor, Copilot, etc.)
+#     Human co-author attribution is preserved.
 #   - AI tool footer lines: "Generated with Cursor/Claude/Copilot", etc.
 #
 # Why: AI coding tools inject attribution footers into every commit. These
 # clutter the git log and expose which commits were AI-assisted. This script
 # removes them so commit history stays clean and human-authored in tone.
+#
+# NOTE: Only Co-authored-by lines mentioning AI tools are stripped. Human
+# pair-programmer attribution (e.g. "Co-authored-by: Jane <jane@example.com>")
+# is intentionally preserved.
 
 f="$1"
 [ -n "$f" ] && [ -f "$f" ] || exit 0
 
 t=$(mktemp) || exit 1
 
-grep -viE '^[[:space:]]*(co-authored-by|signed-off-by|reviewed-by|acked-by|tested-by|helped-by|on-behalf-of|made-with)[[:space:]]*:' "$f" |
+# Strip Co-authored-by only when the value references a known AI tool or service.
+# Matches: tool names (Claude, Cursor, Copilot) and known AI no-reply addresses.
+grep -viE '^[[:space:]]*co-authored-by[[:space:]]*:.*([Cc]laude|[Cc]ursor|[Cc]opilot|[Gg]it[Hh]ub[[:space:]]+[Cc]opilot|noreply@anthropic\.com|noreply@cursor\.com|noreply@github\.com)' "$f" |
   grep -viE '^[[:space:]]*([#*>-][[:space:]]*)*[Gg]enerated[[:space:]]+with[[:space:]]+(Cursor|Claude|Copilot|GitHub Copilot)([[:space:]].*)?$' |
   grep -viE '^[[:space:]]*([#*>-][[:space:]]*)*[Gg]enerated[[:space:]]+by[[:space:]]+(Cursor|Claude|Copilot|GitHub Copilot)([[:space:]].*)?$' |
   grep -viE '^[[:space:]]*([#*>-][[:space:]]*)*[Cc]ommitted[[:space:]]+with[[:space:]]+(Cursor|Claude|Copilot)([[:space:]].*)?$' |


### PR DESCRIPTION
## Summary

Two bugs that caused real problems in production:

1. `/run` was treating `TASK_example.md` as a real task (it has `Status: backlog` and `Priority: P0`)
2. `Co-authored-by:` stripping was removing human pair-programmer attribution alongside AI tool attribution

## Changes

- `.claude/commands/run.md`: Step 1 now explicitly skips `TASK_example.md` when building the work queue
- `.husky/filter-commit-message-inplace.sh`: `Co-authored-by:` filter now only strips lines containing known AI tool names or no-reply addresses — human co-authors are preserved

## Closes

Closes #49
Closes #50

## Test plan

- [ ] Create a real task file in `.rig/tasks/backlog/`, run `/run` — confirm `TASK_example.md` does not appear in the queue
- [ ] Add `Co-authored-by: Jane Smith <jane@example.com>` to a commit — confirm it is not stripped
- [ ] Add `Co-authored-by: Claude <noreply@anthropic.com>` to a commit — confirm it is stripped

## Notes

The `Co-authored-by` fix preserves `Signed-off-by`, `Reviewed-by`, etc. intentionally — those are stripped by the previous version, but they're legitimate in open-source workflows. Removing those strips was a deliberate scope reduction: the hook's stated purpose is stripping AI attribution, not all trailers.
