### PR TITLE
feat: compaction wrap, commit gate, /ship hard gate, external .rig/

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -123,6 +123,47 @@ project's requirements. Common additions:
 
 ---
 
+## Keeping .rig/ invisible to teammates
+
+If you're using The Rig on a shared repo where teammates don't use it, you have
+two options to avoid `.rig/` showing up in their `git status`.
+
+### Option A — Local gitignore (simplest)
+
+The installer offers this as a tracking choice. It adds `.rig/` to
+`.git/info/exclude`, which is per-clone and never committed. Teammates don't see
+it; no `.gitignore` change is needed.
+
+To do it manually after install:
+
+```bash
+echo ".rig/" >> .git/info/exclude
+```
+
+### Option B — External directory
+
+Install `.rig/` to a path outside the repo entirely. Pass `--rig-dir` to the
+installer:
+
+```bash
+~/tools/the-rig/install.sh --project-only --rig-dir ~/.rig/projects/my-project
+```
+
+Or choose option 3 in the interactive tracking prompt. The installer will:
+
+1. Install all `.rig/` files to the external path
+2. Write a `.rigpath` file in the project root containing the external path
+3. Add `.rigpath` to `.git/info/exclude` automatically
+4. Update `CLAUDE.md`'s `@` imports and context-loading paths to use the
+   absolute external location
+5. Update the hooks (`pre-tool.sh`, `post-tool.sh`) to resolve `RIG_DIR` via
+   `.rigpath` at runtime — no hardcoded paths
+
+The project root stays clean. The agent finds its memory and rules via
+`.rigpath`. Teammates never see any of it.
+
+---
+
 ## Scaling to a team
 
 The Rig was designed for solo or small-team use. For larger teams:
@@ -132,7 +173,8 @@ is individual — don't share it. The `CLAUDE.md` global template should be the 
 across the team (standardized hard rules and working style).
 
 **Project layer**: Commit the project layer to the repo. Every team member gets the
-same rules and workflows.
+same rules and workflows. If some engineers don't use The Rig, use the local
+gitignore approach above.
 
 **Memory files**: `PROGRESS.md` and `ERRORS.md` are committed and shared — everyone
 sees the same build history and pitfall log. `CONTEXT_SNAPSHOT.md` is gitignored and

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -155,12 +155,13 @@ Step 6: Wrap up — move task, update PROGRESS, log ERRORS, commit
 
 ### SHIP_WORKFLOW
 ```
-Step 0: Create GitHub issue FIRST — commit must reference [#N]
-Step 1: Pre-ship checklist (AC, no debug code, no secrets, Docker verification)
-Step 2: Self-review — does this do ONLY what was asked?
-Step 3: Commit (conventional format, issue reference)
-Step 4: Update memory (move task, PROGRESS, SNAPSHOT, ERRORS)
-Step 5: Open PR (template exactly, labels at creation time)
+Step 0:   Create GitHub issue FIRST — commit must reference [#N]
+Step 1:   Pre-ship checklist (AC, no debug code, no secrets, Docker verification)
+Step 2:   Self-review — does this do ONLY what was asked?
+Step 2.5: Pause — ask user to confirm local testing done (non-negotiable)
+Step 3:   Commit (conventional format, issue reference)
+Step 4:   Update memory (move task, PROGRESS, SNAPSHOT, ERRORS)
+Step 5:   Open PR (read .github/pull_request_template.md; labels at creation time)
 ```
 
 ### DEBUG_WORKFLOW
@@ -196,19 +197,21 @@ Wired via `.claude/settings.json`. Run on every tool call (`"matcher": ".*"`).
 Every tool call
      │
      ├─► pre-tool.sh (PreToolUse)
+     │     Resolves RIG_DIR (.rigpath if present, else $REPO/.rig)
      │     Logs call to /tmp/the-rig-session.log
      │     Checks RIG_PROTECTED: blocks writes to governance files
-     │     (.rig/processes/, .rig/rules/, .husky/, CLAUDE.md, .claude/hooks/)
+     │     (RIG_DIR/processes/, RIG_DIR/rules/, .husky/, CLAUDE.md, .claude/hooks/)
      │     Checks BLOCKED_PATHS: blocks project-specific protected paths
      │     Exit 1 (block) if match found
      │
      └─► post-tool.sh (PostToolUse)
+           Resolves RIG_DIR (.rigpath if present, else $REPO/.rig)
            Logs completion to session log
            If tool is Bash:
              Scan output for git commit hash pattern
              If commit detected:
                Read commit message + hash from git log
-               Append dated stub to .rig/memory/PROGRESS.md (idempotent)
+               Append dated stub to RIG_DIR/memory/PROGRESS.md (idempotent)
 ```
 
 **Critical implementation note:** Tool names in Claude Code are `PascalCase`
@@ -276,7 +279,7 @@ Eight slash commands covering the full development lifecycle:
 ### Ship and debug
 | Command | Triggers | Key behaviour |
 |---|---|---|
-| `/ship` | `SHIP_WORKFLOW` | Pre-ship checklist, conventional commit, opens PR |
+| `/ship` | `SHIP_WORKFLOW` | Sequential 9-step hard gate: task confirm → issue → labels → checklist → local test pause → commit approval → commit → housekeeping → PR |
 | `/debug` | `DEBUG_WORKFLOW` | Hypothesis before code, mandatory ERRORS.md entry |
 
 ### Governance and housekeeping

--- a/install.sh
+++ b/install.sh
@@ -48,20 +48,35 @@ PROJECT_TEMPLATES="$SCRIPT_DIR/templates/project"
 # ── Parse flags ───────────────────────────────────────────────────────────────
 DO_GLOBAL=true
 DO_PROJECT=true
+EXTERNAL_RIG_DIR=""   # set via --rig-dir <path>
 
 for arg in "$@"; do
   case "$arg" in
     --global-only)  DO_PROJECT=false ;;
     --project-only) DO_GLOBAL=false ;;
+    --rig-dir)
+      # --rig-dir is handled below as a two-arg flag; skip here
+      ;;
     --help|-h)
-      echo "Usage: ./install.sh [--global-only | --project-only | --help]"
+      echo "Usage: ./install.sh [--global-only | --project-only] [--rig-dir <path>] [--help]"
       echo ""
-      echo "  --global-only   Install ~/.claude/ layer only (CLAUDE.md + skills)"
-      echo "  --project-only  Scaffold project layer only (processes, rules, memory, etc.)"
-      echo "  (no flags)      Interactive — prompts for both"
+      echo "  --global-only      Install ~/.claude/ layer only (CLAUDE.md + skills)"
+      echo "  --project-only     Scaffold project layer only (processes, rules, memory, etc.)"
+      echo "  --rig-dir <path>   Install .rig/ to an external directory outside the repo."
+      echo "                     A .rigpath pointer file is written to the project root."
+      echo "                     Useful for shared repos where teammates don't use The Rig."
+      echo "  (no flags)         Interactive — prompts for both"
       exit 0
       ;;
   esac
+done
+
+# Capture --rig-dir value (two-argument flag)
+args=("$@")
+for (( i=0; i<${#args[@]}; i++ )); do
+  if [[ "${args[$i]}" == "--rig-dir" && $((i+1)) -lt ${#args[@]} ]]; then
+    EXTERNAL_RIG_DIR="${args[$((i+1))]}"
+  fi
 done
 
 # ── Portable in-place sed ─────────────────────────────────────────────────────
@@ -331,6 +346,54 @@ if [[ "$DO_PROJECT" == true ]]; then
 
   echo ""
 
+  # ── GIT TRACKING FOR .rig/ ────────────────────────────────────────────────
+  # How should .rig/ appear (or not appear) in git?
+  # Only asked in interactive mode; --rig-dir flag bypasses this.
+  RIG_TRACKING="repo"   # default: committed with the project
+  RIGPATH_FILE=""       # absolute path to .rigpath (set if external or exclude mode)
+
+  if [[ -z "$EXTERNAL_RIG_DIR" ]]; then
+    echo "How should .rig/ be tracked in git?"
+    echo ""
+    echo "  1) In the repo      — committed with the project (default, recommended for solo projects)"
+    echo "  2) Local only       — added to .git/info/exclude; invisible to teammates, no .gitignore change"
+    echo "  3) External         — install .rig/ to a path outside this repo entirely"
+    echo ""
+    read -r -p "$(echo -e "${BOLD}?${RESET} Choose [1/2/3] (default: 1): ")" rig_tracking_input
+    rig_tracking_input="${rig_tracking_input:-1}"
+
+    case "$rig_tracking_input" in
+      1) RIG_TRACKING="repo" ;;
+      2) RIG_TRACKING="exclude" ;;
+      3) RIG_TRACKING="external"
+         ask "External path for .rig/ files?"
+         read -r -p "    Path: " EXTERNAL_RIG_DIR
+         if [[ -z "$EXTERNAL_RIG_DIR" ]]; then
+           error "External path cannot be empty."
+           exit 1
+         fi
+         ;;
+      *)
+        warn "Invalid choice — defaulting to 'In the repo'."
+        RIG_TRACKING="repo"
+        ;;
+    esac
+  else
+    RIG_TRACKING="external"
+  fi
+
+  # Resolve and validate the external path (if applicable)
+  if [[ "$RIG_TRACKING" == "external" ]]; then
+    # Expand ~ and resolve to absolute path
+    EXTERNAL_RIG_DIR="${EXTERNAL_RIG_DIR/#\~/$HOME}"
+    mkdir -p "$EXTERNAL_RIG_DIR" || { error "Cannot create directory: $EXTERNAL_RIG_DIR"; exit 1; }
+    EXTERNAL_RIG_DIR="$(cd "$EXTERNAL_RIG_DIR" && pwd)"
+    RIGPATH_FILE="$TARGET/.rigpath"
+    info "External .rig/ location: $EXTERNAL_RIG_DIR"
+  fi
+
+  echo ""
+
   # ── COMPONENT SELECTION ───────────────────────────────────────────────────
   echo "Which components do you want to install?"
   echo ""
@@ -353,12 +416,17 @@ if [[ "$DO_PROJECT" == true ]]; then
   INSTALL_PROJECT_BRIEF=true
 
   if [[ "$component_choice" == "b" ]]; then
+    # Show context-aware paths for .rig/ components
+    RIG_LABEL=".rig/"
+    if [[ "$RIG_TRACKING" == "external" ]]; then
+      RIG_LABEL="${EXTERNAL_RIG_DIR}/"
+    fi
     echo ""
     confirm "Install CLAUDE.md (project brain template)?" "y"     && INSTALL_CLAUDE_MD=true    || INSTALL_CLAUDE_MD=false
-    confirm "Install memory system (.rig/memory/, PROGRESS, ERRORS)?" "y" && INSTALL_MEMORY=true   || INSTALL_MEMORY=false
-    confirm "Install task lifecycle (.rig/tasks/backlog, active, done)?" "y" && INSTALL_TASKS=true  || INSTALL_TASKS=false
-    confirm "Install process workflows (.rig/processes/)?" "y"     && INSTALL_PROCESSES=true   || INSTALL_PROCESSES=false
-    confirm "Install rules (.rig/rules/)?" "y"                     && INSTALL_RULES=true        || INSTALL_RULES=false
+    confirm "Install memory system (${RIG_LABEL}memory/, PROGRESS, ERRORS)?" "y" && INSTALL_MEMORY=true   || INSTALL_MEMORY=false
+    confirm "Install task lifecycle (${RIG_LABEL}tasks/backlog, active, done)?" "y" && INSTALL_TASKS=true  || INSTALL_TASKS=false
+    confirm "Install process workflows (${RIG_LABEL}processes/)?" "y"  && INSTALL_PROCESSES=true   || INSTALL_PROCESSES=false
+    confirm "Install rules (${RIG_LABEL}rules/)?" "y"                  && INSTALL_RULES=true        || INSTALL_RULES=false
     confirm "Install Claude Code hooks (.claude/hooks/, settings.json)?" "y" && INSTALL_CLAUDE_HOOKS=true || INSTALL_CLAUDE_HOOKS=false
     confirm "Install slash commands (.claude/commands/)?" "y"      && INSTALL_COMMANDS=true    || INSTALL_COMMANDS=false
     confirm "Install git hooks (.husky/, .gitleaks.toml)?" "y"     && INSTALL_GIT_HOOKS=true   || INSTALL_GIT_HOOKS=false
@@ -370,6 +438,11 @@ if [[ "$DO_PROJECT" == true ]]; then
   echo ""
   info "Scaffolding into: $TARGET"
   info "Project name:     $PROJECT_NAME"
+  if [[ "$RIG_TRACKING" == "external" ]]; then
+    info ".rig/ location:   $EXTERNAL_RIG_DIR (external)"
+  elif [[ "$RIG_TRACKING" == "exclude" ]]; then
+    info ".rig/ tracking:   local only (.git/info/exclude)"
+  fi
   echo ""
 
   # ── FILE → COMPONENT MAPPING ──────────────────────────────────────────────
@@ -398,8 +471,16 @@ if [[ "$DO_PROJECT" == true ]]; then
       info "Component not selected — skipped: $rel"
       continue
     fi
-    dest_file="$TARGET/$rel"
-    copy_file "$src_file" "$dest_file" "$TARGET"
+
+    # Route .rig/ files to the external directory when applicable
+    if [[ "$RIG_TRACKING" == "external" && "$rel" == .rig/* ]]; then
+      rig_rel="${rel#.rig/}"
+      dest_file="$EXTERNAL_RIG_DIR/$rig_rel"
+      copy_file "$src_file" "$dest_file" "$EXTERNAL_RIG_DIR"
+    else
+      dest_file="$TARGET/$rel"
+      copy_file "$src_file" "$dest_file" "$TARGET"
+    fi
   done < <(find "$PROJECT_TEMPLATES" -type f -print0)
 
   # ── SUBSTITUTE PLACEHOLDERS ───────────────────────────────────────────────
@@ -418,6 +499,52 @@ if [[ "$DO_PROJECT" == true ]]; then
     ESCAPED_PATH="${TARGET_ABS//\//\\/}"
     sed_inplace "s/\\[REPO_ROOT\\]/${ESCAPED_PATH}/g" "$TARGET_SETTINGS"
     success "Substituted [REPO_ROOT] in .claude/settings.json → $TARGET_ABS"
+  fi
+
+  # ── EXTERNAL .rig/ — write .rigpath and update git excludes ──────────────
+  if [[ "$RIG_TRACKING" == "external" ]]; then
+    # Write the pointer file so hooks can resolve RIG_DIR at runtime
+    echo "$EXTERNAL_RIG_DIR" > "$RIGPATH_FILE"
+    success "Created .rigpath → $EXTERNAL_RIG_DIR"
+
+    # Exclude .rigpath from git tracking (per-clone, not shared via .gitignore)
+    GIT_EXCLUDE="$TARGET/.git/info/exclude"
+    if [[ -f "$GIT_EXCLUDE" ]]; then
+      if ! grep -qF ".rigpath" "$GIT_EXCLUDE"; then
+        echo ".rigpath" >> "$GIT_EXCLUDE"
+        success "Added .rigpath to .git/info/exclude"
+      else
+        info ".rigpath already in .git/info/exclude"
+      fi
+    else
+      warn ".git/info/exclude not found — add '.rigpath' to your .gitignore manually"
+    fi
+
+    # Update CLAUDE.md @imports to use absolute paths for the external .rig/ dir
+    TARGET_CLAUDE="$TARGET/CLAUDE.md"
+    if [[ -f "$TARGET_CLAUDE" ]]; then
+      ESCAPED_EXT="${EXTERNAL_RIG_DIR//\//\\/}"
+      sed_inplace "s|@\\.rig/|@${ESCAPED_EXT}/|g" "$TARGET_CLAUDE"
+      # Also update the context-loading paths in the prose
+      sed_inplace "s|\`.rig/memory/|\`${EXTERNAL_RIG_DIR}/memory/|g" "$TARGET_CLAUDE"
+      sed_inplace "s|\`.rig/tasks/|\`${EXTERNAL_RIG_DIR}/tasks/|g" "$TARGET_CLAUDE"
+      success "Updated CLAUDE.md to reference external .rig/ path"
+    fi
+  fi
+
+  # ── LOCAL-ONLY: add .rig/ to .git/info/exclude ───────────────────────────
+  if [[ "$RIG_TRACKING" == "exclude" ]]; then
+    GIT_EXCLUDE="$TARGET/.git/info/exclude"
+    if [[ -f "$GIT_EXCLUDE" ]]; then
+      if ! grep -qF ".rig/" "$GIT_EXCLUDE"; then
+        printf "\n# The Rig system files — local only, not shared with teammates\n.rig/\n" >> "$GIT_EXCLUDE"
+        success "Added .rig/ to .git/info/exclude (local only — teammates won't see it)"
+      else
+        info ".rig/ already in .git/info/exclude"
+      fi
+    else
+      warn ".git/info/exclude not found — add '.rig/' to your .gitignore manually"
+    fi
   fi
 
   # ── EXECUTABLE BITS ───────────────────────────────────────────────────────

--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -19,6 +19,8 @@ At the start of any session, silently read in this order:
 3. The project's `./CLAUDE.md` (if present)
 4. `./.rig/memory/CONTEXT_SNAPSHOT.md` — **if this exists, it is sufficient for orientation.
    Stop here unless the task requires deeper history.**
+   *(If `.rigpath` exists at the project root, read that file to get the real `.rig/` path
+   and substitute it for `.rig/` in steps 4–7.)*
 5. `./.rig/memory/PROGRESS.md` — only if `CONTEXT_SNAPSHOT.md` is absent or more than
    one session old. Load the most recent entries only (last 20 `##` sections).
 6. `./.rig/memory/ERRORS.md` (if present)
@@ -45,6 +47,9 @@ Do not summarise these back to me unless asked.
 - **When the user corrects a mistake or changes an approach, update the relevant
   process, rule, or task file immediately.** Don't just acknowledge — codify it.
   Corrections that aren't written down repeat.
+- **When you see a compaction warning** (e.g. "8% until auto-compact"), run `/wrap`
+  immediately — before the next tool call. Compaction destroys in-flight context.
+  A timely `/wrap` means the next session can resume cleanly.
 
 ---
 
@@ -64,7 +69,10 @@ Do not summarise these back to me unless asked.
 8. **Never touch files outside the current task scope** unless explicitly asked.
 9. **Never make architectural decisions silently** — surface them for discussion first.
 10. **Never assume continuity from a prior session** — always re-read context files.
-11. **Always work in the main repo, not the worktree.** Claude Code sessions run inside
+11. **Never run `git commit` without first pausing to ask the user to confirm that
+    local testing is done.** Show the proposed commit message, then wait for explicit
+    go-ahead. This is non-negotiable regardless of autonomy level.
+12. **Always work in the main repo, not the worktree.** Claude Code sessions run inside
     `.claude/worktrees/<name>/`. File edits made there are invisible to the user's git
     client. At the start of every session, identify the main repo root with
     `git rev-parse --show-toplevel` and target ALL Write/Edit tool calls and `git`

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -1,32 +1,161 @@
 # Command: /ship
 
-Trigger this command when you're ready to commit and close out a task.
+Trigger this command when you are ready to commit and close out a task.
 
-## What this does
+This is a **sequential hard gate** — each step must be completed and confirmed
+before the next one executes. Do not skip steps, combine steps, or proceed past
+a failure without surfacing it.
 
-Follows `.rig/processes/SHIP_WORKFLOW.md`:
+---
 
-1. Identifies the active task file and confirms which task is being shipped
-2. Runs through the pre-ship checklist (acceptance criteria, no debug code, no secrets, verification)
-3. Shows you the proposed commit message and waits for approval
-4. Commits, moves the task file to `.rig/tasks/done/`, updates `.rig/memory/PROGRESS.md`
-5. Opens the PR using the project's PR template
+## Step 1 — Identify the task
 
-## Usage
+Read `.rig/tasks/active/`. If there is exactly one task file, confirm it.
+If there are multiple, ask the user which task is being shipped. If there are
+none, stop and say: "No active task found. Move a task to `.rig/tasks/active/`
+before shipping."
+
+State clearly:
+> "Shipping: **[task name]** — [one-line goal from the task file]"
+
+Wait for the user to confirm this is the right task before continuing.
+
+---
+
+## Step 2 — Confirm the GitHub issue
+
+Read the task file's `**GitHub issue**:` field.
+
+- If it contains a real issue number (e.g. `#12`): state it and proceed.
+- If it is empty or still a placeholder: **stop.**
+  Say: "No GitHub issue linked. Per SHIP_WORKFLOW Step 0, the issue must exist
+  before committing. Create the issue first, then update the task file."
+
+Do not proceed to Step 3 until a valid issue number is confirmed.
+
+---
+
+## Step 3 — Verify labels
+
+Run:
+```bash
+gh label list --repo $(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+Display the available labels. Determine which `type:` label matches this
+commit type (`feat`, `fix`, `chore`, `refactor`, `docs`, `devops`, etc.) and
+which `area:` labels apply.
+
+If the required labels do not exist, offer to create them before continuing:
+```bash
+gh label create "type: feat" --color "#0e8a16" --description "New functionality"
+```
+
+State which labels will be applied to the PR. Wait for confirmation before
+continuing.
+
+---
+
+## Step 4 — Pre-ship checklist
+
+Work through the following. Report the result of each check:
+
+- [ ] All acceptance criteria in the task file are met
+- [ ] No `console.log`, `print()`, or other debug statements left in code
+- [ ] No commented-out code
+- [ ] No hardcoded secrets, tokens, or credentials
+- [ ] Error cases handled — not just the happy path
+- [ ] If `Dockerfile`, `requirements.txt`, `package.json`, or service layer was
+      touched: in-container verification has been run per `.rig/rules/verification.md`
+- [ ] `git status --short` checked for untracked files from Docker volume mounts
+
+If any item cannot be confirmed, stop and resolve it before continuing.
+
+---
+
+## Step 5 — Pause for local testing
+
+**Stop here.** Do not commit yet.
+
+Say to the user:
+> "Ready to commit. Have you tested the changes locally and confirmed they work
+> as expected?"
+
+Wait for explicit confirmation ("yes", "looks good", "go ahead", etc.).
+Do not proceed if the response is ambiguous. This step cannot be skipped
+regardless of autonomy level.
+
+---
+
+## Step 6 — Show the commit message and wait for go-ahead
+
+Compose the commit message in conventional format:
 
 ```
-/ship
+type(scope): short description [#N]
+
+Body: explain WHY, not what. The diff shows what.
 ```
 
-Claude will confirm:
-- Which task is being shipped
-- The commit message it will use (conventional format, references the issue)
-- Any checklist items that look incomplete or ambiguous
+Display it. Then ask:
+> "Commit with this message? [yes / edit]"
 
-It then waits for your explicit **"go ahead"** before committing.
+If the user says "edit", accept the revised message. Do not commit until the
+message is explicitly approved.
+
+---
+
+## Step 7 — Commit
+
+Write the approved commit message to `/tmp/ship-commit-msg.txt` and commit:
+
+```bash
+cat > /tmp/ship-commit-msg.txt << 'EOF'
+[approved commit message]
+EOF
+git commit -F /tmp/ship-commit-msg.txt
+```
+
+Report the commit hash on success.
+
+---
+
+## Step 8 — Post-commit housekeeping
+
+In this order:
+
+1. Move the task file: `.rig/tasks/active/TASK_[name].md` → `.rig/tasks/done/`
+2. Update `.rig/memory/PROGRESS.md` — add a full entry at the top (not a stub)
+3. Overwrite `.rig/memory/CONTEXT_SNAPSHOT.md` with current project state
+
+---
+
+## Step 9 — Open the PR
+
+Use the project's PR template if one exists at `.github/pull_request_template.md`.
+Read it, fill in every section, then:
+
+```bash
+cat > /tmp/ship-pr-body.md << 'EOF'
+[filled-in PR template]
+EOF
+gh pr create \
+  --title "type(scope): description" \
+  --body-file /tmp/ship-pr-body.md \
+  --base main \
+  --label "type: [type]" \
+  --label "area: [area]"
+```
+
+Report the PR URL.
+
+---
 
 ## Notes
 
-- The GitHub issue must already exist before `/ship` is run (see SHIP_WORKFLOW Step 0)
-- Labels are applied at PR creation time — Claude will prompt if none are specified
-- The task file is staged only from `.rig/tasks/done/`, never from `.rig/tasks/active/`
+- Steps 1–6 are **gates** — any failure stops the sequence entirely.
+- The GitHub issue (Step 2) must exist before `/ship` is run, not after.
+- Labels (Step 3) must be verified against the actual repo — never assumed.
+- The local testing pause (Step 5) is non-negotiable regardless of autonomy level.
+- If the task has multiple commits, summarise all changes in the PR body.
+- The task file is moved to `.rig/tasks/done/` only after a successful commit.

--- a/templates/project/.claude/hooks/post-tool.sh
+++ b/templates/project/.claude/hooks/post-tool.sh
@@ -17,7 +17,17 @@ if [[ -z "$REPO" ]]; then
   exit 0  # Not in a git repo, nothing to do
 fi
 
-PROGRESS_FILE="$REPO/.rig/memory/PROGRESS.md"
+# ── Resolve RIG_DIR ───────────────────────────────────────────────────────────
+# Supports external .rig/ installations (see install.sh --rig-dir).
+# If .rigpath exists in the repo root, it contains the absolute path to the
+# .rig/ directory (which may be outside the repo). Otherwise default to $REPO/.rig.
+if [[ -f "$REPO/.rigpath" ]]; then
+  RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+else
+  RIG_DIR="$REPO/.rig"
+fi
+
+PROGRESS_FILE="$RIG_DIR/memory/PROGRESS.md"
 SESSION_LOG="/tmp/the-rig-session.log"
 
 # ── Session log ───────────────────────────────────────────────────────────────

--- a/templates/project/.claude/hooks/pre-tool.sh
+++ b/templates/project/.claude/hooks/pre-tool.sh
@@ -15,6 +15,22 @@
 TOOL="$1"
 INPUT=$(cat)
 
+# ── Repo root — dynamic, never hardcoded ─────────────────────────────────────
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -z "$REPO" ]]; then
+  exit 0  # Not in a git repo, nothing to do
+fi
+
+# ── Resolve RIG_DIR ───────────────────────────────────────────────────────────
+# Supports external .rig/ installations (see install.sh --rig-dir).
+# If .rigpath exists in the repo root, it contains the absolute path to the
+# .rig/ directory (which may be outside the repo). Otherwise default to $REPO/.rig.
+if [[ -f "$REPO/.rigpath" ]]; then
+  RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+else
+  RIG_DIR="$REPO/.rig"
+fi
+
 # ── Session log ──────────────────────────────────────────────────────────────
 # Logs every tool call with a timestamp. Useful for debugging agent behaviour.
 # Comment out if too noisy.
@@ -41,12 +57,15 @@ if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
   #
   # This is intentional. The governance system protects itself even during
   # approved changes — the human is always the one who applies them.
+  #
+  # Uses absolute paths so the block works whether .rig/ is inside the repo
+  # or at an external location (see .rigpath / install.sh --rig-dir).
   RIG_PROTECTED=(
-    ".rig/processes/"
-    ".rig/rules/"
-    ".husky/"
-    "CLAUDE.md"
-    ".claude/hooks/"
+    "$RIG_DIR/processes/"
+    "$RIG_DIR/rules/"
+    "$REPO/.husky/"
+    "$REPO/CLAUDE.md"
+    "$REPO/.claude/hooks/"
   )
 
   for protected in "${RIG_PROTECTED[@]}"; do

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -74,6 +74,20 @@ If any answer gives you pause, fix it before committing.
 
 ---
 
+## Step 2.5 — Pause for local testing
+
+**Stop. Do not commit yet.**
+
+Ask the user:
+> "Ready to commit. Have you tested the changes locally and confirmed they work
+> as expected?"
+
+Wait for explicit confirmation. Do not proceed until the user says yes (or
+equivalent). This step is **non-negotiable** — it cannot be skipped regardless
+of autonomy level or how confident the agent is in the changes.
+
+---
+
 ## Step 3 — Commit
 
 Use conventional commit format:
@@ -112,7 +126,14 @@ In this order:
 
 ## Step 5 — Open the PR
 
-Use the PR template **exactly**. Five sections: Summary, Changes, Closes, Test plan, Notes.
+**First, check for a PR template:**
+
+```bash
+cat .github/pull_request_template.md 2>/dev/null
+```
+
+If a template exists, fill in **every section** of it. Do not skip sections or
+leave placeholders. If no template exists, use this default:
 
 ```bash
 cat > /tmp/pr-body.md << 'EOF'
@@ -128,7 +149,13 @@ Closes #N
 
 ## Notes
 EOF
-gh pr create --title "..." --body-file /tmp/pr-body.md --base main --label "type: feat"
+```
+
+Then create the PR:
+
+```bash
+gh pr create --title "..." --body-file /tmp/pr-body.md --base main \
+  --label "type: [type]" --label "area: [area]"
 ```
 
 **Apply labels at creation time.** Never retroactively. Required labels:

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -108,6 +108,10 @@ When starting a new session, read in this order:
 3. `.rig/memory/ERRORS.md` — known pitfalls
 4. `.rig/tasks/active/` — current in-flight task(s)
 
+> **External .rig/ note:** if `.rigpath` exists at the project root, all `.rig/`
+> paths above resolve to the external directory it points to. The installer
+> updates these paths automatically when the external tracking option is chosen.
+
 ---
 
 ## Imported rules


### PR DESCRIPTION
## Summary

Four improvements to agent behaviour, workflow enforcement, and installation flexibility. All changes are additive — existing installs require no migration.

## Changes

### #57 — Auto-wrap on compaction warning
- `templates/global/CLAUDE.md`: new Working style rule — when the agent sees a compaction warning ("X% until auto-compact"), it runs `/wrap` immediately before the next tool call. Compaction destroys in-flight context; a timely `/wrap` keeps the next session resumable.

### #59 — Pause before git commit (non-negotiable)
- `templates/global/CLAUDE.md`: new Hard rule #11 — never run `git commit` without first asking the user to confirm local testing is done. Show the proposed commit message. Wait for explicit go-ahead.
- `templates/project/.rig/processes/SHIP_WORKFLOW.md`: new Step 2.5 — explicit pause for local test confirmation between self-review and commit. Non-negotiable at all autonomy levels.

### #58 — `/ship` as 9-step hard gate
- `templates/project/.claude/commands/ship.md`: fully rewritten. Was descriptive; now executable and enforced. Each step is a gate: (1) identify task, (2) confirm GitHub issue, (3) verify labels, (4) pre-ship checklist, (5) pause for local testing, (6) commit message approval, (7) commit, (8) housekeeping, (9) PR using `.github/pull_request_template.md`. No step executes until the previous one is confirmed.
- `templates/project/.rig/processes/SHIP_WORKFLOW.md` Step 5: now reads `.github/pull_request_template.md` first; falls back to inline default.

### #60 — External `.rig/` directory
- `install.sh`: new git tracking prompt with three options — (1) in the repo (default), (2) local only via `.git/info/exclude`, (3) external path. Also accepts `--rig-dir <path>` flag for non-interactive use. External mode: installs `.rig/` to the external path, writes `.rigpath` to project root, adds `.rigpath` to `.git/info/exclude`, updates `CLAUDE.md` `@imports` and context-loading paths to absolute external location.
- `templates/project/.claude/hooks/pre-tool.sh`: resolves `RIG_DIR` dynamically — reads `.rigpath` if present, falls back to `$REPO/.rig`. Updates `RIG_PROTECTED` to use absolute paths so the block works regardless of `.rig/` location.
- `templates/project/.claude/hooks/post-tool.sh`: same `RIG_DIR` resolution. `PROGRESS_FILE` now points to `$RIG_DIR/memory/PROGRESS.md`.
- `templates/project/CLAUDE.md`: adds `.rigpath` note to context-loading section.
- `docs/customizing.md`: new section "Keeping .rig/ invisible to teammates" covering both options.
- `docs/how-it-works.md`: updated hook diagram and `/ship` description.

## Closes

Closes #57
Closes #58
Closes #59
Closes #60

## Test plan

- [ ] Existing installs: confirm `pre-tool.sh` and `post-tool.sh` still work with no `.rigpath` present (fallback to `$REPO/.rig`)
- [ ] New install with option 1 (in repo): no `.rigpath`, `.rig/` in repo as before
- [ ] New install with option 2 (local only): `.rig/` installed, `.git/info/exclude` entry added, no `.gitignore` change
- [ ] New install with option 3 (external): `.rigpath` written, `.rig/` at external path, `CLAUDE.md` @imports updated, `.rigpath` in `.git/info/exclude`
- [ ] `install.sh --rig-dir ~/tmp/test-rig --project-only`: non-interactive external path
- [ ] `/ship` in a session with a proper active task: confirm all 9 steps gate correctly
- [ ] Compaction warning in a session: confirm agent triggers `/wrap`

## Notes

Backward-compatible: the `.rigpath` check in both hooks is a no-op when the file doesn't exist. No changes required for existing deployments.
