### PR TITLE
feat(ship): enforce PR and issue template detection as a hard gate

### DIFF
--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -31,6 +31,17 @@ Read the task file's `**GitHub issue**:` field.
   Say: "No GitHub issue linked. Per SHIP_WORKFLOW Step 0, the issue must exist
   before committing. Create the issue first, then update the task file."
 
+If you need to create an issue now, check for issue templates first:
+
+```bash
+ls .github/ISSUE_TEMPLATE/ 2>/dev/null
+```
+
+If templates exist, select the appropriate one (`feature.md`, `bug.md`, etc.),
+strip the YAML frontmatter (lines starting with `---`, `name:`, `about:`, `title:`,
+`labels:`, `assignees:`), and use the remaining content as the issue body. **Never
+use a freeform issue body when an issue template exists.**
+
 Do not proceed to Step 3 until a valid issue number is confirmed.
 
 ---
@@ -158,12 +169,40 @@ In this order:
 If scope changed during implementation, note it explicitly. Reviewers read the PR
 description to understand what landed, not what was intended.
 
-Use the project's PR template if one exists at `.github/pull_request_template.md`.
-Read it, fill in every section, then:
+**Template detection — this is a hard gate:**
+
+```bash
+# Check both common paths (GitHub accepts both)
+cat .github/pull_request_template.md 2>/dev/null || \
+cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || \
+cat PULL_REQUEST_TEMPLATE.md 2>/dev/null || echo ""
+```
+
+**If a PR template is found: you MUST use it. Do not write a freeform PR body.**
+Fill in every section of the template — do not leave placeholders, skip sections,
+or collapse multiple sections into one. If a section does not apply, write "N/A"
+or delete it. Never silently ignore the template.
+
+If no template exists, use this fallback:
+```
+## Summary
+
+## Changes
+-
+
+## Closes
+Closes #N
+
+## Test plan
+
+## Notes
+```
+
+Then create the PR:
 
 ```bash
 cat > /tmp/ship-pr-body.md << 'EOF'
-[filled-in PR template]
+[filled-in template or fallback]
 EOF
 gh pr create \
   --title "type(scope): description" \

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -20,6 +20,18 @@ The commit message must reference the issue number: `feat(scope): description [#
 If you create the issue after the commit, you cannot reference it honestly — the
 number belongs in the commit, not as a retroactive edit.
 
+**Check for issue templates first:**
+
+```bash
+ls .github/ISSUE_TEMPLATE/ 2>/dev/null
+```
+
+If templates exist, choose the appropriate one based on the type of work
+(`feature.md` for new features, `bug.md` for fixes, `chore.md` for maintenance).
+Strip the YAML frontmatter (everything between the `---` delimiters at the top)
+and use the template body as your issue body. **Never use a freeform issue body
+when a project issue template exists.**
+
 **First, verify the labels you need exist:**
 
 ```bash
@@ -38,6 +50,9 @@ gh label create "type: chore" --color "#e4e669" --description "Tooling and maint
 Then create the issue:
 
 ```bash
+cat > /tmp/issue-body.md << 'EOF'
+[filled-in template body, or freeform if no template exists]
+EOF
 gh issue create --title "..." --body-file /tmp/issue-body.md --label "type: feat"
 ```
 
@@ -173,17 +188,23 @@ In this order:
 If scope changed during implementation, the PR body should note it explicitly. Reviewers
 read the PR description to understand what landed, not what was intended.
 
-**First, check for a PR template:**
+**Template detection — this is a hard gate:**
 
 ```bash
-cat .github/pull_request_template.md 2>/dev/null
+# Check all common PR template paths
+cat .github/pull_request_template.md 2>/dev/null || \
+cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || \
+cat PULL_REQUEST_TEMPLATE.md 2>/dev/null
 ```
 
-If a template exists, fill in **every section** of it. Do not skip sections or
-leave placeholders. If no template exists, use this default:
+**If a template is found: you MUST use it. Never write a freeform PR body when a
+project template exists.** Fill in every section — do not leave placeholders, skip
+sections, or collapse multiple sections into one. If a section doesn't apply, write
+"N/A" or delete it.
 
-```bash
-cat > /tmp/pr-body.md << 'EOF'
+If no template exists, use this fallback:
+
+```
 ## Summary
 
 ## Changes
@@ -195,12 +216,14 @@ Closes #N
 ## Test plan
 
 ## Notes
-EOF
 ```
 
 Then create the PR:
 
 ```bash
+cat > /tmp/pr-body.md << 'EOF'
+[filled-in template or fallback]
+EOF
 gh pr create --title "..." --body-file /tmp/pr-body.md --base [BASE_BRANCH] \
   --label "type: [type]" --label "area: [area]"
 ```


### PR DESCRIPTION
## Summary
Strengthens template detection in `ship.md` and `SHIP_WORKFLOW.md` from advisory ("use the template if one exists") to a hard gate ("you MUST use it — never write freeform").

## Changes
- **`ship.md` Step 2**: adds issue template detection guidance — check `.github/ISSUE_TEMPLATE/`, strip YAML frontmatter, use template body
- **`ship.md` Step 9**: detects PR templates from 3 paths (lowercase, uppercase, root-level); explicit non-negotiable language
- **`SHIP_WORKFLOW.md` Step 0**: same issue template detection
- **`SHIP_WORKFLOW.md` Step 6**: same multi-path PR template detection + non-negotiable framing

## Closes
Closes #116

## Test plan
- [ ] Review template detection commands cover all common GitHub paths
- [ ] Language is unambiguous: template use is a gate, not a suggestion
- [ ] Frontmatter stripping guidance is clear for issue templates

## Notes
Root cause: on tableau-www, the agent bypassed an existing PR template because the old check only looked at one path and used advisory ("if one exists, fill it in") rather than directive language. This change makes bypassing the template effectively impossible without the agent explicitly acknowledging a missing template.