### PR TITLE
feat(commands): add /recon command for evolution research

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 **Feature knowledge**
 ```
+/recon [topic]               →  sweep PR history + commits + codebase for a keyword; synthesize an evolution timeline
 /doc-feature [name]          →  research a feature end-to-end; produce a structured doc in docs/features/
 /refresh-feature-doc [name]  →  re-verify an existing feature doc against current code; correct stale claims
 ```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -308,7 +308,7 @@ staged only from `.rig/tasks/done/` in a separate housekeeping commit.
 
 ## The command set
 
-Eleven slash commands covering the full development lifecycle:
+Twelve slash commands covering the full development lifecycle:
 
 ### Project bootstrap
 | Command | Triggers | Key behaviour |
@@ -327,9 +327,10 @@ Eleven slash commands covering the full development lifecycle:
 | `/ship` | `SHIP_WORKFLOW` | Sequential 9-step hard gate: task confirm → issue → labels → checklist → local test pause → commit approval → commit → housekeeping → PR |
 | `/debug` | `DEBUG_WORKFLOW` | Hypothesis before code, mandatory ERRORS.md entry |
 
-### Feature documentation
+### Feature knowledge
 | Command | Triggers | Key behaviour |
 |---|---|---|
+| `/recon` | Keyword research | Sweeps merged PR history, commit messages, and live codebase for a keyword. Synthesizes an evolution timeline + current state. `--depth shallow` (default) or `--depth full`. Natural precursor to `/doc-feature`. |
 | `/doc-feature` | Research + write | Traces a named feature end-to-end (entry point → data layer → render logic) and produces a structured doc in `docs/features/`. Guards against duplicates; updates the README index. |
 | `/refresh-feature-doc` | Re-verify + update | Re-reads every claim in an existing feature doc against current code; corrects stale paths/line numbers; logs bugs found to `ERRORS.md`. Run after any PR that touches a documented feature. |
 

--- a/templates/project/.claude/commands/doc-feature.md
+++ b/templates/project/.claude/commands/doc-feature.md
@@ -7,6 +7,10 @@ Run this any time you've traced through 5+ files to understand how something
 works — capture the knowledge while it's fresh so future sessions don't repeat
 the same archaeology.
 
+> **Tip:** If you haven't already, run `/recon <feature>` first. It sweeps PR
+> history and commit messages so you understand how the feature evolved before
+> you document its current state.
+
 ---
 
 ## Usage

--- a/templates/project/.claude/commands/recon.md
+++ b/templates/project/.claude/commands/recon.md
@@ -1,0 +1,145 @@
+# Command: /recon
+
+Research how a feature, pattern, or system was built — and how it has evolved.
+
+`/recon` sweeps three sources in one pass: merged PR history, commit messages, and
+the live codebase. It synthesizes a timeline of decisions and the current state of
+the code. Run it before starting work on anything non-trivial so you know what
+you're walking into.
+
+> **Tip:** `/recon` is a natural precursor to `/doc-feature`. Use `/recon` to
+> understand what exists and how it got there, then `/doc-feature` to produce the
+> canonical reference doc.
+
+---
+
+## Usage
+
+```
+/recon <keyword or topic>
+/recon <keyword or topic> --depth shallow
+/recon <keyword or topic> --depth full
+```
+
+Examples:
+```
+/recon auth
+/recon stripe webhooks --depth full
+/recon PDF export
+/recon PROGRESS.md --depth shallow
+```
+
+If no argument is given, ask: **"What topic or feature should I research?"**
+
+**Depth flag** (optional):
+- `--depth shallow` *(default)* — commit messages, file list, and brief code skim
+- `--depth full` — full diff content, complete file reads, and exhaustive synthesis
+
+> ⚠️ `--depth full` on an active repo with many PRs can be slow and context-heavy.
+> Use it when you need the full picture and have a narrowly scoped keyword.
+
+---
+
+## What this does
+
+### Step 1 — Keyword sweep: merged PR history
+
+Search merged PR titles and bodies for the keyword(s):
+
+```bash
+gh pr list --state merged --limit 200 --json number,title,body,mergedAt \
+  | jq '.[] | select(.title + .body | ascii_downcase | contains("<keyword>"))'
+```
+
+For each matching PR, collect: PR number, title, merge date, and a one-line summary
+of what changed.
+
+> **Rate limit note:** GitHub API calls are subject to rate limits. If the search
+> returns a rate-limit error, wait 60 seconds and retry. Report the delay to the user.
+
+---
+
+### Step 2 — Commit history sweep
+
+Search commit messages on `main` (or the default branch) for the keyword:
+
+```bash
+git log --oneline --all | grep -i "<keyword>"
+```
+
+Collect matching commits: hash, date, message. Cross-reference against the PRs
+found in Step 1 to identify commits not covered by any PR (direct-to-main commits
+or commits on branches that didn't have a PR).
+
+---
+
+### Step 3 — Live codebase sweep
+
+Search the current codebase for the keyword in file names and contents:
+
+```bash
+# File name matches
+find . -name "*<keyword>*" -not -path "*/node_modules/*" -not -path "*/.git/*"
+
+# Content matches (top files by hit count)
+grep -rl --include="*.md" --include="*.ts" --include="*.js" \
+  --include="*.py" --include="*.sh" "<keyword>" . \
+  | grep -v "node_modules\|\.git"
+```
+
+At `--depth shallow`: read only the most relevant 3–5 files (highest hit count or
+most directly named for the topic). At `--depth full`: read all matching files.
+
+---
+
+### Step 4 — Synthesize
+
+Produce a structured report with three sections:
+
+#### Evolution timeline
+A chronological list of the meaningful changes: when they happened, what PR/commit
+drove them, and what decision or shift each represents. Focus on *why* over *what* —
+the diff shows what; the timeline should explain the thinking.
+
+```
+[YYYY-MM-DD] PR #N — [title]
+  → [What changed and why — 1–2 sentences]
+
+[YYYY-MM-DD] commit <hash>
+  → [What changed and why]
+```
+
+#### Current state
+A concise description of how the topic/feature works *right now*:
+- Key files and their roles
+- How it's triggered / entry points
+- Any notable configuration or flags
+- Known gotchas visible in the code
+
+#### Open questions / gaps
+Things the research surfaced but couldn't confirm. Flag anything that looks
+inconsistent, undocumented, or potentially stale.
+
+---
+
+### Step 5 — Suggest next steps
+
+Based on the synthesis, suggest one of:
+
+- **`/doc-feature <topic>`** — if no feature doc exists yet and the feature is
+  complex enough to warrant one
+- **`/task`** — if the research surfaced a clear piece of work
+- **Nothing** — if the research was purely informational and no action is needed
+
+State the suggestion explicitly. Don't act on it — let the user decide.
+
+---
+
+## Notes
+
+- `/recon` is read-only. It never writes to any file, creates commits, or opens issues.
+- If the keyword is very broad (e.g. "auth", "user"), warn the user and ask if they
+  want to narrow it before proceeding.
+- If the repo has no merged PRs yet (fresh project), skip Step 1 and note it.
+- The session log at `/tmp/the-rig-session.log` is not part of the recon scope —
+  it's ephemeral and not meaningful for evolution research.


### PR DESCRIPTION
Closes #82

## Summary
- Adds `templates/project/.claude/commands/recon.md` — a new slash command that sweeps merged PR history, commit messages, and the live codebase for a keyword
- Synthesizes an evolution timeline (what changed and why, chronologically) + current state + open questions
- Supports `--depth shallow` (default) and `--depth full` flags
- Includes GitHub API rate limit warning and handling instructions
- Updates README command table (Feature knowledge section)
- Updates `docs/how-it-works.md` command count (11 → 12) and command table
- Adds cross-reference tip to `/doc-feature` pointing to `/recon` as a precursor

## Why
The problem: every session that touches a non-trivial feature spends the first 20 minutes re-discovering how it was built. `/recon` externalizes that archaeology into a single command that sweeps all three sources (PRs, commits, live code) and produces a structured summary. The timeline format captures the *why* behind decisions, not just the current state.

## Test plan
- [ ] Run `/recon auth` on a project with merged PRs — verify PR history is swept and timeline produced
- [ ] Run `/recon <topic> --depth full` — verify full file reads are included
- [ ] Run `/recon` on a fresh project with no PRs — verify Step 1 is gracefully skipped
- [ ] Verify `/doc-feature` now shows the `/recon` tip at the top

🤖 Generated with [Claude Code](https://claude.ai/claude-code)