### PR TITLE
fix(docs): add /post-merge + /rename to command set, update counts, fix Origin section [#110]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Rig has two layers that load in sequence at every session start:
 | Rules (4) | `templates/project/.rig/rules/` | Coding standards, git conventions, security rules, verification protocol |
 | Memory system | `templates/project/.rig/memory/` | PROGRESS log, ERRORS log, DECISIONS log, CONTEXT_SNAPSHOT (session state), RIG_GAPS (self-improvement feedback) |
 | Task lifecycle | `templates/project/.rig/tasks/` | Structured task files through backlog → active → done |
-| Claude Code hooks | `templates/project/.claude/` | Pre/post-tool enforcement + 12 slash commands |
+| Claude Code hooks | `templates/project/.claude/` | Pre/post-tool enforcement + 13 slash commands |
 | Feature docs | `templates/project/docs/features/` | README index + `/doc-feature` and `/refresh-feature-doc` commands for capturing and maintaining business-critical feature knowledge |
 | Git hooks | `templates/project/.husky/` | Secret scanning (gitleaks) + AI attribution trailer stripping |
 | GitHub templates | `templates/project/.github/` | PR template + 3 issue templates |
@@ -227,7 +227,9 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 **Governance and housekeeping**
 ```
+/post-merge   →  post-merge hygiene: pull main, update memory, move task file, housekeeping commit
 /propose      →  submit a change to governance files for human approval before anything is touched
+/rename       →  derive a session name from current work and present it as a ready-to-run suggestion
 /wrap         →  write CONTEXT_SNAPSHOT, ensure memory is current, log any Rig gaps before closing
 /rig-gaps     →  compile workflow friction from RIG_GAPS.md + ERRORS.md; format for submission to The Rig dev session
 ```
@@ -269,9 +271,11 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 ## Origin
 
-The Rig was designed and refined entirely within a single project — [LaudBot](https://github.com/laudtetteh/laudbot), an AI-powered interactive resume. It grew organically as each session revealed a new failure mode. Every component exists because something went wrong without it.
+The Rig grew organically out of real project work, starting with [LaudBot](https://github.com/laudtetteh/laudbot) — an AI-powered interactive resume where each session revealed a new failure mode and prompted a new layer of scaffolding. Every component exists because something went wrong without it.
 
-The LaudBot repo history — 100+ PRs, clean conventional commits, linked issues, documented architecture — is the proof of concept.
+It was subsequently piloted on [4Culture.org](https://4culture.org), a shared-repo WordPress platform with multiple contributors. That engagement surface stealth mode, the housekeeping commit convention, and several robustness improvements to the hook system.
+
+The LaudBot repo history — 100+ PRs, clean conventional commits, linked issues, documented architecture — is the original proof of concept.
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -318,7 +318,7 @@ staged only from `.rig/tasks/done/` in a separate housekeeping commit.
 
 ## The command set
 
-Twelve slash commands covering the full development lifecycle:
+Thirteen slash commands covering the full development lifecycle:
 
 ### Project bootstrap
 | Command | Triggers | Key behaviour |
@@ -347,8 +347,10 @@ Twelve slash commands covering the full development lifecycle:
 ### Governance and housekeeping
 | Command | Triggers | Key behaviour |
 |---|---|---|
+| `/post-merge` | `POST_MERGE_WORKFLOW` | Post-merge hygiene: pull base branch, update PROGRESS, move task file, housekeeping commit, suggest session name, surface next priority |
 | `/propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
-| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, runs self-improvement check (logs Rig gaps), trims PROGRESS/ERRORS, suggests session name via `/rename`, surfaces next priority |
+| `/rename` | Session naming | Derives a session name from current PROGRESS entries and presents it as a ready-to-run suggestion — callable at any time, not just at wrap |
+| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, runs self-improvement check (logs Rig gaps), trims PROGRESS/ERRORS, suggests session name, surfaces next priority |
 | `/rig-gaps` | Self-improvement | Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats a report with submission instructions for The Rig dev session |
 | `/new-feature` | *(deprecated)* | Redirects to `/task`. Kept for backward compatibility only. |
 


### PR DESCRIPTION
Fixes multiple stale spots found in docs audit.

- **README command set**: /post-merge and /rename added under Governance and housekeeping
- **README count**: 12 -> 13 slash commands
- **README Origin**: updated to mention 4Culture.org as a second pilot alongside LaudBot
- **docs/how-it-works.md**: /post-merge and /rename added to command table; 'Twelve' -> 'Thirteen'

Closes #110