### PR TITLE
feat(memory): add DECISIONS.md to default scaffold

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -228,15 +228,15 @@ Common alternatives: `trufflehog`, `git-secrets`, `detect-secrets`.
 
 ---
 
-## Adding a decisions log
+## The decisions log
 
-The memory system has `PROGRESS.md` (what shipped) and `ERRORS.md` (what went wrong),
-but not a structured decisions log. If your project benefits from explicit decision
-records, add `.rig/memory/DECISIONS.md`:
+`.rig/memory/DECISIONS.md` is included in the default scaffold. The agent logs to it
+when a significant architectural, product, or process decision is made — especially
+one that closes off alternatives or would surprise a future reader.
+
+Format per entry:
 
 ```markdown
-# Decisions log
-
 ## [YYYY-MM-DD] — [Short title]
 
 **Context**: Why this decision needed to be made
@@ -246,7 +246,8 @@ records, add `.rig/memory/DECISIONS.md`:
 **Consequences**: What this decision implies going forward
 ```
 
-Reference it in the project `CLAUDE.md` context-loading sequence.
+Unlike `CONTEXT_SNAPSHOT.md`, this file is committed — decisions are project history.
+The project `CLAUDE.md` context-loading sequence already references it.
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -144,6 +144,12 @@ Three files, three purposes:
 - The most valuable file in the system — it's institutional memory
 - **Trim convention:** capped at 30 entries. `/wrap` moves older entries to `.rig/memory/ERRORS_archive.md` (gitignored, disk-only) when the cap is exceeded. Same pattern as PROGRESS.md.
 
+### .rig/memory/DECISIONS.md
+- Structured log of significant architectural, product, and process decisions
+- Format per entry: Context → Decision → Rejected → Rationale → Consequences
+- Committed (unlike CONTEXT_SNAPSHOT) — decisions are project history, not session state
+- Skimmed at session start; the agent logs to it when a non-obvious choice is made
+
 ### .rig/memory/RIG_GAPS.md
 - Self-improvement feedback log — committed to every project repo
 - Captures workflow friction, bugs, missing features, and improvement ideas observed during real use

--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -102,6 +102,9 @@ Do not summarise these back to me unless asked.
 - At the start of each session, check `.rig/memory/PROGRESS.md` and `.rig/memory/ERRORS.md`.
 - After completing meaningful work, update `.rig/memory/PROGRESS.md`.
 - When you hit an error or unexpected edge case, log it in `.rig/memory/ERRORS.md`.
+- When a significant architectural, product, or process decision is made — especially
+  one that closes off alternatives or would surprise a future reader — log it in
+  `.rig/memory/DECISIONS.md`.
 - Before ending a session or when approaching a context limit, run `/wrap` to write
   `.rig/memory/CONTEXT_SNAPSHOT.md`. Never delete it — always overwrite.
 - Never assume continuity from a prior session — always re-read context files.

--- a/templates/project/.rig/memory/DECISIONS.md
+++ b/templates/project/.rig/memory/DECISIONS.md
@@ -1,0 +1,23 @@
+# Decisions log
+
+Structured records of significant architectural, product, and process decisions.
+Add an entry whenever a non-obvious choice is made — especially ones that would
+surprise a future reader or that closed off alternatives permanently.
+
+---
+
+## Format
+
+```markdown
+## [YYYY-MM-DD] — [Short title]
+
+**Context**: Why this decision needed to be made
+**Decision**: What was chosen
+**Rejected**: What was considered and not chosen
+**Rationale**: Why
+**Consequences**: What this decision implies going forward
+```
+
+---
+
+*(No decisions logged yet. Add the first entry when a meaningful choice is made.)*

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -108,7 +108,8 @@ When starting a new session, read in this order:
 2. `.rig/memory/PROGRESS.md` — only if `CONTEXT_SNAPSHOT.md` is absent or more than one
    session old. Load the most recent entries only (last 20 `##` sections).
 3. `.rig/memory/ERRORS.md` — known pitfalls
-4. `.rig/tasks/active/` — current in-flight task(s)
+4. `.rig/memory/DECISIONS.md` — architectural and process decisions (skim only)
+5. `.rig/tasks/active/` — current in-flight task(s)
 
 > **External .rig/ note:** if `.rigpath` exists at the project root, all `.rig/`
 > paths above resolve to the external directory it points to. The installer


### PR DESCRIPTION
Closes #81

## Summary
- Adds `templates/project/.rig/memory/DECISIONS.md` to the default scaffold with a structured entry format (Context → Decision → Rejected → Rationale → Consequences)
- Updates `templates/project/CLAUDE.md` context-loading sequence to include DECISIONS.md (step 4, skimmed at session start)
- Updates `templates/global/CLAUDE.md` memory discipline section — agent logs significant decisions as they happen
- Adds DECISIONS.md subsection to `docs/how-it-works.md` memory system documentation
- Rewrites `docs/customizing.md` "Adding a decisions log" section from opt-in framing to "it's already included" framing

## Why
PROGRESS.md captures what shipped. ERRORS.md captures what went wrong. Nothing captured *why* significant choices were made — especially ones that closed off alternatives. DECISIONS.md closes that gap. Making it part of the default scaffold means every project gets it without needing to remember to add it.

## Test plan
- [ ] Fresh install includes `.rig/memory/DECISIONS.md` when memory system is selected
- [ ] Agent references DECISIONS.md in session context-loading
- [ ] Agent logs to DECISIONS.md when a non-obvious architectural choice is made

🤖 Generated with [Claude Code](https://claude.ai/claude-code)