### PR TITLE
feat(workflows): add branch safety check and git state verification

### DIFF
--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -36,6 +36,26 @@ Follows `.rig/processes/POST_MERGE_WORKFLOW.md`:
 Run this immediately after you merge (or are told a PR merged). Claude will ask
 which PR merged if it's not clear from context.
 
+## Git state check — run first, before anything else
+
+Before touching any files, verify the repo is in a known-good state:
+
+```bash
+git branch --show-current
+git status --short
+git log --oneline -3
+```
+
+Report briefly:
+
+> "Branch: `main` | Clean working tree | HEAD: `abc1234 feat: merged PR #N`"
+
+**If the working tree is not clean:** surface any uncommitted changes and ask
+the user whether to stash, commit, or discard them before proceeding.
+
+**If not on `main`:** note the current branch. The POST_MERGE_WORKFLOW Step 1
+will `git checkout main && git pull`, but flag it now so the user is aware.
+
 ---
 
 ## Session naming step

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -24,6 +24,28 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 /wrap
 ```
 
+## Git state check — run first, before anything else
+
+Before writing any files, run:
+
+```bash
+git branch --show-current
+git status --short
+git log --oneline -3
+```
+
+Report the results briefly:
+
+> "Branch: `feat/my-feature` | 2 uncommitted changes | Last commit: `abc1234 feat: add thing`"
+
+**If there are uncommitted changes to non-Rig files:** surface them explicitly.
+The user may have forgotten to commit something before ending the session. Ask:
+> "There are uncommitted changes to `[files]`. Should I include them in a commit
+> before wrapping, or proceed with wrap as-is?"
+Wait for the answer before continuing.
+
+**If the repo is clean:** note it and proceed directly.
+
 Run this:
 - Before closing Claude Code for the day
 - When the conversation is getting long and you want a clean handoff point

--- a/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
+++ b/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
@@ -12,13 +12,31 @@
 
 ---
 
-## Step 1 — Pull latest main
+## Step 1 — Verify state and pull latest main
+
+First, snapshot current state:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+If the working tree is not clean, surface the uncommitted changes and resolve them
+before continuing (stash, commit, or discard — ask the user).
+
+Then pull:
 
 ```bash
 git checkout main && git pull origin main
 ```
 
-Confirm the expected commit is at HEAD before proceeding.
+Confirm the expected merge commit is at HEAD:
+
+```bash
+git log --oneline -3
+```
+
+State the HEAD commit. If it doesn't match the expected merge, stop and flag it.
 
 ---
 

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -89,7 +89,28 @@ level or how confident the agent is in the changes.
 
 ---
 
-## Step 3 — Commit
+## Step 3 — Branch safety check
+
+Before committing, verify you are on a suitable branch:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+**If you are on `main` or `master`:** do not commit. Say:
+> "You're on `main` — I can't commit directly here. Which branch should I use?
+> I can create `feat/[slug]` off main, or use an existing branch."
+Wait for the user's answer before proceeding.
+
+**If you are on any other branch:** proceed. Briefly confirm: `"Branch: [name] — looks good."`
+
+**If there are untracked or modified files outside the task scope** (shown by `git status`):
+surface them and ask whether to stage, stash, or ignore before continuing.
+
+---
+
+## Step 4 — Commit
 
 Use conventional commit format:
 
@@ -114,7 +135,7 @@ git commit -F /tmp/commit-msg.txt
 
 ---
 
-## Step 4 — Update memory
+## Step 5 — Update memory
 
 In this order:
 
@@ -146,7 +167,7 @@ In this order:
 
 ---
 
-## Step 5 — Open the PR
+## Step 6 — Open the PR
 
 **The PR body must describe what was actually built — not the original plan.**
 If scope changed during implementation, the PR body should note it explicitly. Reviewers
@@ -190,7 +211,7 @@ gh pr create --title "..." --body-file /tmp/pr-body.md --base main \
 
 ---
 
-## Step 6 — Housekeeping commit (if needed)
+## Step 7 — Housekeeping commit (if needed)
 
 If the memory updates and task file move were not included in the implementation commit,
 make a follow-up housekeeping commit on the same branch:


### PR DESCRIPTION
Closes #97

## Summary
- **SHIP_WORKFLOW**: inserts a new Step 3 that checks `git branch` and `git status` before any commit. Blocks if on `main`/`master` and asks which branch to use. Surfaces out-of-scope dirty files. Old Steps 3–5 renumbered 4–6.
- **POST_MERGE_WORKFLOW**: Step 1 now snapshots state before pulling, then confirms HEAD matches the expected merge commit after `git pull`.
- **/wrap**: runs `git branch + status + log --oneline -3` before touching any files. Asks about uncommitted non-Rig changes.
- **/post-merge**: same pre-flight check before switching to main.

## Test plan
- [ ] Run /ship while on main — verify it blocks and prompts for a branch name
- [ ] Run /wrap with a dirty tree — verify it surfaces uncommitted files before writing
- [ ] Run /post-merge from a feature branch — verify it notes the branch before switching to main

🤖 Generated with Claude Code