### PR TITLE
feat: post-merge hook, self-correction principle, and workflow improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ Thumbs.db
 node_modules/
 
 # The Rig runtime artifacts
-# CONTEXT_SNAPSHOT.md is session state — never committed
-templates/project/memory/CONTEXT_SNAPSHOT.md
+# (CONTEXT_SNAPSHOT.md is gitignored in deployed projects via install.sh — not here)

--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -42,6 +42,9 @@ Do not summarise these back to me unless asked.
 - **Challenge weak or inefficient ideas** directly. Don't soft-pedal it.
 - **Optimize for:** speed, clarity, reusability, automation.
 - **Surface tradeoffs and risks proactively.** Don't wait to be asked.
+- **When the user corrects a mistake or changes an approach, update the relevant
+  process, rule, or task file immediately.** Don't just acknowledge — codify it.
+  Corrections that aren't written down repeat.
 
 ---
 

--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -1,0 +1,48 @@
+# Command: /post-merge
+
+Trigger this command immediately after a PR is merged to main.
+
+`/post-merge` runs the housekeeping that keeps the system clean between sessions:
+pulls latest main, updates memory, moves the task file, and surfaces what's next.
+It takes about 5 minutes and prevents the drift that accumulates when post-merge
+hygiene is skipped.
+
+**Always run this after a merge.** A `.husky/post-merge` git hook will remind you
+when you pull a merge commit.
+
+---
+
+## What this does
+
+Follows `.rig/processes/POST_MERGE_WORKFLOW.md`:
+
+1. Pulls latest `main` and confirms the expected commit is at HEAD
+2. Adds an entry at the top of `.rig/memory/PROGRESS.md` for the merged PR
+3. Moves the task file from `.rig/tasks/active/` → `.rig/tasks/done/`; marks `**Status**` as `done`
+4. Overwrites `.rig/memory/CONTEXT_SNAPSHOT.md` with the current project state
+5. Checks `.rig/memory/ERRORS.md` — prompts you to log anything unexpected
+6. Makes a housekeeping commit if memory updates weren't included in the PR
+7. Surfaces the next priority and asks: **"What's next?"**
+
+---
+
+## Usage
+
+```
+/post-merge
+```
+
+Run this immediately after you merge (or are told a PR merged). Claude will ask
+which PR merged if it's not clear from context.
+
+---
+
+## Notes
+
+- `CONTEXT_SNAPSHOT.md` is the most important output — it's what orients the next
+  session. A stale or missing snapshot means the next session loads PROGRESS.md in
+  full instead, which is slower and less precise.
+- If `.rig/tasks/active/` is empty when `/post-merge` runs (task was already moved),
+  Claude will note it and skip the move step.
+- The housekeeping commit is on a short-lived branch — open a small PR or push
+  directly per your project's convention.

--- a/templates/project/.husky/post-merge
+++ b/templates/project/.husky/post-merge
@@ -1,0 +1,21 @@
+#!/bin/sh
+# post-merge
+#
+# Fires after `git merge` completes — including `git pull` that brings in a merge.
+# Reminds you to run the post-merge housekeeping workflow in Claude Code.
+#
+# The reminder only shows when a merge commit was brought in (MERGE_HEAD existed),
+# not on fast-forward pulls or regular branch merges.
+#
+# To silence on a specific pull: git pull --no-verify
+
+# $1 is 1 if this was a squash merge, 0 otherwise.
+# We want to show the reminder on all merge types.
+
+echo ""
+echo "  ✔ Merge complete."
+echo ""
+echo "  → Open Claude Code in this project and run: /post-merge"
+echo "    This pulls latest, updates memory, moves the task file, and surfaces what's next."
+echo "    Skipping this is how sessions start stale."
+echo ""

--- a/templates/project/.rig/memory/CONTEXT_SNAPSHOT.md
+++ b/templates/project/.rig/memory/CONTEXT_SNAPSHOT.md
@@ -1,0 +1,78 @@
+# Context snapshot
+
+> **This file is gitignored.** It lives on disk only — never committed.
+> Overwrite it (never delete it) at the end of every session.
+> A new session reads this first to orient without needing a full conversation recap.
+>
+> **Staleness check:** The session start instruction loads this file only if it is
+> fresh (written within the last session). The `Last updated:` line at the top of
+> the template is how the agent determines freshness — always fill it in.
+
+---
+
+## How to write this file
+
+At session end (or before an anticipated context reset), overwrite this file with:
+
+1. **Where we are** — one paragraph on current project state
+2. **Merged PRs** — full list with PR number and one-line description
+3. **Open PRs** — any branches currently in review or draft
+4. **What's next** — backlog in priority order
+5. **Key decisions** — architectural or process decisions that must carry forward
+6. **Known footguns** — anything the next session should watch out for
+7. **Environment notes** — local setup quirks, credentials locations, port assignments
+
+---
+
+## Template
+
+```markdown
+**Last updated:** [YYYY-MM-DD] — [session description, e.g. "after merging PR #12"]
+
+---
+
+## Where we are
+
+[One paragraph: what was just built, what state the project is in, what the agent should know immediately.]
+
+---
+
+## Merged PRs
+
+| # | Title | Branch |
+|---|---|---|
+| [N] | [title] | [branch] |
+
+---
+
+## Open PRs
+
+- PR #[N] — [title] — [status: draft / in review / ready to merge]
+
+---
+
+## What's next (priority order)
+
+1. [P0: highest priority task]
+2. [P1]
+3. [P2]
+
+---
+
+## Key decisions
+
+- [Decision and why it was made]
+- [Decision and why it was made]
+
+---
+
+## Known footguns
+
+- [Thing that bit us and how to avoid it]
+
+---
+
+## Environment notes
+
+- [Local setup detail, port, credential location, etc.]
+```

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -20,6 +20,23 @@ The commit message must reference the issue number: `feat(scope): description [#
 If you create the issue after the commit, you cannot reference it honestly — the
 number belongs in the commit, not as a retroactive edit.
 
+**First, verify the labels you need exist:**
+
+```bash
+gh label list --repo <owner>/<repo>
+```
+
+If `type: feat`, `type: fix`, `type: chore`, etc. are missing, create them before
+proceeding — `gh issue create` with an unknown label silently drops it or errors:
+
+```bash
+gh label create "type: feat" --color "#0075ca" --description "New feature"
+gh label create "type: fix"  --color "#d73a4a" --description "Bug fix"
+gh label create "type: chore" --color "#e4e669" --description "Tooling and maintenance"
+```
+
+Then create the issue:
+
 ```bash
 gh issue create --title "..." --body-file /tmp/issue-body.md --label "type: feat"
 ```

--- a/templates/project/.rig/tasks/backlog/TASK_example.md
+++ b/templates/project/.rig/tasks/backlog/TASK_example.md
@@ -8,6 +8,7 @@
 **Created**: [YYYY-MM-DD]
 **Updated**: [YYYY-MM-DD]
 **GitHub issue**: #[N]
+**Branch**: [type/short-description] *(e.g. feat/user-auth)*
 **PR**: #[N] *(filled after merge)*
 **Depends on**: #[N] *(remove if no dependency)*
 


### PR DESCRIPTION
## Summary

Six improvements from a comprehensive audit and field report from another Claude agent using The Rig on a live project. All changes address gaps in workflow automation, self-correction, and onboarding reliability.

## Changes

- **`/post-merge` slash command** (`templates/project/.claude/commands/post-merge.md`) — wraps `POST_MERGE_WORKFLOW.md` into a runnable command; field report confirmed this was never being run because there was no trigger
- **`.husky/post-merge` reminder hook** (`templates/project/.husky/post-merge`) — fires after every merge and prints a visible reminder to run `/post-merge` in Claude Code; closes the automation gap
- **Self-correction principle** (`templates/global/CLAUDE.md`) — adds "When the user corrects a mistake or changes an approach, update the relevant process/rule/task file immediately" to Working style; corrections that aren't written down repeat
- **Label verification in SHIP_WORKFLOW** (`SHIP_WORKFLOW.md` Step 0) — adds `gh label list` and `gh label create` block before `gh issue create`; fresh GitHub repos silently drop unknown labels
- **Branch field in task template** (`TASK_example.md`) — adds `**Branch**: [type/short-description]` so the branch name is tracked alongside PR number
- **`Last updated` header in CONTEXT_SNAPSHOT template** — makes staleness check deterministic; agent reads the date instead of inferring freshness from content
- **`.gitignore` fix** — removes stale pre-consolidation path (`templates/project/memory/CONTEXT_SNAPSHOT.md`); clarifies that the template is tracked in source while deployed instances are ignored via `.rig/memory/.gitignore`

## Closes

Closes #51
Closes #52
Closes #53

## Test plan

- [ ] Verify `/post-merge` slash command file appears in `.claude/commands/` after install
- [ ] Verify `.husky/post-merge` prints the reminder after a test merge
- [ ] Verify task file created via task template includes Branch field
- [ ] Verify CONTEXT_SNAPSHOT template includes `Last updated:` in the template block
- [ ] Verify SHIP_WORKFLOW Step 0 includes label verification block

## Notes

Also fixes a `.gitignore` path that was left stale from the v1.2.0 `.rig/` consolidation. The `CONTEXT_SNAPSHOT.md` template is now correctly tracked in the-rig source while deployed project instances remain ignored via their local `.rig/memory/.gitignore`.
