### PR TITLE
feat(commands): add Related features table to feature doc template

### DIFF
--- a/templates/project/.claude/commands/doc-feature.md
+++ b/templates/project/.claude/commands/doc-feature.md
@@ -173,6 +173,18 @@ Things that have caused or could cause bugs, surprises, or confusion.
 
 ---
 
+## Related features
+
+Features that interact with, depend on, or are commonly confused with this one.
+
+| Feature | Doc | Relationship |
+|---|---|---|
+| [Feature name] | [slug.md](slug.md) | [e.g. "shares the same data model", "called by this feature", "commonly confused with"] |
+
+*(Delete this section if no meaningful relationships exist.)*
+
+---
+
 ## Last verified against
 
 Commit: [hash or branch]

--- a/templates/project/.claude/commands/refresh-feature-doc.md
+++ b/templates/project/.claude/commands/refresh-feature-doc.md
@@ -51,6 +51,10 @@ For each claim in the doc, re-read the referenced file and line range:
 - **Business rules** — verify each rule is still enforced in the code; flag any
   that were removed or changed
 - **Gotchas** — verify each gotcha still applies; remove ones that were fixed
+- **Related features table** — if the doc has a `## Related features` section,
+  check that every linked doc still exists (`docs/features/<slug>.md`). Remove
+  rows pointing to deleted docs. Add rows for any new features that now interact
+  with this one.
 
 Mark anything you can't fully verify with `<!-- TODO: verify -->`.
 


### PR DESCRIPTION
Closes #85

## Summary
- Adds a Related features section to the doc template in doc-feature.md — captures cross-feature relationships at doc-creation time
- Adds cross-reference verification to refresh-feature-doc.md step 2 — stale cross-references are caught during refresh

## Test plan
- Run /doc-feature on a feature with known relationships; verify the Related features table appears in the output
- Verify /refresh-feature-doc step 2 now checks Related features links

Generated with Claude Code