### PR TITLE
feat(post-merge): configurable housekeeping commit convention

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -61,6 +61,27 @@ Don't modify it directly — use `/propose` instead.
 
 ---
 
+## Configuring the housekeeping commit convention
+
+By default, `/post-merge` commits memory updates directly to `main` — no branch,
+no PR. For repos that require a PR for every change, set `pr-required` in the
+project `CLAUDE.md`:
+
+```markdown
+## Git workflow convention
+
+housekeeping: pr-required
+```
+
+| Value | Behaviour |
+|---|---|
+| `direct-push` | Commits and pushes directly to `main`. Default. |
+| `pr-required` | Creates `chore/post-merge-[N]` branch and opens a small PR. |
+
+Change this once per project and `/post-merge` respects it every time.
+
+---
+
 ## Adjusting the intake wizard defaults
 
 `/task` defaults to **Medium autonomy / Normal check-ins / Balanced risk**. If your

--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -109,5 +109,6 @@ that `/post-merge` ran successfully.
   full instead, which is slower and less precise.
 - If `.rig/tasks/active/` is empty when `/post-merge` runs (task was already moved),
   Claude will note it and skip the move step.
-- The housekeeping commit is on a short-lived branch — open a small PR or push
-  directly per your project's convention.
+- **Housekeeping commit convention** is controlled by `## Git workflow convention` in
+  the project `CLAUDE.md`. Default is `direct-push` (no branch, no PR). Change to
+  `pr-required` for repos that require PRs for all changes to main.

--- a/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
+++ b/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
@@ -78,15 +78,39 @@ and submit those entries to The Rig dev session.
 ## Step 6 — Housekeeping commit
 
 If `.rig/memory/PROGRESS.md` updates and the task file move were not already committed
-as part of the PR:
+as part of the PR, commit them now.
+
+**First, read the `## Git workflow convention` field from the project `CLAUDE.md`.**
+It will be one of:
+
+- `housekeeping: direct-push` — commit and push directly to `main` (default)
+- `housekeeping: pr-required` — create a short-lived branch and open a PR
+
+### If `direct-push` (default)
+
+```bash
+git add .rig/memory/PROGRESS.md .rig/tasks/done/TASK_[name].md
+git commit -m "chore: post-merge housekeeping for PR #N"
+git push origin main
+```
+
+No branch, no PR. Done.
+
+### If `pr-required`
 
 ```bash
 git checkout -b chore/post-merge-[N]
 git add .rig/memory/PROGRESS.md .rig/tasks/done/TASK_[name].md
 git commit -m "chore: post-merge housekeeping for PR #N"
 git push -u origin chore/post-merge-[N]
-# Then open a small PR or push directly per your team's convention
+gh pr create --title "chore: post-merge housekeeping for PR #N" \
+  --body "Memory updates and task file move for merged PR #N." \
+  --label "type: chore" --base main
 ```
+
+### If no changes to commit
+
+If PROGRESS.md and the task file were already part of the PR, skip this step entirely.
 
 ---
 

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -72,6 +72,24 @@
 
 ---
 
+## Git workflow convention
+
+Controls how `/post-merge` handles housekeeping commits (PROGRESS.md updates,
+task file moves) that were not included in the PR itself.
+
+```
+housekeeping: direct-push
+```
+
+| Value | Behaviour |
+|---|---|
+| `direct-push` | Commits and pushes directly to `main`. No branch, no PR. Default for solo projects. |
+| `pr-required` | Creates a short-lived `chore/post-merge-[N]` branch and opens a PR. Use when your team requires PRs for all changes. |
+
+Change this value to match your project's branching convention.
+
+---
+
 ## Off-limits — never touch without explicit instruction
 
 - `.husky/` — git hooks are stable; do not modify


### PR DESCRIPTION
Closes #98

## Summary
- Adds `## Git workflow convention` section to project `CLAUDE.md` template with `housekeeping: direct-push | pr-required`
- **Default is `direct-push`** — no more `chore/post-merge-N` branches and PRs on every merge for solo/small projects
- **`pr-required`** creates a short-lived branch and opens a PR (for teams with branch-protection rules)
- `POST_MERGE_WORKFLOW` Step 6 reads the setting and follows the right path
- `/post-merge` Notes section updated to explain the config
- `docs/customizing.md` documents how to change it

## Test plan
- [ ] Run /post-merge with default config — verify it pushes directly to main, no PR opened
- [ ] Change config to `pr-required`, run /post-merge — verify branch + PR created
- [ ] Verify the convention field is present in the project CLAUDE.md template

🤖 Generated with Claude Code