### PR TITLE
feat(hooks): flag-file detection for /wrap and /post-merge

### DIFF
--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -26,6 +26,19 @@ At the start of any session, silently read in this order:
 6. `./.rig/memory/ERRORS.md` (if present)
 7. `./.rig/tasks/active/` (if present) — understand the current task
 
+**After reading context, check for pending housekeeping flags before starting any work:**
+
+- If `.rig/memory/.wrap-needed` exists: say exactly —
+  > "⚠️ The last session ended without running `/wrap`. CONTEXT_SNAPSHOT.md may be
+  > stale and PROGRESS.md has unexpanded entries. Run `/wrap` now to capture session
+  > state before we start new work — or say 'skip wrap' to proceed anyway."
+  Wait for the user's response before continuing.
+
+- If `.rig/memory/.post-merge-pending` exists: say exactly —
+  > "⚠️ A merge landed since `/post-merge` was last run. Memory may not reflect the
+  > merged state. Run `/post-merge` now — or say 'skip post-merge' to proceed anyway."
+  Wait for the user's response before continuing.
+
 Do not summarise these back to me unless asked.
 
 ---

--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -88,6 +88,20 @@ If no meaningful work shipped (pure exploration, no merges), skip this step sile
 
 ---
 
+## Flag cleanup
+
+After step 8 ("What's next?"), delete the `.post-merge-pending` flag file if it exists:
+
+```bash
+rm -f "$(git rev-parse --show-toplevel)/.rig/memory/.post-merge-pending" 2>/dev/null || true
+```
+
+(Resolve via `.rigpath` if present.) This flag is written by `.husky/post-merge` after
+every merge and is detected at the next session start. Cleaning it up here confirms
+that `/post-merge` ran successfully.
+
+---
+
 ## Notes
 
 - `CONTEXT_SNAPSHOT.md` is the most important output — it's what orients the next

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -9,12 +9,14 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 1. Writes (overwrites) `.rig/memory/CONTEXT_SNAPSHOT.md` with full current project state
 2. Ensures `.rig/memory/PROGRESS.md` is up to date — expands any auto-stubbed entries
 3. **Trims `.rig/memory/PROGRESS.md`** if it has grown beyond 20 entries (see Trim step below)
-4. Checks `.rig/memory/ERRORS.md` — prompts you to log anything unexpected from this session
-5. **Self-improvement check** — scans for Rig workflow gaps and logs them to `.rig/memory/RIG_GAPS.md`
-6. **Trims `.rig/memory/ERRORS.md`** if it has grown beyond 30 entries (see Trim step below)
-7. Reports what's in `.rig/tasks/active/` so you know what's in flight
-8. **Suggests a session name** — derives a `/rename` command from this session's work (see Session naming step below)
-9. Surfaces the next priority from `.rig/tasks/backlog/` and asks: "What's next?"
+4. **Prunes stale session-end markers** from `PROGRESS.md` (see Marker prune step below)
+5. Checks `.rig/memory/ERRORS.md` — prompts you to log anything unexpected from this session
+6. **Self-improvement check** — scans for Rig workflow gaps and logs them to `.rig/memory/RIG_GAPS.md`
+7. **Trims `.rig/memory/ERRORS.md`** if it has grown beyond 30 entries (see Trim step below)
+8. Reports what's in `.rig/tasks/active/` so you know what's in flight
+9. **Suggests a session name** — derives a `/rename` command from this session's work (see Session naming step below)
+10. Surfaces the next priority from `.rig/tasks/backlog/` and asks: "What's next?"
+11. **Cleans up housekeeping flags** — deletes `.rig/memory/.wrap-needed` if present
 
 ## Usage
 
@@ -48,6 +50,25 @@ If the user confirms:
 4. Confirm: "`.rig/memory/PROGRESS.md` trimmed to 20 entries. Archive: `.rig/memory/PROGRESS_archive.md`"
 
 Never trim without confirmation. Never delete entries — only move them.
+
+---
+
+## Marker prune step — PROGRESS.md session-end markers
+
+`stop.sh` appends `<!-- session-end YYYY-MM-DD HH:MM -->` after every agent turn.
+Over time these accumulate in PROGRESS.md without bound — they are not covered by
+the `## ` header trim above.
+
+After the PROGRESS.md trim step, remove all but the **most recent** session-end
+marker from PROGRESS.md:
+
+1. Find all lines matching `<!-- session-end`
+2. Keep the last one (most recent)
+3. Delete all earlier ones in-place
+4. Log: "Pruned [N] stale session-end markers from PROGRESS.md" — only if N > 0
+
+This is automatic — no user confirmation needed (these are housekeeping comments,
+not content).
 
 ---
 
@@ -176,6 +197,22 @@ detect an existing name and suggest appends instead of replacements.
 
 If nothing meaningful shipped this session (pure exploration, no PRs, no
 completions), skip this step silently.
+
+---
+
+## Flag cleanup (step 11)
+
+After suggesting a session name and before asking "What's next?", delete the
+`.wrap-needed` flag file if it exists:
+
+```bash
+rm -f "$(git rev-parse --show-toplevel)/.rig/memory/.wrap-needed" 2>/dev/null || true
+```
+
+(Resolve via `.rigpath` if present.) Log to session log: "`.wrap-needed` cleared."
+
+This signals to `stop.sh` that `/wrap` has run and no flag should be written until
+the next commit creates new unexpanded stubs.
 
 ---
 

--- a/templates/project/.claude/hooks/stop.sh
+++ b/templates/project/.claude/hooks/stop.sh
@@ -11,6 +11,8 @@
 #      (preserves the description — only the YYYY-MM-DD changes)
 #   2. Appends a session-end comment to PROGRESS.md so the session naming
 #      heuristic in /wrap and /post-merge knows where this session ends
+#   3. Writes .wrap-needed if PROGRESS.md has unexpanded auto-stubs,
+#      signalling that /wrap should be run before the next session starts
 #
 # What it does NOT do:
 #   - Write a full CONTEXT_SNAPSHOT (that's /wrap's job)
@@ -32,6 +34,7 @@ fi
 
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
 PROGRESS="$RIG_DIR/memory/PROGRESS.md"
+WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
 SESSION_LOG="/tmp/the-rig-session.log"
 NOW=$(date +%Y-%m-%d)
 NOW_FULL=$(date "+%Y-%m-%d %H:%M")
@@ -70,6 +73,23 @@ if [[ -f "$PROGRESS" ]]; then
     echo "[$(date +%H:%M:%S)] STOP: session-end marker already present — skipped" \
       >> "$SESSION_LOG"
   fi
+fi
+
+# ── Write .wrap-needed flag if unexpanded auto-stubs exist ────────────────────
+# post-tool.sh auto-stubs PROGRESS.md after every git commit with a line:
+#   "_Auto-logged by post-tool hook. Expand this entry during wrap-up._"
+# /wrap expands those stubs and removes that marker text.
+# If stubs are still present, /wrap hasn't run since the last commit.
+# The next session will read this flag and prompt the user to run /wrap first.
+if [[ -f "$PROGRESS" ]] && grep -q "Auto-logged by post-tool hook" "$PROGRESS"; then
+  touch "$WRAP_NEEDED"
+  echo "[$(date +%H:%M:%S)] STOP: .wrap-needed written (unexpanded stubs found)" \
+    >> "$SESSION_LOG"
+elif [[ ! -f "$SNAPSHOT" ]] && [[ -f "$PROGRESS" ]]; then
+  # No snapshot at all — /wrap has never been run in this project
+  touch "$WRAP_NEEDED"
+  echo "[$(date +%H:%M:%S)] STOP: .wrap-needed written (no CONTEXT_SNAPSHOT.md)" \
+    >> "$SESSION_LOG"
 fi
 
 exit 0

--- a/templates/project/.husky/post-merge
+++ b/templates/project/.husky/post-merge
@@ -3,6 +3,8 @@
 #
 # Fires after `git merge` completes — including `git pull` that brings in a merge.
 # Reminds you to run the post-merge housekeeping workflow in Claude Code.
+# Writes .post-merge-pending so the next Claude Code session detects the gap
+# and prompts you to run /post-merge before starting new work.
 #
 # The reminder only shows when a merge commit was brought in (MERGE_HEAD existed),
 # not on fast-forward pulls or regular branch merges.
@@ -19,3 +21,17 @@ echo "  → Open Claude Code in this project and run: /post-merge"
 echo "    This pulls latest, updates memory, moves the task file, and surfaces what's next."
 echo "    Skipping this is how sessions start stale."
 echo ""
+
+# Write a flag file so the next Claude Code session detects the skipped /post-merge.
+# Resolved via .rigpath if present (external .rig/), otherwise defaults to .rig/.
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -n "$REPO" ]]; then
+  if [[ -f "$REPO/.rigpath" ]]; then
+    RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+  else
+    RIG_DIR="$REPO/.rig"
+  fi
+  if [[ -d "$RIG_DIR/memory" ]]; then
+    touch "$RIG_DIR/memory/.post-merge-pending"
+  fi
+fi

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -24,3 +24,13 @@ ERRORS_archive.md
 # Created by the agent when the user gives explicit go-ahead ("commit approved", etc.).
 # Deleted automatically by post-tool.sh after the commit lands. Never committed.
 .rig-commit-ok
+
+# .wrap-needed is written by stop.sh when unexpanded PROGRESS.md auto-stubs exist,
+# signalling that /wrap should be run before the next session starts.
+# Deleted by /wrap when it completes successfully. Never committed.
+.wrap-needed
+
+# .post-merge-pending is written by .husky/post-merge after a merge completes,
+# signalling that /post-merge should be run before starting new work.
+# Deleted by /post-merge when it completes successfully. Never committed.
+.post-merge-pending


### PR DESCRIPTION
## Summary

Two related gaps closed:

**1. /wrap and /post-merge are now detectable when skipped.**
`stop.sh` writes `.rig/memory/.wrap-needed` whenever PROGRESS.md has unexpanded auto-stubs (commits that happened without a wrap). `.husky/post-merge` writes `.post-merge-pending` after every merge. The global `CLAUDE.md` orientation sequence checks for both flags at session start and surfaces a prompt before any new work begins. Each command cleans up its own flag on successful completion.

**2. session-end marker accumulation fixed.**
`stop.sh` appended `<!-- session-end -->` markers after every agent turn with no trim. `/wrap` now includes a marker prune step that keeps only the most recent marker — no user confirmation needed (these are housekeeping HTML comments, not content).

## Changes

- `templates/project/.claude/hooks/stop.sh` — .wrap-needed logic
- `templates/project/.husky/post-merge` — .post-merge-pending write
- `templates/project/.rig/memory/.gitignore` — both flag files added
- `templates/global/CLAUDE.md` — session-start flag checks with exact prompt text
- `templates/project/.claude/commands/wrap.md` — step 4 (marker prune), step 11 (flag cleanup)
- `templates/project/.claude/commands/post-merge.md` — flag cleanup section

## Closes

Closes #79

## Test plan

- [ ] Commit something without running /wrap → stop.sh fires → `.wrap-needed` exists
- [ ] Open new Claude Code session → agent prompts about .wrap-needed before starting work
- [ ] Run /wrap → .wrap-needed is deleted
- [ ] Run a git merge → .post-merge-pending exists
- [ ] Open new session → agent prompts about .post-merge-pending
- [ ] Run /post-merge → .post-merge-pending is deleted
- [ ] After /wrap: verify stale session-end markers are pruned from PROGRESS.md

## Notes

The .wrap-needed detection relies on the 'Auto-logged by post-tool hook' stub marker in PROGRESS.md. When /wrap expands all stubs, this string disappears and stop.sh no longer writes the flag. This is intentional — the flag tracks 'commits since last wrap', not 'session ended without wrap'.