### PR TITLE
feat: feature documentation system — /doc-feature + /refresh-feature-doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`/doc-feature` slash command** (`templates/project/.claude/commands/doc-feature.md`): research a named feature end-to-end and produce a structured doc in `docs/features/`. Traces entry points, render logic, data model, business rules, and gotchas. Guards against duplicates — redirects to `/refresh-feature-doc` if the slug already exists. Updates `docs/features/README.md` index automatically.
+- **`/refresh-feature-doc` slash command** (`templates/project/.claude/commands/refresh-feature-doc.md`): re-verify every claim in an existing feature doc against current code. Corrects stale paths and line numbers, flags removed fields, and logs any actual bugs found (not just doc inaccuracies) to `ERRORS.md`. Intended to run after any PR that touches a documented feature.
+- **`docs/features/README.md` template** (`templates/project/docs/features/README.md`): scaffolded index for all feature docs. Imported by the project `CLAUDE.md` via `@docs/features/README.md` so every session knows the feature doc system exists and is loaded. Starts with a placeholder row that `/doc-feature` replaces on first use.
+- **Feature documentation section in project `CLAUDE.md`**: adds `@docs/features/README.md` import and a 3-point guide (when to read, when to refresh, when to create) so every session knows the system exists and when to engage it. Originated as a project-level pattern in the 4Culture pilot.
+
+### Changed
+
+- **`templates/project/CLAUDE.md`**: repo structure tree updated to show `docs/features/` directory.
+- **`docs/how-it-works.md`**: command count updated from 9 to 11; "Feature documentation" command group added to the command table.
+- **`README.md`**: "What's included" table updated; command set section adds "Feature knowledge" group with `/doc-feature` and `/refresh-feature-doc`.
+
 ---
 
 ## [1.6.0] — 2026-04-30

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ The Rig has two layers that load in sequence at every session start:
 | Rules (4) | `templates/project/.rig/rules/` | Coding standards, git conventions, security rules, verification protocol |
 | Memory system | `templates/project/.rig/memory/` | PROGRESS log, ERRORS log, CONTEXT_SNAPSHOT (session state), RIG_GAPS (self-improvement feedback) |
 | Task lifecycle | `templates/project/.rig/tasks/` | Structured task files through backlog → active → done |
-| Claude Code hooks | `templates/project/.claude/` | Pre/post-tool enforcement + 9 slash commands |
+| Claude Code hooks | `templates/project/.claude/` | Pre/post-tool enforcement + 11 slash commands |
+| Feature docs | `templates/project/docs/features/` | README index + `/doc-feature` and `/refresh-feature-doc` commands for capturing and maintaining business-critical feature knowledge |
 | Git hooks | `templates/project/.husky/` | Secret scanning (gitleaks) + AI attribution trailer stripping |
 | GitHub templates | `templates/project/.github/` | PR template + 3 issue templates |
 | Installer | `install.sh` | Interactive setup script — handles both layers |
@@ -177,6 +178,12 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 ```
 /ship         →  pre-ship checklist, commit, open PR
 /debug        →  hypothesis-first diagnosis, mandatory ERRORS.md entry
+```
+
+**Feature knowledge**
+```
+/doc-feature [name]          →  research a feature end-to-end; produce a structured doc in docs/features/
+/refresh-feature-doc [name]  →  re-verify an existing feature doc against current code; correct stale claims
 ```
 
 **Governance and housekeeping**

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -308,7 +308,7 @@ staged only from `.rig/tasks/done/` in a separate housekeeping commit.
 
 ## The command set
 
-Nine slash commands covering the full development lifecycle:
+Eleven slash commands covering the full development lifecycle:
 
 ### Project bootstrap
 | Command | Triggers | Key behaviour |
@@ -326,6 +326,12 @@ Nine slash commands covering the full development lifecycle:
 |---|---|---|
 | `/ship` | `SHIP_WORKFLOW` | Sequential 9-step hard gate: task confirm → issue → labels → checklist → local test pause → commit approval → commit → housekeeping → PR |
 | `/debug` | `DEBUG_WORKFLOW` | Hypothesis before code, mandatory ERRORS.md entry |
+
+### Feature documentation
+| Command | Triggers | Key behaviour |
+|---|---|---|
+| `/doc-feature` | Research + write | Traces a named feature end-to-end (entry point → data layer → render logic) and produces a structured doc in `docs/features/`. Guards against duplicates; updates the README index. |
+| `/refresh-feature-doc` | Re-verify + update | Re-reads every claim in an existing feature doc against current code; corrects stale paths/line numbers; logs bugs found to `ERRORS.md`. Run after any PR that touches a documented feature. |
 
 ### Governance and housekeeping
 | Command | Triggers | Key behaviour |

--- a/templates/project/.claude/commands/doc-feature.md
+++ b/templates/project/.claude/commands/doc-feature.md
@@ -1,0 +1,188 @@
+# Command: /doc-feature
+
+Research a named feature end-to-end and produce a structured feature doc in
+`docs/features/`.
+
+Run this any time you've traced through 5+ files to understand how something
+works — capture the knowledge while it's fresh so future sessions don't repeat
+the same archaeology.
+
+---
+
+## Usage
+
+```
+/doc-feature <feature name or description>
+```
+
+Examples:
+```
+/doc-feature upcoming grants feed
+/doc-feature user authentication flow
+/doc-feature PDF export pipeline
+/doc-feature Stripe webhook handler
+```
+
+If no argument is given, ask: **"Which feature should I document?"**
+
+---
+
+## What this does
+
+### Step 1 — Confirm the feature
+
+Restate in one sentence what you understand the feature to be and what it does
+for the user or business. Ask for correction before proceeding if unsure.
+
+---
+
+### Step 2 — Research end-to-end
+
+Trace the full stack for this feature. The exact layer names vary by project —
+use the ones that apply:
+
+- **Entry point** — URL, route, template file, shortcode, webhook, CLI command,
+  or cron job that triggers this feature
+- **Render / response layer** — every template part, view, component, or
+  controller involved in producing output
+- **Business logic layer** — service classes, utility functions, hooks, filters,
+  or middleware that process data
+- **Data layer** — every query, ORM call, or raw SQL involved; post types, meta
+  keys, model fields, or schema columns read or written
+- **External integrations** — third-party APIs, queues, storage, or services involved
+- **Configuration** — environment variables, CMS fields, feature flags, or admin
+  settings that control behaviour
+- **Conditional logic** — any branching, gating, or edge-case handling visible in
+  the code
+
+Use only line numbers you have verified by reading the file. Mark anything you
+couldn't confirm with `<!-- TODO: verify -->`.
+
+---
+
+### Step 3 — Check for an existing doc
+
+Derive a slug from the feature name (lowercase, hyphens, no punctuation).
+Check `docs/features/` for `<slug>.md`.
+
+- **If it exists:** stop and say:
+  > "A doc for this feature already exists at `docs/features/<slug>.md`.
+  > Run `/refresh-feature-doc` to update it instead."
+- **If it doesn't exist:** proceed.
+
+---
+
+### Step 4 — Write the doc
+
+Create `docs/features/<slug>.md` using the template below.
+Fill in every section. Delete sections that genuinely don't apply rather than
+leaving them empty. Never leave placeholder brackets in the final file.
+
+---
+
+### Step 5 — Update the index
+
+Add a row to the index table in `docs/features/README.md`:
+
+```
+| <Feature name> | [<slug>.md](<slug>.md) | YYYY-MM-DD |
+```
+
+If the index table currently has the "none yet" placeholder row, replace it.
+
+---
+
+### Step 6 — Report
+
+Output:
+- Path of the new doc
+- Count of: entry points traced, data fields documented, gotchas captured
+- Any gaps where you couldn't confirm a detail (these are already flagged with
+  `<!-- TODO: verify -->` in the doc — summarise them here too)
+
+---
+
+## Doc template
+
+````markdown
+# Feature: [Name]
+
+> Last updated: YYYY-MM-DD
+
+## Summary
+
+One paragraph: what this feature does, why it exists, and why it matters to the
+business or users. Written for someone who has never seen the code.
+
+---
+
+## Entry points
+
+Where does this feature start?
+
+- `path/to/file.ext` line N — [what triggers it here]
+- `path/to/file.ext` line N — [another entry point if multiple]
+
+---
+
+## Flow
+
+Step-by-step trace from entry point to final output.
+
+1. **[Layer name]** — `path/to/file.ext` lines N–M
+   [What happens here. Be specific about function names, field names, conditions.]
+
+2. **[Layer name]** — `path/to/file.ext` lines N–M
+   [What happens here.]
+
+3. **[Continue for each meaningful step]**
+
+---
+
+## Data model
+
+Fields, columns, meta keys, or CMS fields involved in this feature.
+
+| Field / key | Type | Role |
+|---|---|---|
+| `field_name` | [type] | [what it controls] |
+| `field_name` | [type] | [what it controls] |
+
+---
+
+## Business rules
+
+The non-obvious logic that isn't obvious from reading the code alone.
+
+- [Rule: e.g. "The label only appears when X is set — if X is absent, no label renders even though the type value exists"]
+- [Rule]
+- [Rule]
+
+---
+
+## Known gotchas
+
+Things that have caused or could cause bugs, surprises, or confusion.
+
+- **[Short title]**: [description of the gotcha and what to watch for]
+- **[Short title]**: [description]
+
+---
+
+## Last verified against
+
+Commit: [hash or branch]
+Date: YYYY-MM-DD
+````
+
+---
+
+## Notes
+
+- Gotchas and business rules are the highest-value sections — they capture
+  knowledge that code alone doesn't communicate. Don't shortchange them.
+- If the feature is too large to trace fully in one pass, document what you've
+  confirmed and mark the gaps with `<!-- TODO: verify -->`. A partial doc is
+  better than no doc.
+- After writing the doc, check whether any open task or in-progress PR touches
+  this feature. If so, note it in the doc under a `## Related work` section.

--- a/templates/project/.claude/commands/refresh-feature-doc.md
+++ b/templates/project/.claude/commands/refresh-feature-doc.md
@@ -1,0 +1,107 @@
+# Command: /refresh-feature-doc
+
+Re-research an existing feature doc and update it to reflect the current state
+of the code.
+
+Run this after any PR that changes a documented feature's data model, query
+logic, render logic, or business rules. Stale docs are worse than no docs —
+they actively mislead future sessions.
+
+---
+
+## Usage
+
+```
+/refresh-feature-doc <feature name or doc path>
+```
+
+Examples:
+```
+/refresh-feature-doc upcoming grants feed
+/refresh-feature-doc docs/features/upnext-feed.md
+/refresh-feature-doc user auth
+```
+
+If no argument is given, ask: **"Which feature doc should I refresh?"**
+If the argument doesn't match any existing doc, list the docs in
+`docs/features/` and ask the user to confirm which one.
+
+---
+
+## What this does
+
+### Step 1 — Load the existing doc
+
+Read `docs/features/<slug>.md` in full. Note the `Last updated:` date and every
+claim made — entry point paths, line numbers, field names, flow steps, business
+rules, and gotchas.
+
+---
+
+### Step 2 — Re-verify every claim
+
+For each claim in the doc, re-read the referenced file and line range:
+
+- **Paths and line numbers** — verify they still point to the right code; update
+  if the code moved or was refactored
+- **Field names and data model** — verify each field/column still exists and has
+  the same role; note any additions or removals
+- **Flow steps** — re-trace the execution path; capture any new branches,
+  middleware, or layers added since the doc was written
+- **Business rules** — verify each rule is still enforced in the code; flag any
+  that were removed or changed
+- **Gotchas** — verify each gotcha still applies; remove ones that were fixed
+
+Mark anything you can't fully verify with `<!-- TODO: verify -->`.
+
+---
+
+### Step 3 — Identify what changed
+
+Before rewriting, produce a brief change summary:
+
+> **Changes since YYYY-MM-DD:**
+> - [What changed and where]
+> - [What was added]
+> - [What was removed or fixed]
+
+If nothing changed, say so and stop — don't update the doc needlessly.
+
+---
+
+### Step 4 — Rewrite the doc
+
+Update `docs/features/<slug>.md`:
+- Correct all stale paths, line numbers, field names, and flow steps
+- Add new sections or entries for anything that was added
+- Remove entries for anything that was deleted or fixed
+- Update `Last updated:` to today's date
+- Keep all sections from the template — don't delete sections that still apply
+
+Do **not** rewrite the Summary unless the feature's fundamental purpose changed.
+
+---
+
+### Step 5 — Side effects
+
+1. **Update the index** — update the `Last updated` date for this feature in
+   `docs/features/README.md`.
+
+2. **Log bugs to ERRORS.md** — if re-verifying the doc revealed a real bug
+   (not a doc inaccuracy — an actual code problem), log it in
+   `.rig/memory/ERRORS.md` using the standard format:
+   - Symptom / Root cause / Fix / Watch for
+
+3. **Report** — output what changed, what stayed the same, and any remaining
+   `<!-- TODO: verify -->` gaps.
+
+---
+
+## Notes
+
+- Re-verification should be thorough, not cursory. Read the actual code — don't
+  assume a line number still points to the same thing.
+- If the feature grew significantly and the doc needs a full rewrite, it's okay
+  to do that. The goal is accuracy, not preserving the original prose.
+- If you find the doc references a file that no longer exists, check git log to
+  understand what happened to it before marking the claim as stale.

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -40,7 +40,9 @@
 │   ├── processes/    # Agent workflow files
 │   ├── rules/        # Coding standards, git conventions, security, verification
 │   └── tasks/        # active/, backlog/, done/
-├── docs/             # Architecture, decisions, PRD
+├── docs/
+│   ├── features/     # Feature docs (README.md index + one .md per feature)
+│   └── [other docs]  # Architecture, decisions, PRD
 ├── CLAUDE.md         # This file
 └── README.md
 ```
@@ -111,6 +113,21 @@ When starting a new session, read in this order:
 > **External .rig/ note:** if `.rigpath` exists at the project root, all `.rig/`
 > paths above resolve to the external directory it points to. The installer
 > updates these paths automatically when the external tracking option is chosen.
+
+---
+
+## Feature documentation
+
+End-to-end traces for business-critical features live in `docs/features/`.
+
+- **Before touching code** that overlaps with a documented feature, read the
+  relevant doc — it captures the full chain, data model, business rules, and gotchas
+- **After any PR** that changes a documented feature's logic, run
+  `/refresh-feature-doc <feature>` to keep the doc current
+- **To document a new feature**, run `/doc-feature <feature name>` immediately
+  after researching it — capture the knowledge while it's fresh
+
+@docs/features/README.md
 
 ---
 

--- a/templates/project/docs/features/README.md
+++ b/templates/project/docs/features/README.md
@@ -1,0 +1,35 @@
+# Feature Documentation
+
+End-to-end traces for business-critical features in this project.
+Each doc maps a feature from entry point to render: templates, PHP/code, queries,
+data models, business rules, and known gotchas.
+
+---
+
+## When to read these
+
+- **Before touching code** that overlaps with a documented feature — understand
+  the full chain before making a change
+- **When a bug surfaces** in a documented area — check the gotchas section first
+- **When onboarding** — feature docs are the fastest way to understand how
+  non-obvious parts of the system actually work
+
+## When to update these
+
+- **After any PR that changes** a documented feature's data model, query logic,
+  render logic, or business rules — run `/refresh-feature-doc <feature>` to
+  keep the doc current
+
+## When to create new docs
+
+- **After researching any non-obvious feature** — if you had to read 5+ files
+  to understand how something works, future sessions will too. Run
+  `/doc-feature <name>` to capture it while the knowledge is fresh.
+
+---
+
+## Index
+
+| Feature | Doc | Last updated |
+|---|---|---|
+| *(none yet — run `/doc-feature <name>` to create the first one)* | — | — |


### PR DESCRIPTION
## Summary

Adds a structured feature knowledge layer to The Rig. Every scaffolded project now includes a `docs/features/` directory and two new slash commands for creating and maintaining business-critical feature documentation.

Originated as a project-level pattern built during the 4Culture pilot.

## Problem

On non-trivial projects, understanding how a complex feature works requires reading 5–10 files and reverse-engineering business rules that aren't obvious from code alone. Every new session repeats the same archaeology. There was no standard place to put accumulated knowledge.

## Changes

**New templates:**
- `templates/project/docs/features/README.md` — index file; imported by `CLAUDE.md` via `@docs/features/README.md` so every session knows the system exists
- `templates/project/.claude/commands/doc-feature.md` — `/doc-feature <name>`: traces entry points → data layer → render logic → business rules → gotchas; writes a structured doc; updates the README index; guards against duplicates
- `templates/project/.claude/commands/refresh-feature-doc.md` — `/refresh-feature-doc <name>`: re-verifies every claim in an existing doc after a PR that touches it; corrects stale paths/line numbers; logs real bugs to ERRORS.md

**Updated templates:**
- `templates/project/CLAUDE.md` — `docs/features/` in repo structure; Feature documentation section with import and 3-point guide
- `docs/how-it-works.md` — command count 9 → 11; Feature documentation command group added
- `README.md` — What's included table updated; Feature knowledge command group added
- `CHANGELOG.md` — [Unreleased] section documents all additions

## Closes
Closes #76

## Test plan
- [ ] Install into a new project with `--strategy skip` — verify `docs/features/README.md` is created
- [ ] Verify `CLAUDE.md` includes the Feature documentation section and `@docs/features/README.md` import
- [ ] Run `/doc-feature` on a non-trivial feature — verify it produces a doc matching the template structure and updates the README index
- [ ] Run `/doc-feature` again on the same feature — verify it redirects to `/refresh-feature-doc` instead of overwriting

## Notes
The `docs/features/` directory is user-owned (not in `is_rig_owned()`) so the Upgrade strategy will never overwrite it once a project has populated it.
