### PR TITLE
feat(install): configurable base branch — prompt and [BASE_BRANCH] substitution [#108]

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -61,9 +61,32 @@ Don't modify it directly — use `/propose` instead.
 
 ---
 
+## Configuring the base branch
+
+The installer prompts for the base branch name and substitutes it throughout
+all workflow files. If you need to change it after install, update the
+`## Base branch` section in your project `CLAUDE.md`:
+
+```markdown
+## Base branch
+
+base-branch: integration
+```
+
+Then manually update `git checkout [BASE_BRANCH]` references in:
+- `.rig/processes/POST_MERGE_WORKFLOW.md`
+- `.rig/processes/SHIP_WORKFLOW.md`
+- `.claude/commands/ship.md`
+- `.claude/commands/post-merge.md`
+
+To auto-detect, the installer reads `git symbolic-ref refs/remotes/origin/HEAD`
+and offers it as the default.
+
+---
+
 ## Configuring the housekeeping commit convention
 
-By default, `/post-merge` commits memory updates directly to `main` — no branch,
+By default, `/post-merge` commits memory updates directly to the base branch — no branch,
 no PR. For repos that require a PR for every change, set `pr-required` in the
 project `CLAUDE.md`:
 
@@ -75,7 +98,7 @@ housekeeping: pr-required
 
 | Value | Behaviour |
 |---|---|
-| `direct-push` | Commits and pushes directly to `main`. Default. |
+| `direct-push` | Commits and pushes directly to the base branch. Default. |
 | `pr-required` | Creates `chore/post-merge-[N]` branch and opens a small PR. |
 
 Change this once per project and `/post-merge` respects it every time.

--- a/install.sh
+++ b/install.sh
@@ -136,12 +136,13 @@ EXTERNAL_RIG_DIR=""   # set via --rig-dir <path>
 _FLAG_STRATEGY=""     # set via --strategy <name>  (skips interactive prompt)
 _FLAG_TARGET=""       # set via --target <path>    (skips interactive prompt)
 _FLAG_PROJECT_NAME="" # set via --project-name <n> (skips interactive prompt)
+_FLAG_BASE_BRANCH=""  # set via --base-branch <n>  (skips interactive prompt)
 
 for arg in "$@"; do
   case "$arg" in
     --global-only)  DO_PROJECT=false ;;
     --project-only) DO_GLOBAL=false ;;
-    --rig-dir|--strategy|--target|--project-name)
+    --rig-dir|--strategy|--target|--project-name|--base-branch)
       # two-arg flags; value captured in the loop below
       ;;
     --version|-v)
@@ -171,6 +172,8 @@ for arg in "$@"; do
       echo "                        overwrite — replace everything; back up originals"
       echo "  --target <path>       Set target project directory."
       echo "  --project-name <name> Set project name (used in CLAUDE.md substitution)."
+      echo "  --base-branch <name>  Set base branch name (default: main). Substituted into"
+      echo "                        workflow examples and CLAUDE.md base-branch field."
       echo ""
       echo "Other:"
       echo "  --rig-dir <path>      Install .rig/ to an external path outside the repo."
@@ -196,6 +199,9 @@ for (( i=0; i<${#args[@]}; i++ )); do
   fi
   if [[ "${args[$i]}" == "--project-name" && $((i+1)) -lt ${#args[@]} ]]; then
     _FLAG_PROJECT_NAME="${args[$((i+1))]}"
+  fi
+  if [[ "${args[$i]}" == "--base-branch" && $((i+1)) -lt ${#args[@]} ]]; then
+    _FLAG_BASE_BRANCH="${args[$((i+1))]}"
   fi
 done
 
@@ -691,6 +697,31 @@ if [[ "$DO_PROJECT" == true ]]; then
 
   echo ""
 
+  # ── BASE BRANCH ──────────────────────────────────────────────────────────────
+  # The main integration branch for this repo (main, master, integration, etc.).
+  # Substituted into workflow examples in CLAUDE.md, processes, and commands.
+  if [[ -n "$_FLAG_BASE_BRANCH" ]]; then
+    BASE_BRANCH="$_FLAG_BASE_BRANCH"
+  else
+    # Try to auto-detect from git
+    _DETECTED_BASE=""
+    if command -v git >/dev/null 2>&1 && git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+      _DETECTED_BASE="$(git -C "$TARGET" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')"
+    fi
+    _DEFAULT_BASE="${_DETECTED_BASE:-main}"
+    ask "What is the base branch for this repo?"
+    read -r -p "    Branch [${_DEFAULT_BASE}]: " _BASE_INPUT
+    BASE_BRANCH="${_BASE_INPUT:-$_DEFAULT_BASE}"
+  fi
+  # Sanitize: letters, digits, hyphens, underscores, dots only
+  BASE_BRANCH="$(echo "$BASE_BRANCH" | tr -dc 'A-Za-z0-9._-')"
+  if [[ -z "$BASE_BRANCH" ]]; then
+    BASE_BRANCH="main"
+    warn "Invalid base branch name — defaulting to 'main'"
+  fi
+  info "Base branch: $BASE_BRANCH"
+  echo ""
+
   # ── GIT TRACKING FOR .rig/ ────────────────────────────────────────────────
   # How should .rig/ appear (or not appear) in git?
   # Bypassed when --rig-dir or --target is provided (defaults to "repo").
@@ -884,6 +915,26 @@ if [[ "$DO_PROJECT" == true ]]; then
     sed_inplace "s/\\[REPO_ROOT\\]/${ESCAPED_PATH}/g" "$TARGET_SETTINGS"
     success "Substituted [REPO_ROOT] in .claude/settings.json → $TARGET_ABS"
   fi
+
+  # Substitute [BASE_BRANCH] in CLAUDE.md, commands, and process files.
+  # Covers both inline (.claude/commands/) and external (.rig/processes/) paths.
+  _BASE_ESC="${BASE_BRANCH//\//\\/}"
+  _subst_base_branch() {
+    local f="$1"
+    [[ -f "$f" ]] || return 0
+    sed_inplace "s/\\[BASE_BRANCH\\]/${_BASE_ESC}/g" "$f"
+  }
+  _subst_base_branch "$TARGET/CLAUDE.md"
+  _subst_base_branch "$TARGET/.claude/commands/ship.md"
+  _subst_base_branch "$TARGET/.claude/commands/post-merge.md"
+  # .rig/processes/ may be in-repo or external
+  _TARGET_RIG_DIR="$TARGET/.rig"
+  if [[ "$RIG_TRACKING" == "external" || "$RIG_TRACKING" == "stealth" ]]; then
+    _TARGET_RIG_DIR="$EXTERNAL_RIG_DIR"
+  fi
+  _subst_base_branch "$_TARGET_RIG_DIR/processes/POST_MERGE_WORKFLOW.md"
+  _subst_base_branch "$_TARGET_RIG_DIR/processes/SHIP_WORKFLOW.md"
+  success "Substituted [BASE_BRANCH] → $BASE_BRANCH in workflow files"
 
   # ── EXTERNAL .rig/ — write .rigpath and update git excludes ──────────────
   if [[ "$RIG_TRACKING" == "external" || "$RIG_TRACKING" == "stealth" ]]; then

--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -48,13 +48,13 @@ git log --oneline -3
 
 Report briefly:
 
-> "Branch: `main` | Clean working tree | HEAD: `abc1234 feat: merged PR #N`"
+> "Branch: `[BASE_BRANCH]` | Clean working tree | HEAD: `abc1234 feat: merged PR #N`"
 
 **If the working tree is not clean:** surface any uncommitted changes and ask
 the user whether to stash, commit, or discard them before proceeding.
 
-**If not on `main`:** note the current branch. The POST_MERGE_WORKFLOW Step 1
-will `git checkout main && git pull`, but flag it now so the user is aware.
+**If not on `[BASE_BRANCH]`:** note the current branch. The POST_MERGE_WORKFLOW Step 1
+will `git checkout [BASE_BRANCH] && git pull`, but flag it now so the user is aware.
 
 ---
 

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -168,7 +168,7 @@ EOF
 gh pr create \
   --title "type(scope): description" \
   --body-file /tmp/ship-pr-body.md \
-  --base main \
+  --base [BASE_BRANCH] \
   --label "type: [type]" \
   --label "area: [area]"
 ```

--- a/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
+++ b/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
@@ -1,6 +1,6 @@
 # POST_MERGE_WORKFLOW
 
-> Run this immediately after a PR is merged to main.
+> Run this immediately after a PR is merged to [BASE_BRANCH].
 > Takes about 5 minutes. Keeps the system clean for the next session.
 
 ---
@@ -8,11 +8,11 @@
 ## When to follow this workflow
 
 - After the user says "merged" or confirms a PR has landed
-- After any PR merges to main, regardless of size
+- After any PR merges to [BASE_BRANCH], regardless of size
 
 ---
 
-## Step 1 — Verify state and pull latest main
+## Step 1 — Verify state and pull latest [BASE_BRANCH]
 
 First, snapshot current state:
 
@@ -27,7 +27,7 @@ before continuing (stash, commit, or discard — ask the user).
 Then pull:
 
 ```bash
-git checkout main && git pull origin main
+git checkout [BASE_BRANCH] && git pull origin [BASE_BRANCH]
 ```
 
 Confirm the expected merge commit is at HEAD:
@@ -58,7 +58,7 @@ Add an entry at the **top** of `.rig/memory/PROGRESS.md` (below the header):
 
 1. Move the completed task file: `.rig/tasks/active/TASK_[name].md` → `.rig/tasks/done/TASK_[name].md`
 2. Update its `**Status**` field to `done`
-3. Verify `.rig/tasks/active/` is clean — only `.gitkeep` should remain if all tasks are done
+3. Verify `.rig/tasks/active/` is clean — only `.gitkeep` should re[BASE_BRANCH] if all tasks are done
 
 ---
 
@@ -101,7 +101,7 @@ as part of the PR, commit them now.
 **First, read the `## Git workflow convention` field from the project `CLAUDE.md`.**
 It will be one of:
 
-- `housekeeping: direct-push` — commit and push directly to `main` (default)
+- `housekeeping: direct-push` — commit and push directly to `[BASE_BRANCH]` (default)
 - `housekeeping: pr-required` — create a short-lived branch and open a PR
 
 ### If `direct-push` (default)
@@ -109,7 +109,7 @@ It will be one of:
 ```bash
 git add .rig/memory/PROGRESS.md .rig/tasks/done/TASK_[name].md
 git commit -m "chore: post-merge housekeeping for PR #N"
-git push origin main
+git push origin [BASE_BRANCH]
 ```
 
 No branch, no PR. Done.
@@ -123,7 +123,7 @@ git commit -m "chore: post-merge housekeeping for PR #N"
 git push -u origin chore/post-merge-[N]
 gh pr create --title "chore: post-merge housekeeping for PR #N" \
   --body "Memory updates and task file move for merged PR #N." \
-  --label "type: chore" --base main
+  --label "type: chore" --base [BASE_BRANCH]
 ```
 
 ### If no changes to commit

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -201,7 +201,7 @@ EOF
 Then create the PR:
 
 ```bash
-gh pr create --title "..." --body-file /tmp/pr-body.md --base main \
+gh pr create --title "..." --body-file /tmp/pr-body.md --base [BASE_BRANCH] \
   --label "type: [type]" --label "area: [area]"
 ```
 

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -72,6 +72,17 @@
 
 ---
 
+## Base branch
+
+The repository's main integration branch. All PRs target this branch.
+`/post-merge`, `/ship`, and related workflows read this field.
+
+```
+base-branch: [BASE_BRANCH]
+```
+
+---
+
 ## Git workflow convention
 
 Controls how `/post-merge` handles housekeeping commits (PROGRESS.md updates,
@@ -83,7 +94,7 @@ housekeeping: direct-push
 
 | Value | Behaviour |
 |---|---|
-| `direct-push` | Commits and pushes directly to `main`. No branch, no PR. Default for solo projects. |
+| `direct-push` | Commits and pushes directly to `[BASE_BRANCH]`. No branch, no PR. Default for solo projects. |
 | `pr-required` | Creates a short-lived `chore/post-merge-[N]` branch and opens a PR. Use when your team requires PRs for all changes. |
 
 Change this value to match your project's branching convention.


### PR DESCRIPTION
Adds base branch configurability to the installer.

## What changes

- Installer prompts for base branch after project name (auto-detects from git, defaults to main)
- `--base-branch <name>` flag for CI/scripting
- Replaces hardcoded `main` with `[BASE_BRANCH]` in 5 template files
- Adds `## Base branch` config section to project CLAUDE.md template
- Substitution runs post-copy, covering both inline and external .rig/ paths
- Documented in docs/customizing.md

Closes #108