### PR TITLE
fix(docs): correct stale counts, Batches opt-in, reclone/single-session notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 - [How it works](docs/how-it-works.md) — architecture deep-dive with diagrams
 - [Key decisions](docs/decisions.md) — design rationale and tradeoffs
-- [Lessons learned](docs/lessons-learned.md) — 10 documented pitfalls from the pilot
+- [Lessons learned](docs/lessons-learned.md) — 13 documented pitfalls from the pilot
 - [Customizing](docs/customizing.md) — adapting The Rig for your stack
 
 ---

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -162,9 +162,23 @@ Or choose option 3 in the interactive tracking prompt. The installer will:
 The project root stays clean. The agent finds its memory and rules via
 `.rigpath`. Teammates never see any of it.
 
+> ⚠️ **Re-clone warning:** when you clone the project on a new machine, the
+> external `.rig/` directory doesn't travel with it. You must manually restore
+> the external directory on the new machine — either by re-running the installer
+> with `--rig-dir` pointing to the same path, or by copying it from a backup.
+> See `docs/troubleshooting.md` → "CONTEXT_SNAPSHOT.md is missing after a re-clone"
+> for the full recovery steps.
+
 ---
 
 ## Scaling to a team
+
+> **Single-session assumption:** The Rig is designed around one active Claude Code
+> session at a time per project. Running two sessions simultaneously against the same
+> repo is untested — hooks write to shared files (`PROGRESS.md`, the session log)
+> without locking, so concurrent sessions can produce race conditions in PROGRESS.md
+> auto-stubs. For team use, each engineer should work in their own branch with their
+> own active task file.
 
 The Rig was designed for solo or small-team use. For larger teams:
 

--- a/templates/project/.rig/tasks/backlog/TASK_example.md
+++ b/templates/project/.rig/tasks/backlog/TASK_example.md
@@ -57,15 +57,17 @@
 
 ---
 
-## Batches
+<!--
+## Batches (optional — add this section for tasks that span multiple commits)
 
-> Use this section when a task spans multiple commits or PR checkpoints.
-> Record each sub-goal as it lands. Delete this section for single-commit tasks.
+Use this section when a task spans multiple commits or PR checkpoints.
+Record each sub-goal as it lands. Delete this section for single-commit tasks.
 
 | # | Sub-goal | Commit | PR checkpoint |
 |---|---|---|---|
 | 1 | [What this batch delivers] | `[hash]` *(filled after commit)* | — |
 | 2 | [Next sub-goal] | — | — |
+-->
 
 ---
 


### PR DESCRIPTION
Closes #84

## Summary
Four targeted doc fixes:
1. README pitfall count corrected: 10 -> 13 (lessons-learned.md has 13 entries)
2. TASK_example.md Batches section wrapped in HTML comment — now opt-in, not shown by default
3. docs/customizing.md external .rig/ section gets reclone warning pointing to troubleshooting doc
4. docs/customizing.md team-scaling section gets single-session assumption note (concurrent sessions untested)

## Test plan
- Verify README links to lessons-learned.md count accurately
- Open a new task file and confirm Batches section is hidden by default

Generated with Claude Code