### PR TITLE
feat(global): /task gate for freeform change requests

### DIFF
--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -50,6 +50,16 @@ Do not summarise these back to me unless asked.
 - **When you see a compaction warning** (e.g. "8% until auto-compact"), run `/wrap`
   immediately — before the next tool call. Compaction destroys in-flight context.
   A timely `/wrap` means the next session can resume cleanly.
+- **Gate freeform change requests through `/task`.** Before acting on any user
+  request that reads like a change request, apply this scope check:
+  - **Proceed directly** if the change is a one-liner or touches a single known file
+    and can be verified in under 5 minutes. Offer to log it as a task file afterward.
+  - **Redirect to `/task`** if the change is likely to touch more than 2–3 files,
+    requires a GitHub issue, or would take more than one exchange to complete. Say:
+    > "This looks like a task worth tracking. Does it have an issue number I can
+    > reference — or should I open a `/task` intake?"
+    Wait for the user's response before touching any code.
+  - **Never proceed** on a multi-file change request without an issue number.
 
 ---
 


### PR DESCRIPTION
Closes #80

## Summary
- Adds a scope-check rule to the `Working style` section of `templates/global/CLAUDE.md`
- One-liner single-file fixes proceed directly (with an offer to log as a task file afterward)
- Multi-file or ambiguous-scope requests redirect to `/task` with a required issue number
- Never proceeds on a multi-file change request without an issue number

## Test plan
- [ ] Install fresh global `CLAUDE.md` and verify the agent redirects multi-file requests to `/task`
- [ ] Verify one-liner fixes still proceed without friction
- [ ] Verify the agent asks for an issue number when scope is ambiguous

🤖 Generated with [Claude Code](https://claude.ai/claude-code)