### PR TITLE
feat: ERRORS archival, /task issue gate, batch tracking, debug guard

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -132,9 +132,9 @@ Three files, three purposes:
 
 ### .rig/memory/ERRORS.md
 - Pitfall log — every non-obvious bug logged with structured format
-- Never deleted, only appended
 - Format: Symptom → Root cause → Fix → Watch for
 - The most valuable file in the system — it's institutional memory
+- **Trim convention:** capped at 30 entries. `/wrap` moves older entries to `.rig/memory/ERRORS_archive.md` (gitignored, disk-only) when the cap is exceeded. Same pattern as PROGRESS.md.
 
 ---
 
@@ -144,7 +144,7 @@ Four workflow files that define step-by-step behaviour at each phase:
 
 ### NEW_TASK_WORKFLOW
 ```
-Step 0: Confirm working directory (main repo, not worktree)
+Step 0: GitHub issue first — /task wizard enforces this at intake time
 Step 1: Orient (read SNAPSHOT → PROGRESS if needed → ERRORS → task file)
 Step 2: Confirm understanding — restate goal, files, risks. Wait for approval.
 Step 3: Plan — write numbered plan into task file. Wait for approval.
@@ -225,9 +225,12 @@ it ran undetected for 30+ PRs.
 git commit
      │
      ├─► pre-commit
-     │     Run gitleaks --staged
-     │     Block commit if secrets detected
+     │     Run gitleaks --staged → block if secrets detected
      │     (PATH-safe: checks command -v + /usr/local/bin + /opt/homebrew/bin)
+     │     Run debug artifact scanner → block if leftover debug code detected
+     │     (console.log, var_dump, pdb.set_trace, debugger, etc.)
+     │     Extend with project patterns in .rig-debug-patterns
+     │     Override per-line with # rig-debug-ok; bypass with --no-verify
      │
      ├─► commit-msg
      │     Apply filter-commit-message-inplace.sh to message file

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -25,11 +25,20 @@ Ask the user the following. Collect all answers before moving to Part 2.
    the codebase (what service, module, or directory will this touch?).
 3. **Hard constraints?** Any deadline, off-limits paths, technology restrictions, or
    things that must not change?
+4. **GitHub issue number?** Every task must be linked to an issue before any code is
+   written — the number goes in the task file and every commit message on this branch.
+   - If the user provides a number (e.g. `#42`): note it and continue.
+   - If no issue exists yet: **stop here.** Say exactly:
+     > "Every task needs a GitHub issue before we start. Create one now and share
+     > the number — I'll wait. It goes in the task file and every commit."
+     Do not proceed to Part 2 until a real issue number is provided.
+   - Exception: if the project has no GitHub remote or the user explicitly says
+     "no issue tracking", note that in the task file and continue without a number.
 
-After collecting answers, confirm back:
+After collecting all answers, confirm back:
 
 > "Got it. You want to [restate task in one sentence], working in [area], with
-> [constraints or 'no hard constraints']. Let's configure how I'll operate."
+> [constraints or 'no hard constraints']. Issue: #[N]. Let's configure how I'll operate."
 
 ---
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -10,8 +10,9 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 2. Ensures `.rig/memory/PROGRESS.md` is up to date — expands any auto-stubbed entries
 3. **Trims `.rig/memory/PROGRESS.md`** if it has grown beyond 20 entries (see Trim step below)
 4. Checks `.rig/memory/ERRORS.md` — prompts you to log anything unexpected from this session
-5. Reports what's in `.rig/tasks/active/` so you know what's in flight
-6. Surfaces the next priority from `.rig/tasks/backlog/` and asks: "What's next?"
+5. **Trims `.rig/memory/ERRORS.md`** if it has grown beyond 30 entries (see Trim step below)
+6. Reports what's in `.rig/tasks/active/` so you know what's in flight
+7. Surfaces the next priority from `.rig/tasks/backlog/` and asks: "What's next?"
 
 ## Usage
 
@@ -48,10 +49,33 @@ Never trim without confirmation. Never delete entries — only move them.
 
 ---
 
+## Trim step — ERRORS.md
+
+After checking `.rig/memory/ERRORS.md`, count the number of `## ` entry headers in the file.
+
+**If the count is 30 or fewer:** nothing to do.
+
+**If the count exceeds 30:** tell the user:
+
+> "`.rig/memory/ERRORS.md` has [N] entries. I'll move the oldest [N-30] to
+> `.rig/memory/ERRORS_archive.md` to keep session startup lean. The archive is
+> gitignored — pitfall history is preserved locally but won't load at session start.
+> Trim now?"
+
+If the user confirms:
+1. Identify the oldest entries (bottom of the file, since entries are newest-first)
+2. Prepend them to `.rig/memory/ERRORS_archive.md` (create if absent)
+3. Remove them from `.rig/memory/ERRORS.md`, leaving the 30 most recent entries
+4. Confirm: "`.rig/memory/ERRORS.md` trimmed to 30 entries. Archive: `.rig/memory/ERRORS_archive.md`"
+
+Never trim without confirmation. Never delete entries — only move them.
+
+---
+
 ## Notes
 
 - `.rig/memory/CONTEXT_SNAPSHOT.md` is gitignored — it lives on disk only, never committed
-- `.rig/memory/PROGRESS_archive.md` is also gitignored — full history on disk, not in the repo
+- `.rig/memory/PROGRESS_archive.md` and `.rig/memory/ERRORS_archive.md` are gitignored — full history on disk, not in the repo
 - Always **overwrite** the snapshot, never append to it; it represents current state, not history
-- History belongs in `.rig/memory/PROGRESS.md` (recent) and `.rig/memory/PROGRESS_archive.md` (older); the snapshot is for session continuity only
+- History belongs in `.rig/memory/PROGRESS.md` (recent) and `PROGRESS_archive.md` (older); same pattern for `ERRORS.md` / `ERRORS_archive.md`
 - If a task is in progress but not done, note its exact state in the snapshot so the next session can resume without re-reading the whole conversation

--- a/templates/project/.husky/pre-commit
+++ b/templates/project/.husky/pre-commit
@@ -1,15 +1,19 @@
 #!/bin/sh
 # pre-commit
 #
-# Scans staged files for secrets before they leave the machine.
-# Blocks the commit if any secrets are detected.
+# Two checks run on every commit:
 #
-# Requires gitleaks. Install: brew install gitleaks
-# Config: .gitleaks.toml in the repo root
+#   1. Secret scanning via gitleaks (requires install: brew install gitleaks)
+#   2. Debug artifact scanning — blocks commits containing leftover debug code
+#
+# Both checks scan staged files only.
+# To bypass in an emergency: git commit --no-verify
 #
 # NOTE: Git hooks run with a stripped PATH. Never assume `command -v` will
 # find a binary that works in your interactive shell. Always check known
 # install locations explicitly.
+
+# ── 1. Secret scanning ────────────────────────────────────────────────────────
 
 GITLEAKS_BIN=""
 
@@ -33,4 +37,83 @@ if [ -n "$GITLEAKS_BIN" ]; then
 else
   echo "WARNING: gitleaks not installed — secret scanning skipped."
   echo "Install it to protect yourself: brew install gitleaks"
+fi
+
+# ── 2. Debug artifact scanning ────────────────────────────────────────────────
+#
+# Blocks commits that contain leftover debug code.
+# Scans staged file content only — not the working tree.
+#
+# Built-in patterns cover the most common debug statements across languages.
+# Add project-specific patterns to .rig-debug-patterns (one grep-E pattern
+# per line, lines starting with # are ignored).
+#
+# To allow a specific line through: append  # rig-debug-ok  to that line.
+# To skip this check for one commit: git commit --no-verify
+
+# Built-in debug patterns (grep -E syntax, one per line)
+BUILTIN_PATTERNS="console\.log(
+debugger;
+var_dump(
+print_r(
+error_log(
+file_put_contents.*debug
+pdb\.set_trace(
+breakpoint(
+binding\.pry
+byebug
+System\.out\.println(
+dd(
+dump(.*=>>"
+
+# Merge with project-specific patterns if present
+ALL_PATTERNS="$BUILTIN_PATTERNS"
+if [ -f ".rig-debug-patterns" ]; then
+  EXTRA=$(grep -v '^#' .rig-debug-patterns | grep -v '^$')
+  if [ -n "$EXTRA" ]; then
+    ALL_PATTERNS="$ALL_PATTERNS
+$EXTRA"
+  fi
+fi
+
+# Build a single combined regex (patterns joined with |)
+COMBINED=$(printf '%s\n' "$ALL_PATTERNS" | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
+
+if [ -z "$COMBINED" ]; then
+  exit 0
+fi
+
+# Scan staged text files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null)
+FOUND=""
+
+for f in $STAGED_FILES; do
+  # Skip binary files
+  case "$f" in
+    *.png|*.jpg|*.jpeg|*.gif|*.ico|*.svg|*.woff|*.woff2|*.ttf|*.eot|\
+    *.pdf|*.zip|*.tar|*.gz|*.mp4|*.mp3|*.mov) continue ;;
+  esac
+
+  # Get the staged version of the file and scan it
+  hits=$(git show ":$f" 2>/dev/null \
+    | grep -nE "$COMBINED" \
+    | grep -v 'rig-debug-ok')
+
+  if [ -n "$hits" ]; then
+    FOUND="$FOUND
+  $f:
+$(printf '%s\n' "$hits" | head -5 | sed 's/^/    /')"
+  fi
+done
+
+if [ -n "$FOUND" ]; then
+  echo ""
+  echo "Debug artifact check blocked this commit."
+  echo "Remove or clean up the following before committing:"
+  echo "$FOUND"
+  echo ""
+  echo "  To allow a specific line:  append  # rig-debug-ok  to that source line"
+  echo "  To skip this check once:   git commit --no-verify"
+  echo ""
+  exit 1
 fi

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -6,3 +6,7 @@ CONTEXT_SNAPSHOT.md
 # PROGRESS_archive.md holds older entries trimmed from PROGRESS.md.
 # Archive is disk-only: useful for manual reference but not loaded at session start.
 PROGRESS_archive.md
+
+# ERRORS_archive.md holds older entries trimmed from ERRORS.md.
+# Same pattern as PROGRESS_archive.md — local reference, never loaded at session start.
+ERRORS_archive.md

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -13,7 +13,19 @@
 
 ---
 
-## Step 0 — Confirm your working directory
+## Step 0 — GitHub issue first
+
+Before any code is written, a GitHub issue must exist and be linked in the task file.
+The `/task` wizard enforces this: it will not proceed to Part 2 without an issue number.
+If you are running this workflow without going through `/task`, stop and create the issue now.
+
+The issue number belongs in:
+- The task file's `**GitHub issue**: #[N]` field
+- Every commit message on this branch: `feat(scope): description [#N]`
+
+---
+
+## Step 1 — Confirm your working directory
 
 Before touching any file, identify the main repo root and confirm all edits will target it.
 

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -50,7 +50,8 @@ Note the issue number. It goes in every commit on this branch.
 Work through this list before staging anything:
 
 - [ ] All acceptance criteria in the task file are met
-- [ ] No `console.log`, `print()`, or other debug statements left in code
+- [ ] No debug statements left in code (`console.log`, `var_dump`, `pdb.set_trace`, etc.)
+      *(the pre-commit hook will also catch these automatically — this is a manual pre-check)*
 - [ ] No commented-out code (we have git history)
 - [ ] No hardcoded secrets, tokens, or credentials
 - [ ] Error cases handled — not just the happy path

--- a/templates/project/.rig/tasks/backlog/TASK_example.md
+++ b/templates/project/.rig/tasks/backlog/TASK_example.md
@@ -57,6 +57,18 @@
 
 ---
 
+## Batches
+
+> Use this section when a task spans multiple commits or PR checkpoints.
+> Record each sub-goal as it lands. Delete this section for single-commit tasks.
+
+| # | Sub-goal | Commit | PR checkpoint |
+|---|---|---|---|
+| 1 | [What this batch delivers] | `[hash]` *(filled after commit)* | — |
+| 2 | [Next sub-goal] | — | — |
+
+---
+
 ## Prompt history
 
 > Running log of significant prompts and outcomes during this task.


### PR DESCRIPTION
## Summary

Four gap fixes from field use and system audit. All additive — no breaking changes to existing installs.

## Changes

### #62 — ERRORS.md archival (`/wrap`)
- `/wrap` now checks `ERRORS.md` entry count after the existing PROGRESS.md trim step
- If count exceeds 30, offers to move oldest entries to `ERRORS_archive.md` (same confirmed-trim pattern as PROGRESS.md)
- `ERRORS_archive.md` added to `.rig/memory/.gitignore`
- `docs/how-it-works.md` memory section updated to document the cap

### #63 — `/task` intake wizard issue gate
- Part 1 of the wizard now asks for a GitHub issue number as question 4
- Wizard will not proceed to Part 2 without a real issue number — shows "create one first" message and waits
- Exception documented: projects with no GitHub remote or explicit no-tracking preference
- `NEW_TASK_WORKFLOW.md` Step 0 rewritten to clarify enforcement is at wizard time, not just recommended
- Consistent with the existing `/ship` Step 2 gate

### #64 — Batch tracking in task template
- New `## Batches` section in `TASK_example.md` with a table: sub-goal | commit hash | PR checkpoint
- Instruction to delete the section for single-commit tasks

### #65 — Debug artifact guard in pre-commit
- `pre-commit` hook now runs a second check after gitleaks: grep scan of staged file content for debug patterns
- Built-in patterns: `console.log`, `debugger`, `var_dump`, `print_r`, `error_log`, `file_put_contents.*debug`, `pdb.set_trace`, `breakpoint`, `binding.pry`, `byebug`, `System.out.println`, `dd(`, `dump(=>>`
- Extend with `.rig-debug-patterns` file (one grep-E pattern per line)
- Allow individual lines: append `# rig-debug-ok` to the source line
- Bypass entirely: `git commit --no-verify`
- Binary files skipped by extension
- `SHIP_WORKFLOW` pre-ship checklist updated to note the automated enforcement

## Closes

Closes #62
Closes #63
Closes #64
Closes #65

## Test plan

- [ ] Run `/wrap` on a project with > 30 ERRORS.md entries — confirm trim offer appears
- [ ] Run `/task` without providing an issue number — confirm wizard stops at step 4
- [ ] Run `/task` with an issue number — confirm wizard proceeds normally
- [ ] Create a staged file containing `console.log(` — confirm pre-commit blocks it
- [ ] Add `# rig-debug-ok` to the same line — confirm commit goes through
- [ ] Add `.rig-debug-patterns` with a custom pattern — confirm it catches staged matches
- [ ] Existing installs: confirm pre-commit still runs gitleaks correctly (no regression)

## Notes

All changes are backward-compatible. The `ERRORS_archive.md` gitignore entry and debug patterns are purely additive. Existing installs get the debug guard on next `merge` upgrade run.
