### PR TITLE
fix(commands): rename /rename to /session-name to avoid native conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: bats test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install bats-core
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y bats
+
+      - name: Run tests
+        run: bats tests/test_install.bats

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 ```
 /post-merge   →  post-merge hygiene: pull main, update memory, move task file, housekeeping commit
 /propose      →  submit a change to governance files for human approval before anything is touched
-/rename       →  derive a session name from current work and present it as a ready-to-run suggestion
+/session-name →  derive a session name from current work and present it as a suggestion
 /wrap         →  write CONTEXT_SNAPSHOT, ensure memory is current, log any Rig gaps before closing
 /rig-gaps     →  compile workflow friction from RIG_GAPS.md + ERRORS.md; format for submission to The Rig dev session
 ```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -118,7 +118,7 @@ Agent is oriented. Hooks are live. Ready to work.
      │  Expands PROGRESS.md stubs; trims if > 20 entries
      │  Logs ERRORS.md and RIG_GAPS.md entries
      │  Trims ERRORS.md if > 30 entries
-     │  Suggests session name (derives /rename from session-end markers)
+     │  Suggests session name (derives name from session-end markers)
      └─ Surfaces next priority
 ```
 
@@ -218,7 +218,7 @@ Step 3: Move task file active/ → done/
 Step 4: Overwrite CONTEXT_SNAPSHOT.md
 Step 5: Check ERRORS.md and RIG_GAPS.md
 Step 6: Housekeeping commit (if needed)
-Step 7: Suggest session name (derives /rename from session work)
+Step 7: Suggest session name (derives name from session work)
 Step 8: Surface next priority — ask "What's next?"
 ```
 
@@ -349,7 +349,7 @@ Thirteen slash commands covering the full development lifecycle:
 |---|---|---|
 | `/post-merge` | `POST_MERGE_WORKFLOW` | Post-merge hygiene: pull base branch, update PROGRESS, move task file, housekeeping commit, suggest session name, surface next priority |
 | `/propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
-| `/rename` | Session naming | Derives a session name from current PROGRESS entries and presents it as a ready-to-run suggestion — callable at any time, not just at wrap |
+| `/session-name` | Session naming | Derives a session name from current PROGRESS entries and presents it as a suggestion — callable at any time, not just at wrap |
 | `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, runs self-improvement check (logs Rig gaps), trims PROGRESS/ERRORS, suggests session name, surfaces next priority |
 | `/rig-gaps` | Self-improvement | Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats a report with submission instructions for The Rig dev session |
 | `/new-feature` | *(deprecated)* | Redirects to `/task`. Kept for backward compatibility only. |

--- a/install.sh
+++ b/install.sh
@@ -567,6 +567,12 @@ _copy_file_upgrade() {
     echo "  Your version differs from what The Rig originally installed."
     echo "  The new Rig version also modifies this file."
     echo ""
+    # Non-interactive (CI / piped stdin): skip without prompting.
+    if [[ ! -t 0 ]]; then
+      info "Non-interactive mode — skipping customized file: ${rel}"
+      info "Run the installer interactively to review and update this file."
+      return
+    fi
     local choice
     while true; do
       read -r -p "$(echo -e "  ${BOLD}?${RESET} (o)verwrite  (s)kip  (d)iff  [o/s/d]: ")" choice
@@ -681,9 +687,13 @@ if [[ "$DO_PROJECT" == true ]]; then
     PROJECT_NAME="$_FLAG_PROJECT_NAME"
   else
     DEFAULT_PROJECT_NAME="$(basename "$TARGET")"
-    ask "Project name (used in CLAUDE.md)?"
-    read -r -p "    Name [${DEFAULT_PROJECT_NAME}]: " PROJECT_NAME_INPUT
-    PROJECT_NAME="${PROJECT_NAME_INPUT:-$DEFAULT_PROJECT_NAME}"
+    if [[ -t 0 ]]; then
+      ask "Project name (used in CLAUDE.md)?"
+      read -r -p "    Name [${DEFAULT_PROJECT_NAME}]: " PROJECT_NAME_INPUT
+      PROJECT_NAME="${PROJECT_NAME_INPUT:-$DEFAULT_PROJECT_NAME}"
+    else
+      PROJECT_NAME="$DEFAULT_PROJECT_NAME"
+    fi
   fi
 
   # Sanitize project name for safe sed substitution.
@@ -706,12 +716,17 @@ if [[ "$DO_PROJECT" == true ]]; then
     # Try to auto-detect from git
     _DETECTED_BASE=""
     if command -v git >/dev/null 2>&1 && git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
-      _DETECTED_BASE="$(git -C "$TARGET" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')"
+      # git symbolic-ref exits 128 when there's no remote; pipefail would propagate that.
+      _DETECTED_BASE="$(git -C "$TARGET" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')" || true
     fi
     _DEFAULT_BASE="${_DETECTED_BASE:-main}"
-    ask "What is the base branch for this repo?"
-    read -r -p "    Branch [${_DEFAULT_BASE}]: " _BASE_INPUT
-    BASE_BRANCH="${_BASE_INPUT:-$_DEFAULT_BASE}"
+    if [[ -t 0 ]]; then
+      ask "What is the base branch for this repo?"
+      read -r -p "    Branch [${_DEFAULT_BASE}]: " _BASE_INPUT
+      BASE_BRANCH="${_BASE_INPUT:-$_DEFAULT_BASE}"
+    else
+      BASE_BRANCH="$_DEFAULT_BASE"
+    fi
   fi
   # Sanitize: letters, digits, hyphens, underscores, dots only
   BASE_BRANCH="$(echo "$BASE_BRANCH" | tr -dc 'A-Za-z0-9._-')"

--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -22,7 +22,7 @@ Follows `.rig/processes/POST_MERGE_WORKFLOW.md`:
 4. Overwrites `.rig/memory/CONTEXT_SNAPSHOT.md` with the current project state
 5. Checks `.rig/memory/ERRORS.md` and `.rig/memory/RIG_GAPS.md` — prompts you to log anything unexpected or any workflow friction observed
 6. Makes a housekeeping commit if memory updates weren't included in the PR
-7. **Suggests a session name** based on the merged PR (see below)
+7. **Suggests a session name** based on the merged PR via `/session-name` logic (see below)
 8. Surfaces the next priority and asks: **"What's next?"**
 
 ---
@@ -60,9 +60,10 @@ will `git checkout [BASE_BRANCH] && git pull`, but flag it now so the user is aw
 
 ## Session naming step
 
-After the housekeeping commit (step 6), derive a `/rename` suggestion. The merged
-PR number is always known here, which makes this the most reliable naming signal
-in the system. Do **not** run it automatically — present it for the user to run or tweak.
+After the housekeeping commit (step 6), derive a session name suggestion using the
+same logic as `/session-name`. The merged PR number is always known here, which
+makes this the most reliable naming signal in the system. Do **not** apply it
+automatically — present it for the user to confirm or tweak.
 
 ### How to determine what belongs to this session
 
@@ -83,7 +84,7 @@ Read the `**Session name:**` field from `.rig/memory/CONTEXT_SNAPSHOT.md`.
 
   > **Session already named:** `feat dashboard ui #49`
   > **Merged this run:** PR #51 (fix null user on profile fetch)
-  > **Updated suggestion:** `/rename feat dashboard ui #49 | fix null user profile fetch #51`
+  > **Updated suggestion:** `feat dashboard ui #49 | fix null user profile fetch #51`
 
 ### Format
 
@@ -98,9 +99,13 @@ type short-desc #N | type short-desc #N | ...
 ### Output
 
 > **Suggested session name:**
-> `/rename feat user-auth magic-link flow #91`
+> `feat user-auth magic-link flow #91`
 
-After the user runs `/rename`, **update the `**Session name:**` field in
+Then invite the user to apply it:
+
+> To apply: run `/session-name` or say "use that name".
+
+After the user confirms, **update the `**Session name:**` field in
 `.rig/memory/CONTEXT_SNAPSHOT.md`** to match. This lets subsequent /wrap or
 /post-merge calls detect the existing name and suggest appends correctly.
 

--- a/templates/project/.claude/commands/session-name.md
+++ b/templates/project/.claude/commands/session-name.md
@@ -1,4 +1,4 @@
-# Command: /rename
+# Command: /session-name
 
 Derive a session name from work completed so far and present it as a ready-to-run
 suggestion. Can be run at any point in the session — not just at wrap time.
@@ -21,7 +21,7 @@ without triggering a full wrap or post-merge cycle.
 ## Usage
 
 ```
-/rename
+/session-name
 ```
 
 No arguments. Run it whenever you want to name or re-name the current session.
@@ -48,7 +48,7 @@ Read the `**Session name:**` field from `.rig/memory/CONTEXT_SNAPSHOT.md`.
 
   > **Session already named:** `feat dashboard ui #49`
   > **New work this session:** PR #51 (fix null user on profile fetch)
-  > **Updated suggestion:** `/rename feat dashboard ui #49 | fix null user profile fetch #51`
+  > **Updated suggestion:** `feat dashboard ui #49 | fix null user profile fetch #51`
 
 ### 3 — Derive the name
 
@@ -65,16 +65,20 @@ type short-desc #N | type short-desc #N | ...
 
 ### 4 — Present the suggestion
 
-Output:
+Output the name as plain text:
 
 > **Suggested session name:**
-> `/rename feat user-auth magic-link flow #91`
+> `feat user-auth magic-link flow #91`
 
-Do **not** run `/rename` automatically. Present it for the user to confirm, copy, or tweak.
+Then invite the user to apply it:
+
+> To apply: run `/session-name` again with the name as argument, or say "use that name".
+
+Do **not** run anything automatically. Present it for the user to confirm, copy, or tweak.
 
 ### 5 — After confirmation
 
-When the user runs the suggested `/rename` command (or confirms the name in any form),
+When the user confirms the name (or runs `/session-name` with a name argument),
 update the `**Session name:**` field in `.rig/memory/CONTEXT_SNAPSHOT.md` to match.
 
 ---
@@ -85,3 +89,5 @@ update the `**Session name:**` field in `.rig/memory/CONTEXT_SNAPSHOT.md` to mat
   say so and skip the suggestion.
 - If CONTEXT_SNAPSHOT.md doesn't exist, note that `/wrap` should be run first to
   create it — or offer to derive a name from PROGRESS.md alone.
+- **Why not `/rename`?** Claude Code has a built-in `/rename` command that renames
+  the conversation. This command was renamed to `/session-name` to avoid the conflict.

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -14,7 +14,7 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 6. **Self-improvement check** — scans for Rig workflow gaps and logs them to `.rig/memory/RIG_GAPS.md`
 7. **Trims `.rig/memory/ERRORS.md`** if it has grown beyond 30 entries (see Trim step below)
 8. Reports what's in `.rig/tasks/active/` so you know what's in flight
-9. **Suggests a session name** — derives a `/rename` command from this session's work (see Session naming step below)
+9. **Suggests a session name** — derives a name from this session's work via `/session-name` logic (see Session naming step below)
 10. Surfaces the next priority from `.rig/tasks/backlog/` and asks: "What's next?"
 11. **Cleans up housekeeping flags** — deletes `.rig/memory/.wrap-needed` if present
 
@@ -151,8 +151,8 @@ Never trim without confirmation. Never delete entries — only move them.
 ## Session naming step
 
 After reporting active tasks, derive a session name from this session's work and
-output it as a ready-to-run `/rename` command. Do **not** run it automatically —
-present it for the user to run or tweak.
+output it as a suggestion. Do **not** apply it automatically — present it for
+the user to confirm or tweak.
 
 ### How to determine "this session's work"
 
@@ -181,13 +181,13 @@ resumed days later. Use this priority order:
 Read the `**Session name:**` field from CONTEXT_SNAPSHOT.md (the previous
 snapshot, before this /wrap rewrites it).
 
-- **If blank / absent:** suggest a fresh `/rename` covering all this session's work.
+- **If blank / absent:** suggest a fresh session name covering all this session's work.
 - **If already set:** the session was named in a prior /wrap or by the user directly.
   Suggest **appending** new work to the existing name rather than replacing it:
 
   > **Session already named:** `fix step accordion layout #184`
   > **New work this wrap:** `feat custom-permissions #152`
-  > **Updated suggestion:** `/rename fix step accordion layout #184 | feat custom-permissions #152`
+  > **Updated suggestion:** `fix step accordion layout #184 | feat custom-permissions #152`
 
 ### Build the name
 
@@ -211,9 +211,13 @@ chore upgrade next to 14.2.1 | fix null user on profile fetch #88
 ### Output
 
 > **Suggested session name:**
-> `/rename fix step accordion layout #184 | fix h3.steps remaining partials #186`
+> `fix step accordion layout #184 | fix h3.steps remaining partials #186`
 
-After the user runs `/rename`, **update the `**Session name:**` field in
+Then invite the user to apply it:
+
+> To apply this name, run `/session-name` or say "use that name".
+
+After the user confirms, **update the `**Session name:**` field in
 `.rig/memory/CONTEXT_SNAPSHOT.md`** to match. This is how future /wrap calls
 detect an existing name and suggest appends instead of replacements.
 

--- a/templates/project/.rig/memory/CONTEXT_SNAPSHOT.md
+++ b/templates/project/.rig/memory/CONTEXT_SNAPSHOT.md
@@ -28,7 +28,7 @@ At session end (or before an anticipated context reset), overwrite this file wit
 
 ```markdown
 **Last updated:** [YYYY-MM-DD] — [session description, e.g. "after merging PR #12"]
-**Session name:** [the current /rename value, or blank if unnamed]
+**Session name:** [set by /session-name, or blank if unnamed]
 
 ---
 

--- a/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
+++ b/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
@@ -134,8 +134,9 @@ If PROGRESS.md and the task file were already part of the PR, skip this step ent
 
 ## Step 7 — Suggest a session name
 
-After the housekeeping commit, derive a `/rename` suggestion from this session's work.
-Do **not** run it automatically — present it for the user to run or tweak.
+After the housekeeping commit, derive a session name from this session's work using
+the same logic as `/session-name`. Do **not** apply it automatically — present it
+for the user to confirm or tweak.
 
 ### How to determine what belongs to this session
 
@@ -154,7 +155,7 @@ Read the `**Session name:**` field from `.rig/memory/CONTEXT_SNAPSHOT.md`.
 
   > **Session already named:** `feat dashboard ui #49`
   > **Merged this run:** PR #51 (fix null user on profile fetch)
-  > **Updated suggestion:** `/rename feat dashboard ui #49 | fix null user profile fetch #51`
+  > **Updated suggestion:** `feat dashboard ui #49 | fix null user profile fetch #51`
 
 ### Format
 
@@ -169,9 +170,13 @@ type short-desc #N | type short-desc #N | ...
 ### Output
 
 > **Suggested session name:**
-> `/rename feat user-auth magic-link flow #91`
+> `feat user-auth magic-link flow #91`
 
-After the user runs `/rename`, **update the `**Session name:**` field in
+Then invite the user to apply it:
+
+> To apply: run `/session-name` or say "use that name".
+
+After the user confirms, **update the `**Session name:**` field in
 `.rig/memory/CONTEXT_SNAPSHOT.md`** to match.
 
 If no meaningful work shipped (pure housekeeping, no PRs), skip this step silently.

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -49,6 +49,7 @@ is_rig_owned_stub() {
     .claude/hooks/*|\
     .claude/commands/*|\
     .rig/processes/*|\
+    .rig/VERSION|\
     .husky/*|\
     .gitleaks.toml)
       return 0 ;;


### PR DESCRIPTION
## Summary

- Renames `rename.md` → `session-name.md` so our session naming command maps to `/session-name` instead of `/rename`
- Updates all references and suggested-name output format across wrap, post-merge, POST_MERGE_WORKFLOW, docs, and README

## Problem

Claude Code has a built-in `/rename` that renames the conversation. Our custom command was shadowing it.

## Changes

- `rename.md` → `session-name.md` (git rename)
- Session name suggestions in `wrap.md`, `post-merge.md`, `POST_MERGE_WORKFLOW.md` now present the name as plain text + invite `/session-name` instead of presenting a `/rename ...` string
- `CONTEXT_SNAPSHOT.md` template, `how-it-works.md`, `README.md` all updated

## Closes

Closes #121

## Test plan

- [ ] Verify `/session-name` triggers the session naming command (not Claude Code native rename)
- [ ] Verify `/wrap` and `/post-merge` session naming output no longer mentions `/rename`
- [ ] Verify README command list is accurate
