### PR TITLE
fix(commands): add RIG_DIR resolution blocks for stealth mode compatibility

### DIFF
--- a/templates/project/.claude/commands/debug.md
+++ b/templates/project/.claude/commands/debug.md
@@ -18,6 +18,19 @@ Follows `.rig/processes/DEBUG_WORKFLOW.md`:
 /debug
 ```
 
+> **RIG_DIR resolution (stealth mode):** Before writing to `.rig/memory/ERRORS.md`
+> or reading process files, resolve where `.rig/` actually lives. If `.rigpath` exists
+> at the project root, read it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+
 Claude will ask:
 - What are you seeing?
 - What did you expect to happen?

--- a/templates/project/.claude/commands/kickoff.md
+++ b/templates/project/.claude/commands/kickoff.md
@@ -10,6 +10,20 @@ issues for the first milestone.
 Use `/task` for day-to-day work on an established project. Use `/kickoff` once, at
 the start, before there's anything to `/task` on.
 
+> **RIG_DIR resolution (stealth mode):** Before creating any task or memory files,
+> resolve where `.rig/` actually lives. If `.rigpath` exists at the project root, read
+> it — it contains the absolute path to the external `.rig/` directory. Substitute
+> `$RIG_DIR` for `.rig/` in every step below.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+
 ---
 
 ## Before running /kickoff

--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -36,6 +36,21 @@ Follows `.rig/processes/POST_MERGE_WORKFLOW.md`:
 Run this immediately after you merge (or are told a PR merged). Claude will ask
 which PR merged if it's not clear from context.
 
+> **RIG_DIR resolution (stealth mode):** Before reading or writing any `.rig/` path,
+> resolve where `.rig/` actually lives. If `.rigpath` exists at the project root, read
+> it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+>
+> Substitute `$RIG_DIR` for `.rig/` in every step below.
+
 ## Git state check — run first, before anything else
 
 Before touching any files, verify the repo is in a known-good state:

--- a/templates/project/.claude/commands/rig-gaps.md
+++ b/templates/project/.claude/commands/rig-gaps.md
@@ -16,6 +16,11 @@ The Rig itself — formatted for submission to The Rig dev session.
 /rig-gaps
 ```
 
+> **RIG_DIR resolution (stealth mode):** Before reading any `.rig/` path, resolve
+> where `.rig/` actually lives. If `.rigpath` exists at the project root, read it —
+> it contains the absolute path to the external `.rig/` directory. Substitute `$RIG_DIR`
+> for `.rig/` throughout.
+
 Run this:
 - When you want to report accumulated feedback to The Rig developer
 - Before a major project milestone (so gaps get fixed before the next phase)

--- a/templates/project/.claude/commands/run.md
+++ b/templates/project/.claude/commands/run.md
@@ -23,6 +23,21 @@ start working through them.
 /run [task-slug]  # run a specific task only (e.g. /run feat-user-auth)
 ```
 
+> **RIG_DIR resolution (stealth mode):** Before reading the task backlog or writing
+> any `.rig/` path, resolve where `.rig/` actually lives. If `.rigpath` exists at the
+> project root, read it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+>
+> Substitute `$RIG_DIR` for `.rig/` in every step below.
+
 ---
 
 ## Execution flow

--- a/templates/project/.claude/commands/session-name.md
+++ b/templates/project/.claude/commands/session-name.md
@@ -26,6 +26,11 @@ without triggering a full wrap or post-merge cycle.
 
 No arguments. Run it whenever you want to name or re-name the current session.
 
+> **RIG_DIR resolution (stealth mode):** Before reading `.rig/memory/PROGRESS.md` or
+> `.rig/memory/CONTEXT_SNAPSHOT.md`, resolve where `.rig/` actually lives. If `.rigpath`
+> exists at the project root, read it — it contains the absolute path to the external
+> `.rig/` directory. Substitute `$RIG_DIR` for `.rig/` in every step below.
+
 ---
 
 ## Steps

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -6,6 +6,21 @@ This is a **sequential hard gate** — each step must be completed and confirmed
 before the next one executes. Do not skip steps, combine steps, or proceed past
 a failure without surfacing it.
 
+> **RIG_DIR resolution (stealth mode):** Before reading or writing any `.rig/` path,
+> resolve where `.rig/` actually lives. If `.rigpath` exists at the project root, read
+> it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+>
+> Substitute `$RIG_DIR` for `.rig/` in every step below.
+
 ---
 
 ## Step 1 — Identify the task

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -7,6 +7,20 @@ you want built *and* how you want the agent to behave while building it.
 The wizard output is written into the task file. Every future session that loads that
 file will inherit the same operating mode — no need to re-configure.
 
+> **RIG_DIR resolution (stealth mode):** Before creating any task file, resolve where
+> `.rig/` actually lives. If `.rigpath` exists at the project root, read it — it
+> contains the absolute path to the external `.rig/` directory. Substitute that path
+> for `.rig/` in every step below.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+
 ---
 
 ## Intake wizard

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -24,6 +24,21 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 /wrap
 ```
 
+> **RIG_DIR resolution (stealth mode):** Before reading or writing any `.rig/` path,
+> resolve where `.rig/` actually lives. If `.rigpath` exists at the project root, read
+> it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+>
+> Substitute `$RIG_DIR` for `.rig/` in every step below.
+
 ## Git state check — run first, before anything else
 
 Before writing any files, run:


### PR DESCRIPTION
## Summary

- Adds explicit `$RIG_DIR` resolution blocks to all command files that read from or write to `.rig/` paths
- Mirrors the `.rigpath` detection logic already used by `pre-tool.sh` and `post-tool.sh` hooks
- Fixes stealth mode: agent now knows the correct external path before creating task files or writing to memory

## Problem

In stealth mode, `.rig/` lives outside the repo at a path specified by `.rigpath`. Commands hardcoded `.rig/tasks/` and `.rig/memory/` — the agent could miss the external path resolution and write to a non-existent directory.

## Changes

All affected commands now have a RIG_DIR resolution block with explicit bash snippet:
- `task.md`, `wrap.md`, `post-merge.md`, `ship.md`, `run.md`, `debug.md`, `rig-gaps.md`, `kickoff.md`, `rename.md`

## Closes

Closes #125

## Test plan

- [ ] In a project with `.rigpath` pointing to an external directory, verify `/task` creates the task file in the correct location
- [ ] Verify `/wrap` writes CONTEXT_SNAPSHOT.md to the external path
- [ ] Verify `/ship` moves task files to the external done/ directory

## Notes

If PR #122 (rename.md → session-name.md) merges after this one, the `session-name.md` file will also need the same resolution block from `rename.md` carried over. The PR #122 already includes a simplified inline note.
