### PR TITLE
feat(hooks): commit gate with user trigger-phrase flow

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -29,7 +29,7 @@ The Rig solves this at three levels:
 │  Installed once per machine. Cross-project.                     │
 │                                                                 │
 │  ~/.claude/CLAUDE.md                                            │
-│    └─ Hard rules (11), working style, memory discipline,        │
+│    └─ Hard rules (12), working style, memory discipline,        │
 │       planning discipline, session workflow, git conventions,   │
 │       code quality defaults, skill trigger table                │
 │                                                                 │
@@ -145,12 +145,13 @@ Four workflow files that define step-by-step behaviour at each phase:
 ### NEW_TASK_WORKFLOW
 ```
 Step 0: GitHub issue first — /task wizard enforces this at intake time
-Step 1: Orient (read SNAPSHOT → PROGRESS if needed → ERRORS → task file)
-Step 2: Confirm understanding — restate goal, files, risks. Wait for approval.
-Step 3: Plan — write numbered plan into task file. Wait for approval.
-Step 4: Implement — one step at a time, surface surprises
-Step 5: Verify — run tests, check acceptance criteria
-Step 6: Wrap up — move task, update PROGRESS, log ERRORS, commit
+Step 1: Confirm working directory (main repo root, never a worktree path)
+Step 2: Orient (read SNAPSHOT → PROGRESS if needed → ERRORS → task file)
+Step 3: Confirm understanding — restate goal, files, risks. Wait for approval.
+Step 4: Plan — write numbered plan into task file. Wait for approval.
+Step 5: Implement — one step at a time, surface surprises
+Step 6: Verify — run tests, check acceptance criteria
+Step 7: Wrap up — move task, update PROGRESS, log ERRORS, commit
 ```
 
 ### SHIP_WORKFLOW
@@ -158,8 +159,8 @@ Step 6: Wrap up — move task, update PROGRESS, log ERRORS, commit
 Step 0:   Create GitHub issue FIRST — commit must reference [#N]
 Step 1:   Pre-ship checklist (AC, no debug code, no secrets, Docker verification)
 Step 2:   Self-review — does this do ONLY what was asked?
-Step 2.5: Pause — ask user to confirm local testing done (non-negotiable)
-Step 3:   Commit (conventional format, issue reference)
+Step 2.5: Pause — ask user for trigger phrase ("commit approved" / "ship it" / "lgtm" / "go")
+Step 3:   Commit (conventional format, issue reference; sentinel flow via pre-tool.sh)
 Step 4:   Update memory (move task, PROGRESS, SNAPSHOT, ERRORS)
 Step 5:   Open PR (read .github/pull_request_template.md; labels at creation time)
 ```
@@ -202,7 +203,11 @@ Every tool call
      │     Checks RIG_PROTECTED: blocks writes to governance files
      │     (RIG_DIR/processes/, RIG_DIR/rules/, .husky/, CLAUDE.md, .claude/hooks/)
      │     Checks BLOCKED_PATHS: blocks project-specific protected paths
-     │     Exit 1 (block) if match found
+     │     Gates git commit on $RIG_DIR/memory/.rig-commit-ok sentinel:
+     │       Blocked → agent shows commit message, asks for trigger phrase
+     │       ("commit approved" / "ship it" / "lgtm" / "go")
+     │       Agent creates sentinel → commit succeeds → post-tool.sh deletes it
+     │     Exit 1 (block) if any check fails
      │
      └─► post-tool.sh (PostToolUse)
            Resolves RIG_DIR (.rigpath if present, else $REPO/.rig)
@@ -212,6 +217,7 @@ Every tool call
              If commit detected:
                Read commit message + hash from git log
                Append dated stub to RIG_DIR/memory/PROGRESS.md (idempotent)
+               Delete $RIG_DIR/memory/.rig-commit-ok sentinel (one-shot auth)
 ```
 
 **Critical implementation note:** Tool names in Claude Code are `PascalCase`

--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -69,9 +69,13 @@ Do not summarise these back to me unless asked.
 8. **Never touch files outside the current task scope** unless explicitly asked.
 9. **Never make architectural decisions silently** — surface them for discussion first.
 10. **Never assume continuity from a prior session** — always re-read context files.
-11. **Never run `git commit` without first pausing to ask the user to confirm that
-    local testing is done.** Show the proposed commit message, then wait for explicit
-    go-ahead. This is non-negotiable regardless of autonomy level.
+11. **Never run `git commit` without the user's explicit go-ahead.** Before committing:
+    show the proposed commit message, then pause and say:
+    > "Ready to commit. Test locally, then say **'commit approved'** (or 'ship it',
+    > 'lgtm', 'go') and I'll commit and push immediately."
+    When the user says one of those trigger phrases, create `$RIG_DIR/memory/.rig-commit-ok`,
+    run `git commit`, then run `git push`. The sentinel is auto-deleted by post-tool.sh after
+    the commit lands. This pause is non-negotiable regardless of autonomy level.
 12. **Always work in the main repo, not the worktree.** Claude Code sessions run inside
     `.claude/worktrees/<name>/`. File edits made there are invisible to the user's git
     client. At the start of every session, identify the main repo root with

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -78,10 +78,10 @@ If any item cannot be confirmed, stop and resolve it before continuing.
 **Stop here.** Do not commit yet.
 
 Say to the user:
-> "Ready to commit. Have you tested the changes locally and confirmed they work
-> as expected?"
+> "Ready to commit. Test the changes locally, then say **'commit approved'**
+> (or 'ship it', 'lgtm', 'go') and I'll proceed."
 
-Wait for explicit confirmation ("yes", "looks good", "go ahead", etc.).
+Wait for one of those explicit trigger phrases (or equivalent clear confirmation).
 Do not proceed if the response is ambiguous. This step cannot be skipped
 regardless of autonomy level.
 
@@ -107,14 +107,21 @@ message is explicitly approved.
 
 ## Step 7 — Commit
 
-Write the approved commit message to `/tmp/ship-commit-msg.txt` and commit:
+The user confirmed local testing at Step 5 and approved the commit message at Step 6.
+That constitutes explicit go-ahead — create the commit sentinel, then commit:
 
 ```bash
+# Authorise the commit (pre-tool.sh requires this sentinel)
+touch "$(git rev-parse --show-toplevel)/.rig/memory/.rig-commit-ok" 2>/dev/null || \
+  touch "${RIG_DIR:-$(git rev-parse --show-toplevel)/.rig}/memory/.rig-commit-ok"
+
 cat > /tmp/ship-commit-msg.txt << 'EOF'
 [approved commit message]
 EOF
 git commit -F /tmp/ship-commit-msg.txt
 ```
+
+post-tool.sh deletes the sentinel automatically after the commit lands.
 
 Report the commit hash on success.
 

--- a/templates/project/.claude/hooks/post-tool.sh
+++ b/templates/project/.claude/hooks/post-tool.sh
@@ -61,6 +61,16 @@ if [[ "$TOOL" == "Bash" ]]; then
 
         echo "[$(date +%H:%M:%S)] PROGRESS stub: $COMMIT_HASH $COMMIT_MSG" >> "$SESSION_LOG"
       fi
+
+      # ── Clear commit-ok sentinel ────────────────────────────────────────
+      # The sentinel (.rig-commit-ok) authorises a single commit.
+      # Remove it immediately after the commit lands so the next commit
+      # requires a fresh authorisation.
+      COMMIT_OK="$RIG_DIR/memory/.rig-commit-ok"
+      if [[ -f "$COMMIT_OK" ]]; then
+        rm -f "$COMMIT_OK"
+        echo "[$(date +%H:%M:%S)] COMMIT-OK sentinel cleared after $COMMIT_HASH" >> "$SESSION_LOG"
+      fi
     fi
   fi
 fi

--- a/templates/project/.claude/hooks/pre-tool.sh
+++ b/templates/project/.claude/hooks/pre-tool.sh
@@ -36,6 +36,53 @@ fi
 # Comment out if too noisy.
 echo "[$(date +%H:%M:%S)] PRE  $TOOL" >> /tmp/the-rig-session.log
 
+# ── Guard: git commit and git push ───────────────────────────────────────────
+#
+# Prevents the agent from committing or pushing before the user has tested.
+#
+# git push  — blocked unconditionally. The user pushes from their own terminal
+#             after local testing. This ensures nothing reaches the remote
+#             until the user has validated the change.
+#
+# git commit — blocked until a sentinel file exists:
+#              $RIG_DIR/memory/.rig-commit-ok
+#              The agent creates this file only after the user explicitly
+#              confirms local testing is done (e.g. "ready to commit").
+#              post-tool.sh deletes it automatically after the commit lands.
+#              The file is gitignored via .rig/memory/.gitignore.
+#
+# In /ship: the agent creates the sentinel as part of Step 7, after the user
+# has already confirmed local testing at Step 5 and approved the commit
+# message at Step 6. The gate is satisfied in the normal /ship flow.
+#
+# Outside /ship: the gate fires whenever the agent tries to commit mid-task
+# without the user's explicit go-ahead.
+
+if [[ "$TOOL" == "Bash" ]]; then
+  # Parse the command string from the JSON input.
+  # python3 handles embedded quotes and escapes correctly.
+  BASH_CMD=$(python3 -c \
+    "import json,sys; print(json.load(sys.stdin).get('command',''))" \
+    <<< "$INPUT" 2>/dev/null || true)
+
+  # ── Gate git commit on sentinel file ───────────────────────────────────
+  COMMIT_OK="$RIG_DIR/memory/.rig-commit-ok"
+  if echo "$BASH_CMD" | grep -qE '\bgit\s+commit\b'; then
+    if [[ ! -f "$COMMIT_OK" ]]; then
+      echo "" >&2
+      echo "  Commit blocked by The Rig." >&2
+      echo "" >&2
+      echo "  I need your go-ahead before I commit. Here's how it works:" >&2
+      echo "    1. Test the changes in your terminal" >&2
+      echo "    2. Say one of: 'commit approved' · 'ship it' · 'lgtm' · 'go'" >&2
+      echo "       I'll create the authorization and immediately commit and push." >&2
+      echo "" >&2
+      echo "  (Or create it yourself: touch '${COMMIT_OK}')" >&2
+      exit 1
+    fi
+  fi
+fi
+
 # ── Block writes to protected paths ──────────────────────────────────────────
 if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
 

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -10,3 +10,8 @@ PROGRESS_archive.md
 # ERRORS_archive.md holds older entries trimmed from ERRORS.md.
 # Same pattern as PROGRESS_archive.md — local reference, never loaded at session start.
 ERRORS_archive.md
+
+# .rig-commit-ok is a one-shot sentinel that authorises a single git commit.
+# Created by the agent when the user gives explicit go-ahead ("commit approved", etc.).
+# Deleted automatically by post-tool.sh after the commit lands. Never committed.
+.rig-commit-ok

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -45,7 +45,7 @@ git rev-parse --show-toplevel
 
 ---
 
-## Step 1 — Orient
+## Step 2 — Orient
 
 Read these files before anything else, in this order:
 
@@ -59,7 +59,7 @@ Do not invent a task file unilaterally.
 
 ---
 
-## Step 2 — Confirm understanding
+## Step 3 — Confirm understanding
 
 Before writing a plan, state back to the user in 2–3 sentences:
 
@@ -73,7 +73,7 @@ If you have a clarifying question, ask exactly one. Do not stack questions.
 
 ---
 
-## Step 3 — Plan
+## Step 4 — Plan
 
 Write a numbered implementation plan into the task file under `## Approach`.
 
@@ -86,7 +86,7 @@ Requirements for a valid plan:
 
 ---
 
-## Step 4 — Implement
+## Step 5 — Implement
 
 Work through the plan one step at a time.
 
@@ -97,7 +97,7 @@ Work through the plan one step at a time.
 
 ---
 
-## Step 5 — Verify
+## Step 6 — Verify
 
 Before declaring done:
 
@@ -107,7 +107,7 @@ Before declaring done:
 
 ---
 
-## Step 6 — Wrap up
+## Step 7 — Wrap up
 
 In this order:
 

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -80,12 +80,12 @@ If any answer gives you pause, fix it before committing.
 **Stop. Do not commit yet.**
 
 Ask the user:
-> "Ready to commit. Have you tested the changes locally and confirmed they work
-> as expected?"
+> "Ready to commit. Test the changes locally, then say **'commit approved'**
+> (or 'ship it', 'lgtm', 'go') and I'll proceed."
 
-Wait for explicit confirmation. Do not proceed until the user says yes (or
-equivalent). This step is **non-negotiable** — it cannot be skipped regardless
-of autonomy level or how confident the agent is in the changes.
+Wait for one of those trigger phrases (or equivalent clear confirmation).
+This step is **non-negotiable** — it cannot be skipped regardless of autonomy
+level or how confident the agent is in the changes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a commit gate to `pre-tool.sh`: blocks `git commit` unless a one-shot sentinel file (`.rig-commit-ok`) is present
- When blocked, the agent pauses, shows the proposed commit message, and asks the user to say **"commit approved"**, **"ship it"**, **"lgtm"**, or **"go"** — then immediately commits and pushes
- `post-tool.sh` auto-deletes the sentinel after the commit lands (no lingering state)
- Removes the earlier hard push-block — agent pushes after commit as normal; the pause is before commit only
- `/ship` Step 7 creates the sentinel inline (Steps 5 + 6 are already explicit user approval)
- `.rig/memory/.gitignore` now ignores `.rig-commit-ok`
- Global `CLAUDE.md` Hard Rule #11 updated to describe the full trigger-phrase flow

## Changes

- `templates/project/.claude/hooks/pre-tool.sh` — removed push hard-block; added commit sentinel gate with trigger-phrase messaging
- `templates/project/.claude/hooks/post-tool.sh` — sentinel cleanup after commit detection
- `templates/global/CLAUDE.md` — Hard Rule #11 rewritten with trigger-phrase protocol
- `templates/project/.claude/commands/ship.md` — Step 5 + Step 7 updated to match new flow
- `templates/project/.rig/processes/SHIP_WORKFLOW.md` — Step 2.5 updated to use trigger-phrase language
- `templates/project/.rig/memory/.gitignore` — added `.rig-commit-ok` with comment

## Closes
Closes #67

## Test plan

- [ ] Trigger an agent commit without the sentinel → confirm pre-tool.sh blocks with trigger-phrase instructions
- [ ] Say "commit approved" → confirm agent creates sentinel, commits, and pushes
- [ ] Confirm post-tool.sh deletes sentinel after commit
- [ ] Run `/ship` → confirm Steps 5–7 flow without additional blocking

## Notes

The trigger words ("commit approved", "ship it", "lgtm", "go") are documented in three places for redundancy: Hard Rule #11 in `CLAUDE.md`, the pre-tool.sh block message, and `/ship` Steps 5 + 7. Any clear equivalent ("yes", "looks good") should also be accepted by the agent — the list is illustrative, not exhaustive.
