### PR TITLE
feat: self-improving feedback loop + task wrap-up accuracy [#72]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.0] — 2026-04-27
+
+### Added
+
+- **`RIG_GAPS.md` template** (`templates/project/.rig/memory/RIG_GAPS.md`): self-improvement feedback log committed to every project repo. Captures workflow friction, bugs, missing features, and improvement ideas observed during real use. Accumulates across sessions and machines. Closes #72.
+- **`/rig-gaps` slash command** (`templates/project/.claude/commands/rig-gaps.md`): compiles unsubmitted gap entries from `RIG_GAPS.md`, cross-checks `ERRORS.md` for Rig-related issues not yet captured, formats a consolidated report with copy-paste submission instructions, and offers to mark entries as submitted. Closes #72.
+- **`/wrap` self-improvement check** (step 5): at session end, agent scans `ERRORS.md` for Rig-related friction and reflects on session pain points. Any gaps not already in `RIG_GAPS.md` are appended automatically. Closes #72.
+
+### Changed
+
+- **`templates/project/.claude/commands/wrap.md`**: added step 5 (self-improvement check) with full entry format and submission reminder; existing steps 5–7 renumbered to 6–8.
+- **`templates/project/.rig/processes/NEW_TASK_WORKFLOW.md`**: Step 7 (Wrap up) rewritten — adds plan-vs-reality audit before touching anything; structured `## Done notes` fields required (What was built / Deviations from plan / Actual files touched / Follow-ups opened); RIG_GAPS logging added as explicit step.
+- **`templates/project/.rig/processes/SHIP_WORKFLOW.md`**: Step 4 updated — task file accuracy check added; GitHub Issue closing comment required when scope changes; RIG_GAPS logging added. Step 5 updated — PR body must describe what was actually built, not the original plan.
+- **`templates/project/.rig/tasks/backlog/TASK_example.md`**: `## Done notes` section expanded with four structured fields to prevent restatement of plan.
+- **`templates/project/.rig/memory/.gitignore`**: added comment confirming `RIG_GAPS.md` is intentionally tracked and committed.
+
+---
+
 ## [1.4.0] — 2026-04-27
 
 ### Added

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -136,6 +136,13 @@ Three files, three purposes:
 - The most valuable file in the system — it's institutional memory
 - **Trim convention:** capped at 30 entries. `/wrap` moves older entries to `.rig/memory/ERRORS_archive.md` (gitignored, disk-only) when the cap is exceeded. Same pattern as PROGRESS.md.
 
+### .rig/memory/RIG_GAPS.md
+- Self-improvement feedback log — committed to every project repo
+- Captures workflow friction, bugs, missing features, and improvement ideas observed during real use
+- Appended automatically by `/wrap` (step 5) when the agent notices Rig-related friction
+- Submitted to The Rig dev session via `/rig-gaps` command; entries marked `[submitted]` after delivery
+- Accumulates across sessions and machines — the mechanism by which real-world use improves The Rig
+
 ### .rig/memory/.rig-manifest
 - Written by the installer on every install; committed to the repo
 - Records the SHA256 hash of each Rig-owned file at install time
@@ -159,7 +166,8 @@ Step 3: Confirm understanding — restate goal, files, risks. Wait for approval.
 Step 4: Plan — write numbered plan into task file. Wait for approval.
 Step 5: Implement — one step at a time, surface surprises
 Step 6: Verify — run tests, check acceptance criteria
-Step 7: Wrap up — move task, update PROGRESS, log ERRORS, commit
+Step 7: Wrap up — audit plan vs. reality; structured Done notes; move task; update PROGRESS;
+        log ERRORS; log RIG_GAPS; commit
 ```
 
 ### SHIP_WORKFLOW
@@ -169,8 +177,9 @@ Step 1:   Pre-ship checklist (AC, no debug code, no secrets, Docker verification
 Step 2:   Self-review — does this do ONLY what was asked?
 Step 2.5: Pause — ask user for trigger phrase ("commit approved" / "ship it" / "lgtm" / "go")
 Step 3:   Commit (conventional format, issue reference; sentinel flow via pre-tool.sh)
-Step 4:   Update memory (move task, PROGRESS, SNAPSHOT, ERRORS)
-Step 5:   Open PR (read .github/pull_request_template.md; labels at creation time)
+Step 4:   Update memory (verify task file accuracy; move task; PROGRESS; SNAPSHOT; ERRORS;
+          RIG_GAPS; close GitHub Issue with actual-scope comment)
+Step 5:   Open PR (body describes what was actually built; read template; labels at creation time)
 ```
 
 ### DEBUG_WORKFLOW
@@ -280,7 +289,7 @@ staged only from `.rig/tasks/done/` in a separate housekeeping commit.
 
 ## The command set
 
-Eight slash commands covering the full development lifecycle:
+Nine slash commands covering the full development lifecycle:
 
 ### Project bootstrap
 | Command | Triggers | Key behaviour |
@@ -303,7 +312,8 @@ Eight slash commands covering the full development lifecycle:
 | Command | Triggers | Key behaviour |
 |---|---|---|
 | `/propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
-| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, trims if > 20 entries, surfaces next priority |
+| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, runs self-improvement check (logs Rig gaps), trims if > 20 entries, surfaces next priority |
+| `/rig-gaps` | Self-improvement | Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats a report with submission instructions for The Rig dev session |
 | `/new-feature` | `NEW_TASK_WORKFLOW` | Original task entry point — creates task file, plans before coding, waits for approval |
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,9 @@ sha256_file() {
 # Rig-owned:   .claude/hooks/, .claude/commands/, .rig/processes/, .husky/, .gitleaks.toml
 # User-owned:  CLAUDE.md, PROJECT_BRIEF.md, .rig/rules/, .rig/memory/*.md,
 #              .rig/tasks/, .github/
+#              Note: .rig/memory/RIG_GAPS.md is user-owned and committed to the project
+#              repo (not gitignored). It accumulates workflow feedback across sessions.
+#              It is never manifest-tracked and never overwritten by the Upgrade strategy.
 # Special:     .claude/settings.json (always smart-merged, not manifest-tracked)
 is_rig_owned() {
   local rel="$1"

--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -53,7 +53,7 @@ Do not summarise these back to me unless asked.
 
 ---
 
-## Hard rules (non-negotiable)
+## Hard rules (non-negotiable) — 12 total
 
 1. **Never delete files without explicit permission.** Move to `_archive/` instead.
 2. **Never run destructive DB commands** (`DROP`, `TRUNCATE`, `DELETE` without `WHERE`)

--- a/templates/project/.claude/commands/new-feature.md
+++ b/templates/project/.claude/commands/new-feature.md
@@ -23,7 +23,7 @@ Claude will ask:
 - What's the one-sentence goal?
 - Any files that are off-limits or out of scope for this task?
 
-Then it creates the task file and follows `.rig/processes/NEW_TASK_WORKFLOW.md` from Step 1.
+Then it creates the task file and follows `.rig/processes/NEW_TASK_WORKFLOW.md` from Step 0.
 
 ## Notes
 

--- a/templates/project/.claude/commands/rig-gaps.md
+++ b/templates/project/.claude/commands/rig-gaps.md
@@ -1,0 +1,88 @@
+# Command: /rig-gaps
+
+Compile and display all logged gaps, friction points, and improvement ideas about
+The Rig itself — formatted for submission to The Rig dev session.
+
+## What this does
+
+1. Reads `.rig/memory/RIG_GAPS.md` and lists all gap entries
+2. Scans `.rig/memory/ERRORS.md` for any Rig-related issues not yet captured in `RIG_GAPS.md`
+3. Formats a consolidated report with copy-paste instructions
+4. Offers to mark entries as submitted (adds `[submitted]` tag to entry headers)
+
+## Usage
+
+```
+/rig-gaps
+```
+
+Run this:
+- When you want to report accumulated feedback to The Rig developer
+- Before a major project milestone (so gaps get fixed before the next phase)
+- Periodically — once every few weeks of active use
+
+---
+
+## Step 1 — Read RIG_GAPS.md
+
+Read `.rig/memory/RIG_GAPS.md`. Collect all entries that do **not** have `[submitted]` in their header.
+
+If there are no unsubmitted entries, say:
+> "No unsubmitted gaps in `.rig/memory/RIG_GAPS.md`.
+> Run tasks for a while and then come back — gaps are logged automatically during `/wrap`."
+
+---
+
+## Step 2 — Cross-check ERRORS.md
+
+Read `.rig/memory/ERRORS.md`. Look for entries that describe friction with The Rig's own
+workflow rather than project-specific bugs. Examples of Rig-related errors:
+- "pre-tool.sh blocked an operation that should have been allowed"
+- "A process step was missing or wrong"
+- "A slash command produced unexpected output"
+- "Hook fired when it shouldn't have / didn't fire when it should"
+
+For each Rig-related ERRORS.md entry NOT already reflected in `RIG_GAPS.md`:
+- Synthesize it into a gap entry using the standard format
+- Append it to `RIG_GAPS.md` automatically (no confirmation needed — this is non-destructive)
+- Note how many new entries were synthesized
+
+---
+
+## Step 3 — Display report
+
+Print the following:
+
+```
+## Rig Gaps Report — [project name] — [today's date]
+
+[N] unsubmitted entries:
+
+---
+[paste each unsubmitted entry verbatim from RIG_GAPS.md]
+---
+
+## How to submit
+
+1. Copy everything between the --- markers above
+2. Open Claude Code in ~/tools/the-rig (or wherever The Rig lives)
+3. Paste and say:
+   "Here are gap reports from [project name]. Please analyze, triage, and create issues."
+
+The Rig agent will review, open GitHub issues, and implement fixes.
+```
+
+---
+
+## Step 4 — Offer to mark as submitted
+
+After displaying the report, ask:
+
+> "Mark these [N] entries as submitted in `RIG_GAPS.md`? (Useful if you're about to paste
+> them into a Rig dev session.)"
+
+If the user confirms:
+- Append ` [submitted YYYY-MM-DD]` to each entry's `## [date]` header line
+- Confirm: "[N] entries marked as submitted."
+
+If the user declines or there's nothing to mark, skip silently.

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -131,13 +131,32 @@ Report the commit hash on success.
 
 In this order:
 
-1. Move the task file: `.rig/tasks/active/TASK_[name].md` → `.rig/tasks/done/`
-2. Update `.rig/memory/PROGRESS.md` — add a full entry at the top (not a stub)
-3. Overwrite `.rig/memory/CONTEXT_SNAPSHOT.md` with current project state
+1. **Verify the task file reflects reality** before moving it:
+   - `## Done notes` must describe what was actually built — not a restatement of the plan
+   - Required fields: **What was built** / **Deviations from plan** / **Actual files touched** / **Follow-ups opened**
+   - If scope or approach changed during execution, capture it in `## Done notes`
+   - `## Approach` stays as the original plan (historical intent); deviations belong in `## Done notes`
+2. Move the task file: `.rig/tasks/active/TASK_[name].md` → `.rig/tasks/done/`
+3. Update `.rig/memory/PROGRESS.md` — add a full entry at the top (not a stub); if scope changed, the entry reflects the actual outcome
+4. Overwrite `.rig/memory/CONTEXT_SNAPSHOT.md` with current project state
+5. If anything surprised you, log it in `.rig/memory/ERRORS.md`
+6. If anything about The Rig's workflow was missing or felt wrong, log it in `.rig/memory/RIG_GAPS.md`
+7. **Post a closing comment on the GitHub Issue:**
+   ```bash
+   gh issue comment [N] --body "Implemented in PR #[M].
+
+   Actual scope: [one sentence on what was actually built]
+   Deviations: [any changes from the original issue description, or 'none']"
+   ```
+   This is required when scope changed; recommended always.
 
 ---
 
 ## Step 9 — Open the PR
+
+**The PR body must describe what was actually built — not the original plan.**
+If scope changed during implementation, note it explicitly. Reviewers read the PR
+description to understand what landed, not what was intended.
 
 Use the project's PR template if one exists at `.github/pull_request_template.md`.
 Read it, fill in every section, then:
@@ -165,4 +184,5 @@ Report the PR URL.
 - Labels (Step 3) must be verified against the actual repo — never assumed.
 - The local testing pause (Step 5) is non-negotiable regardless of autonomy level.
 - If the task has multiple commits, summarise all changes in the PR body.
-- The task file is moved to `.rig/tasks/done/` only after a successful commit.
+- The task file is moved to `.rig/tasks/done/` only after a successful commit (Step 8).
+- The PR body (Step 9) must reflect what was actually built — not the original plan.

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -152,6 +152,8 @@ Regardless of autonomy level:
 - Changes to The Rig's own `.rig/processes/`, `.rig/rules/`, hooks, or CLAUDE.md still require `/propose`.
 - Secrets and credentials are never written to files.
 - The pre-ship checklist (`/ship`) still runs before any PR is opened.
+- At task completion, any Rig workflow friction or gaps observed must be logged to
+  `.rig/memory/RIG_GAPS.md`. Use `/rig-gaps` to compile and submit them.
 
 ---
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -10,9 +10,10 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 2. Ensures `.rig/memory/PROGRESS.md` is up to date — expands any auto-stubbed entries
 3. **Trims `.rig/memory/PROGRESS.md`** if it has grown beyond 20 entries (see Trim step below)
 4. Checks `.rig/memory/ERRORS.md` — prompts you to log anything unexpected from this session
-5. **Trims `.rig/memory/ERRORS.md`** if it has grown beyond 30 entries (see Trim step below)
-6. Reports what's in `.rig/tasks/active/` so you know what's in flight
-7. Surfaces the next priority from `.rig/tasks/backlog/` and asks: "What's next?"
+5. **Self-improvement check** — scans for Rig workflow gaps and logs them to `.rig/memory/RIG_GAPS.md`
+6. **Trims `.rig/memory/ERRORS.md`** if it has grown beyond 30 entries (see Trim step below)
+7. Reports what's in `.rig/tasks/active/` so you know what's in flight
+8. Surfaces the next priority from `.rig/tasks/backlog/` and asks: "What's next?"
 
 ## Usage
 
@@ -46,6 +47,37 @@ If the user confirms:
 4. Confirm: "`.rig/memory/PROGRESS.md` trimmed to 20 entries. Archive: `.rig/memory/PROGRESS_archive.md`"
 
 Never trim without confirmation. Never delete entries — only move them.
+
+---
+
+## Self-improvement check
+
+After logging new ERRORS.md entries, run a brief Rig retrospective:
+
+**Scan ERRORS.md** for entries that describe friction with The Rig's own workflow
+(not project bugs). Ask: did anything about The Rig slow you down, produce wrong
+output, or feel missing or broken this session?
+
+For each Rig-related friction point — whether from ERRORS.md or from this session —
+that is **not already in** `.rig/memory/RIG_GAPS.md`:
+
+1. Append a new entry to `.rig/memory/RIG_GAPS.md` using this format:
+   ```
+   ## [YYYY-MM-DD] — [short title]
+
+   **Category**: bug | friction | missing-feature | improvement
+   **Severity**: blocking | annoying | nice-to-have
+   **Workflow**: [which command/process/hook triggered this]
+   **Observation**: [what happened or what was missing]
+   **Suggested fix**: [concrete suggestion, or "unclear"]
+   ```
+2. Note in your wrap-up summary: "Logged [N] new gap(s) to `.rig/memory/RIG_GAPS.md`."
+
+If there is nothing to log, skip silently — do not mention this step.
+
+> **Why this matters:** The Rig improves by collecting friction signals from real use.
+> Logging gaps during `/wrap` ensures they don't get lost. Use `/rig-gaps` to compile
+> and submit them to The Rig dev session.
 
 ---
 

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -1,3 +1,7 @@
+# RIG_GAPS.md is intentionally tracked and committed.
+# It accumulates workflow friction signals across sessions and machines.
+# Do NOT add it to this file.
+
 # .rig-manifest is intentionally tracked and committed.
 # It records the SHA256 of each Rig-owned file at last install, enabling
 # the installer's Upgrade strategy to detect user customizations.

--- a/templates/project/.rig/memory/RIG_GAPS.md
+++ b/templates/project/.rig/memory/RIG_GAPS.md
@@ -1,0 +1,34 @@
+# Rig Gaps & Improvement Log
+
+Observations, friction points, bugs, and improvement ideas captured during real use of The Rig.
+Entries are added by the agent — at `/wrap`, task completion, or any time a workflow gap is noticed.
+
+This file is committed to the repo so it persists across machines and accumulates over time.
+
+---
+
+## How to submit gaps for action
+
+1. Run `/rig-gaps` in this project
+2. Copy the formatted output
+3. Open a Claude Code session in `~/tools/the-rig`
+4. Paste and say: **"Here are gap reports from [project name]. Please analyze, triage, and create issues."**
+5. The Rig agent will review, open issues, and implement fixes
+
+---
+
+## Entry format
+
+```
+## [YYYY-MM-DD] — [short title]
+
+**Category**: bug | friction | missing-feature | improvement
+**Severity**: blocking | annoying | nice-to-have
+**Workflow**: [which command/process/hook triggered this]
+**Observation**: [specific description — what happened or what was missing]
+**Suggested fix**: [concrete suggestion, or "unclear"]
+```
+
+---
+
+<!-- Add entries below — newest first -->

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -111,12 +111,33 @@ Before declaring done:
 
 In this order:
 
-1. Update the task file: change `**Status**` to `done`, fill in `## Done notes`
-2. Move the task file from `.rig/tasks/active/` → `.rig/tasks/done/`
-3. Update `.rig/memory/PROGRESS.md` with a one-line summary of what was built
-4. Log any new pitfalls or surprises in `.rig/memory/ERRORS.md`
-5. Commit with a conventional commit message referencing the task name and issue number
-6. Follow `SHIP_WORKFLOW.md` to open the PR
+1. **Audit plan vs. reality** before touching anything:
+   - Compare `## Approach` with what was actually implemented
+   - If scope changed, approach deviated, or unexpected files were touched — note it
+   - Do NOT rewrite `## Approach` (it's the historical plan); add deviations to `## Done notes`
+
+2. **Update the task file:**
+   - Change `**Status**` to `done`
+   - Fill in `## Done notes` with substance — not a restatement of the plan:
+     - **What was built:** actual implementation, specific files and behaviours
+     - **Deviations from plan:** where scope or approach changed and why
+     - **Actual files touched:** anything not in `## Files likely affected`
+     - **Follow-ups opened:** any new task files or issues created
+   - Update `**Updated**` date
+
+3. Move the task file from `.rig/tasks/active/` → `.rig/tasks/done/`
+
+4. Update `.rig/memory/PROGRESS.md` with a one-line summary of what was built
+
+5. Log any new pitfalls or surprises in `.rig/memory/ERRORS.md`
+
+6. Log any Rig workflow gaps or friction points in `.rig/memory/RIG_GAPS.md`
+   *(Was there anything about The Rig itself that slowed you down, was missing, or felt wrong?
+   Log it here — see `/rig-gaps` for the submission workflow.)*
+
+7. Commit with a conventional commit message referencing the task name and issue number
+
+8. Follow `SHIP_WORKFLOW.md` to open the PR
 
 > **Staging note:** Stage the task file **only after** it has been moved to `.rig/tasks/done/`.
 > Never commit a task file from `.rig/tasks/active/` — it creates a confusing history where

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -118,14 +118,39 @@ git commit -F /tmp/commit-msg.txt
 
 In this order:
 
-1. Move task file from `.rig/tasks/active/` → `.rig/tasks/done/`
-2. Update `.rig/memory/PROGRESS.md` — add entry at top with what shipped
-3. Overwrite `.rig/memory/CONTEXT_SNAPSHOT.md` — full current state, never delete
-4. If anything surprised you during the task, log it in `.rig/memory/ERRORS.md`
+1. **Verify the task file reflects reality** before moving it:
+   - `## Done notes` must describe what was actually built — not a restatement of the plan
+   - If scope or approach changed during execution, it must be captured here
+   - `## Approach` stays as the original plan (historical intent); deviations belong in `## Done notes`
+
+2. Move task file from `.rig/tasks/active/` → `.rig/tasks/done/`
+
+3. Update `.rig/memory/PROGRESS.md` — add entry at top with what actually shipped
+   (if scope changed from the plan, the PROGRESS entry reflects the actual outcome)
+
+4. Overwrite `.rig/memory/CONTEXT_SNAPSHOT.md` — full current state, never delete
+
+5. If anything surprised you, log it in `.rig/memory/ERRORS.md`
+
+6. If anything about The Rig's workflow was missing or felt wrong, log it in `.rig/memory/RIG_GAPS.md`
+
+7. **Post a closing comment on the GitHub Issue:**
+   ```bash
+   gh issue comment [N] --body "Implemented in PR #[M].
+
+   Actual scope: [one sentence on what was actually built]
+   Deviations: [any changes from the original issue description, or 'none']"
+   ```
+   This is especially important when scope changed — the issue description captures the original
+   intent; the comment captures what was actually delivered.
 
 ---
 
 ## Step 5 — Open the PR
+
+**The PR body must describe what was actually built — not the original plan.**
+If scope changed during implementation, the PR body should note it explicitly. Reviewers
+read the PR description to understand what landed, not what was intended.
 
 **First, check for a PR template:**
 

--- a/templates/project/.rig/tasks/backlog/TASK_example.md
+++ b/templates/project/.rig/tasks/backlog/TASK_example.md
@@ -106,5 +106,10 @@ updates at milestones, and flag any change that touches more than 5 files.
 ## Done notes
 
 > Filled in when the task is complete, before moving to `tasks/done/`.
+> This section records **what actually happened**, not what was planned.
+> `## Approach` stays as the original plan — the historical record of intent.
 
-[What was built. Any deviations from the original approach. Follow-up tasks opened.]
+**What was built:** [Specific description of actual implementation — files, behaviour, decisions]
+**Deviations from plan:** [Where approach or scope changed and why — write "none" if on plan]
+**Actual files touched:** [Any files not in `## Files likely affected`, or files that were NOT touched]
+**Follow-ups opened:** [Task files or issues created as a result — write "none" if none]


### PR DESCRIPTION
## Summary

- Adds `RIG_GAPS.md` to every project — committed to the repo, accumulates workflow friction signals across sessions and machines
- Adds `/rig-gaps` command to compile and submit gap reports to The Rig dev session
- Adds `/wrap` step 5: automatic self-improvement check that logs Rig-related friction to `RIG_GAPS.md`
- Strengthens task wrap-up accuracy: structured `## Done notes`, plan-vs-reality audit, PR/Issue accuracy requirement

## Changes

- **NEW** `templates/project/.rig/memory/RIG_GAPS.md` — self-improvement feedback log template
- **NEW** `templates/project/.claude/commands/rig-gaps.md` — `/rig-gaps` slash command
- **`templates/project/.claude/commands/wrap.md`** — step 5 added (self-improvement check); steps 6–8 renumbered
- **`templates/project/.rig/processes/NEW_TASK_WORKFLOW.md`** — step 7 rewritten: plan-vs-reality audit, structured Done notes fields, RIG_GAPS logging
- **`templates/project/.rig/processes/SHIP_WORKFLOW.md`** — step 4: task accuracy check + GitHub Issue closing comment; step 5: PR body accuracy note
- **`templates/project/.rig/tasks/backlog/TASK_example.md`** — `## Done notes` expanded with 4 structured fields
- **`templates/project/.rig/memory/.gitignore`** — RIG_GAPS.md confirmation comment added
- **`docs/how-it-works.md`** — RIG_GAPS.md in memory section; `/rig-gaps` in command table; step summaries updated
- **`CHANGELOG.md`** — v1.5.0 entries

## Closes

Closes #72

## Test plan

- [ ] Install The Rig into a test project; confirm `RIG_GAPS.md` is created and committed (not ignored)
- [ ] Run `/wrap` — confirm step 5 fires and appends a gap entry if any friction is noted
- [ ] Run `/rig-gaps` — confirm it reads entries from `RIG_GAPS.md`, cross-checks `ERRORS.md`, and prints a formatted report
- [ ] Run `/rig-gaps` again after marking as submitted — confirm entries show `[submitted YYYY-MM-DD]`
- [ ] Complete a task — confirm `## Done notes` uses the structured fields and the task file reflects actuality

## Notes

- `RIG_GAPS.md` is intentionally committed (unlike `CONTEXT_SNAPSHOT.md`). It persists across machines as a running feedback log.
- The `/rig-gaps` submission flow is async: agent formats the report, user copies and pastes into a separate Rig dev session. No automation of the GitHub issue creation from the project side.
