### PR TITLE
feat(workflows): branch confirmation, stale-main detection, post-batch audit

### DIFF
--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -67,6 +67,52 @@ continuing.
 
 ---
 
+## Step 3.5 — Branch check
+
+Verify the repo is in a clean state before committing.
+
+```bash
+git branch --show-current
+git status --short
+```
+
+**If on `main` or `master`:** stop — you cannot commit directly here. Ask:
+> "You're on `main`. Which branch should this go on? I can create `[type/slug]` off `[BASE]`."
+Wait for the user's answer. Before creating the branch, run the stale-main check below.
+
+**Read the configured base branch:**
+```bash
+BASE=$(grep "^base-branch:" CLAUDE.md 2>/dev/null | awk '{print $2}' | tr -d '[:space:]')
+BASE="${BASE:-main}"
+```
+
+**Stale-main check — run before creating a new branch or opening a PR:**
+```bash
+git fetch origin "$BASE" --quiet 2>/dev/null || true
+AHEAD=$(git rev-list HEAD..origin/"$BASE" --count 2>/dev/null || echo 0)
+```
+
+If `AHEAD > 0`, the base branch has new commits your branch doesn't have:
+
+- **Low/Medium autonomy:**
+  > "`origin/$BASE` is $AHEAD commit(s) ahead. Rebase before opening the PR? [yes / no]"
+  If yes: `git rebase origin/"$BASE"`. Fix any conflicts before proceeding.
+
+- **High autonomy:** auto-rebase silently:
+  ```bash
+  git rebase origin/"$BASE"
+  ```
+  Note the rebase in your next message.
+
+If `git fetch` fails (no network, no remote configured): skip and note it.
+
+**Branch creation — Low/Medium autonomy only:**
+If creating a new branch right now, confirm the base before running `git checkout -b`:
+> "I'll create `[branch-name]` off `$BASE`. Is that the right base?"
+Wait for confirmation. High autonomy: state the base and proceed immediately.
+
+---
+
 ## Step 4 — Pre-ship checklist
 
 Work through the following. Report the result of each check:
@@ -216,12 +262,29 @@ Report the PR URL.
 
 ---
 
+## Post-batch audit (after every group of related PRs)
+
+After the last PR in a batch of 2+ related changes opens (or merges), run this checklist:
+
+- [ ] Tests pass on main
+- [ ] CLI help text matches new behavior
+- [ ] `README.md` and `docs/how-it-works.md` reflect any new commands or behavior
+- [ ] `CHANGELOG.md` has entries for all PRs in the batch
+- [ ] Inline comments are consistent with what the code actually does
+- [ ] Run `/wrap` to write `CONTEXT_SNAPSHOT.md` before starting the next group
+
+This is not needed after every single commit — it's a batch-level checkpoint.
+See `SHIP_WORKFLOW.md` Post-batch audit for full details.
+
+---
+
 ## Notes
 
 - Steps 1–6 are **gates** — any failure stops the sequence entirely.
 - The GitHub issue (Step 2) must exist before `/ship` is run, not after.
 - Labels (Step 3) must be verified against the actual repo — never assumed.
 - The local testing pause (Step 5) is non-negotiable regardless of autonomy level.
+- The branch check (Step 3.5) is also a gate — never commit directly to main.
 - If the task has multiple commits, summarise all changes in the PR body.
 - The task file is moved to `.rig/tasks/done/` only after a successful commit (Step 8).
 - The PR body (Step 9) must reflect what was actually built — not the original plan.

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -130,6 +130,9 @@ Wait for explicit go-ahead before proceeding.
 - Present the implementation plan and wait for explicit approval.
 - Before each file write, state what you're about to do and why. Wait for "ok" or "go".
 - After each file write, show a summary of what changed.
+- **Branch creation:** always confirm which base branch to branch off before running
+  `git checkout -b`. Read `base-branch:` from `CLAUDE.md`; present it and wait for
+  the user to confirm or specify a different base.
 
 **Medium (Supervised)**
 - Present the implementation plan and wait for explicit approval.
@@ -137,6 +140,7 @@ Wait for explicit go-ahead before proceeding.
 - Narrate progress at milestones (plan → implementation → tests → PR-ready).
 - Pause if: an unexpected file needs changing, a dependency must be added, a decision
   branches into two reasonable approaches.
+- **Branch creation:** confirm the base branch before running `git checkout -b`.
 
 **High (Autonomous)**
 - Present the implementation plan; wait for approval (one pause only).
@@ -144,6 +148,8 @@ Wait for explicit go-ahead before proceeding.
 - Only pause for irreversible actions: DB migrations, deleting files, force pushes,
   publishing to external services.
 - Log all decisions in `## Prompt history` of the task file.
+- **Branch creation:** read `base-branch:` from `CLAUDE.md`, state the base you're
+  using ("Creating `[branch-name]` off `[BASE]`"), then branch immediately — no wait.
 
 ### Governance always applies
 

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -43,6 +43,22 @@ git rev-parse --show-toplevel
 - All `git` commands must target the main repo: `git -C <repo-root> <command>`
 - Never create branches, commits, or files inside the `.claude/worktrees/` path
 
+### 1a — Stale-main pre-check (before creating any branch)
+
+Before creating a new branch for this task, verify main hasn't advanced since your last pull:
+
+```bash
+BASE=$(grep "^base-branch:" CLAUDE.md 2>/dev/null | awk '{print $2}' | tr -d '[:space:]')
+BASE="${BASE:-main}"
+git fetch origin "$BASE" --quiet 2>/dev/null || true
+AHEAD=$(git rev-list HEAD..origin/"$BASE" --count 2>/dev/null || echo 0)
+```
+
+**If AHEAD > 0:** main has new commits. Pull before branching — otherwise the new branch
+diverges from current main and may re-introduce already-merged code.
+
+For the full protocol (what to do at each autonomy level), see `SHIP_WORKFLOW.md` Step 3b.
+
 ---
 
 ## Step 2 — Orient

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -113,15 +113,66 @@ git branch --show-current
 git status --short
 ```
 
-**If you are on `main` or `master`:** do not commit. Say:
-> "You're on `main` — I can't commit directly here. Which branch should I use?
-> I can create `feat/[slug]` off main, or use an existing branch."
-Wait for the user's answer before proceeding.
-
-**If you are on any other branch:** proceed. Briefly confirm: `"Branch: [name] — looks good."`
+**If you are on `main` or `master`:** do not commit. You need a feature branch —
+see Step 3c below for how to create one safely.
 
 **If there are untracked or modified files outside the task scope** (shown by `git status`):
 surface them and ask whether to stage, stash, or ignore before continuing.
+
+---
+
+### 3a — Read the configured base branch
+
+Read the `base-branch:` field from `CLAUDE.md` in the project root.
+If absent, default to `main`.
+
+```bash
+BASE=$(grep "^base-branch:" CLAUDE.md 2>/dev/null | awk '{print $2}' | tr -d '[:space:]')
+BASE="${BASE:-main}"
+```
+
+---
+
+### 3b — Stale-main check (run before creating any new branch)
+
+```bash
+git fetch origin "$BASE" --quiet 2>/dev/null || true
+AHEAD=$(git rev-list HEAD..origin/"$BASE" --count 2>/dev/null || echo 0)
+```
+
+**If AHEAD > 0:**
+
+- **Low/Medium autonomy** — warn and pause:
+  > "`origin/$BASE` is $AHEAD commit(s) ahead of your current position.
+  > Rebase onto the latest before branching? [yes / no — branch anyway]"
+  Wait for the user's answer. If yes: `git checkout "$BASE" && git pull`.
+
+- **High autonomy** — auto-update and note it:
+  ```bash
+  git checkout "$BASE" && git pull
+  ```
+  > "Pulled latest $BASE ($AHEAD new commit(s)) before branching."
+
+**If AHEAD == 0:** already up to date — proceed silently.
+
+> If `git fetch` fails (no network, no remote): skip the check and proceed.
+> Note: "Stale-main check skipped — fetch failed."
+
+---
+
+### 3c — Confirm base branch before creating a new branch
+
+**Only applies when creating a new branch** (i.e., you are on `main` or creating a fresh branch
+for this task). Skip this step if you are already on a suitable feature branch.
+
+- **Low/Medium autonomy** — ask before branching:
+  > "I'll create `[branch-name]` off `$BASE`. Is that the right base?
+  > [yes / specify a different base]"
+  Wait for confirmation. Do not run `git checkout -b` until confirmed.
+
+- **High autonomy** — surface and proceed:
+  > "Creating `[branch-name]` off `$BASE`."
+  Run `git checkout -b [branch-name]` without waiting.
 
 ---
 
@@ -245,3 +296,25 @@ git commit -m "chore: post-task housekeeping [#N]"
 ```
 
 This commit goes on the same PR branch before the PR is merged.
+
+---
+
+## Post-batch audit
+
+Run this checklist after every group of related PRs merges — not after every single commit.
+Trigger: the last PR in a batch of 2+ related changes lands on main, or any single PR
+touched multiple systems (e.g. both install.sh and command files).
+
+**Checklist:**
+
+- [ ] **Tests pass** — all bats/unit/integration tests green on main after the merge
+- [ ] **CLI help text accurate** — any new behavior is reflected in `--help` output and flag descriptions
+- [ ] **Docs updated** — `README.md`, `docs/how-it-works.md`, and feature docs reflect new commands or changed behavior
+- [ ] **CHANGELOG.md updated** — entries present for all PRs in the batch
+- [ ] **Comments consistent** — inline code comments match what the code actually does (stale comments are technical debt)
+- [ ] **CONTEXT_SNAPSHOT and PROGRESS current** — run `/wrap` to lock in the batch's state before starting the next group
+
+**Log the result:** a brief line in `.rig/memory/PROGRESS.md` is sufficient —
+e.g. "Post-batch audit passed — batch: PRs #117, #122, #124, #126"
+
+If anything fails the checklist, fix it before starting the next task group.


### PR DESCRIPTION
## Summary

Three workflow improvements to reduce divergence and context drift in multi-PR sessions, implementing the improvements requested by the user after observing the pain points in the recent PRs #117–#126 batch.

## Changes

**Branch confirmation based on autonomy level (#127)**
- `task.md`: Low/Medium autonomy must confirm the base branch before `git checkout -b`; High autonomy states the base and proceeds immediately — all three levels read `base-branch:` from `CLAUDE.md`
- `SHIP_WORKFLOW.md` Step 3c: formalises the confirm protocol as a sub-step
- `ship.md` Step 3.5 (new): branch/base verification gate at ship time

**Stale-main detection before branching (#128)**
- `NEW_TASK_WORKFLOW.md` Step 1a (new): `git fetch + rev-list` check before any branch creation; if main is ahead, Low/Med prompts; High auto-rebases
- `SHIP_WORKFLOW.md` Step 3b (new): same check with autonomy-parameterized behaviour at ship time (catches rebase needs before PR open)
- `ship.md` Step 3.5: also covers stale-main at commit/PR time

**Mandatory post-batch audit (#129)**
- `SHIP_WORKFLOW.md`: new **Post-batch audit** section with a checklist (tests pass, CLI help text accurate, docs/CHANGELOG updated, comments consistent, CONTEXT_SNAPSHOT current)
- `ship.md`: matching compact checklist block after Step 9 with reference to full details

## Closes

Closes #127
Closes #128
Closes #129

## Test plan

- [ ] All 54 bats tests pass (no code changes — markdown only)
- [ ] Verify `ship.md` Step 3.5 reads coherently with the existing steps
- [ ] Verify `SHIP_WORKFLOW.md` Step 3 sub-steps (3a/3b/3c) flow logically

## Notes

These are workflow/process file changes only — no install.sh or test changes.
The stale-main check guards with `|| true` so it never breaks in environments without a remote.
