### PR TITLE
docs: reframe commit-msg hook language — footers not attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Rig has two layers that load in sequence at every session start:
 │  .rig/memory/       ← PROGRESS, ERRORS, DECISIONS, SNAPSHOT      │
 │  .rig/tasks/        ← active / backlog / done lifecycle         │
 │  .claude/           ← hook wiring + slash commands              │
-│  .husky/            ← secret scanning + AI trailer stripping    │
+│  .husky/            ← secret scanning + tool footer cleanup     │
 │  .github/           ← PR template + issue templates             │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -68,7 +68,7 @@ The Rig has two layers that load in sequence at every session start:
 | Task lifecycle | `templates/project/.rig/tasks/` | Structured task files through backlog → active → done |
 | Claude Code hooks | `templates/project/.claude/` | Pre/post-tool enforcement + 13 slash commands |
 | Feature docs | `templates/project/docs/features/` | README index + `/doc-feature` and `/refresh-feature-doc` commands for capturing and maintaining business-critical feature knowledge |
-| Git hooks | `templates/project/.husky/` | Secret scanning (gitleaks) + AI attribution trailer stripping |
+| Git hooks | `templates/project/.husky/` | Secret scanning (gitleaks) + auto-injected tool footer removal |
 | GitHub templates | `templates/project/.github/` | PR template + 3 issue templates |
 | Installer | `install.sh` | Interactive setup script — handles both layers |
 | CI | `.github/workflows/ci.yml` | Runs bats test suite on every push and PR |
@@ -248,7 +248,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 | `post-tool.sh` | After every Claude Code tool call | PROGRESS.md being skipped after a commit; clears commit sentinel after use |
 | `stop.sh` | When the agent finishes its final response | CONTEXT_SNAPSHOT going stale — updates `Last updated:` and appends a session-end boundary to PROGRESS.md without requiring `/wrap` |
 | `pre-commit` | Before every git commit | Secrets reaching the repository |
-| `commit-msg` + `post-commit` | On every git commit | AI attribution trailers (`Co-Authored-By: Claude`, etc.) in history |
+| `commit-msg` + `post-commit` | On every git commit | Auto-injected tool footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.) from embedding in commit messages — keeps history clean |
 
 ---
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -288,11 +288,16 @@ via `prepare` script in `package.json`.
 
 ---
 
-## Disabling the AI trailer stripping
+## Keeping tool attribution footers in commits
 
-If you want co-author credits to appear in your history (e.g., you're building a team
-project where attribution matters), comment out or remove the `commit-msg` and
-`post-commit` hooks from `.husky/`.
+By default, The Rig strips auto-injected footers (`Co-Authored-By: Claude`,
+`Made-with-Claude`, etc.) from commit messages. These lines are inserted automatically
+by AI coding tools — The Rig removes them so commit messages stay clean and reflect
+what the human author wrote.
+
+If you want these footers to remain (e.g. your team has a policy of crediting AI tools
+in commit history), comment out or remove the `commit-msg` and `post-commit` hooks
+from `.husky/`.
 
 The `pre-commit` (gitleaks) is independent and unaffected.
 

--- a/templates/project/.husky/commit-msg
+++ b/templates/project/.husky/commit-msg
@@ -1,8 +1,10 @@
 #!/bin/sh
 # commit-msg
 #
-# Strips AI-generated attribution trailers from the commit message
-# before it is written to the repository.
+# Strips auto-injected tool footers from commit messages before they are
+# written to the repository — keeps history clean and human-authored in tone.
+# Remove this hook if you want tool footers (Co-Authored-By, Made-with-Claude, etc.)
+# to remain in your commit history.
 #
 # Delegates to filter-commit-message-inplace.sh for the actual filtering.
 # Falls back to inline grep if the filter script is not present.

--- a/templates/project/.husky/post-commit
+++ b/templates/project/.husky/post-commit
@@ -1,8 +1,8 @@
 #!/bin/sh
 # post-commit
 #
-# Re-applies trailer stripping after the commit lands.
-# Some git clients (and `git commit --trailer`) re-inject trailers after
+# Re-applies tool footer removal after the commit lands.
+# Some git clients (and `git commit --trailer`) re-inject footers after
 # the commit-msg hook has already run. This hook catches and amends them away.
 #
 # Amends the commit in-place only if the message actually changed.


### PR DESCRIPTION
## Summary

Reframes the language around the `commit-msg` + `post-commit` hooks throughout all user-facing docs. "Attribution stripping" implied removing deserved credit — which reads as dishonest. The actual intent is a clean-history preference.

## What changed

These footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.) are **auto-injected** by AI coding tools. They're not credits written by the human author. Removing them is a stylistic choice about commit message cleanliness — not a cover-up. `docs/decisions.md` already had the correct rationale; this PR aligns the surface-level docs with it.

## Changes

- **README.md**: Three occurrences updated — diagram, component table, hooks table
- **docs/customizing.md**: Section "Disabling the AI trailer stripping" rewritten as "Keeping tool attribution footers in commits" with a clearer explanation of the default behaviour and when to override it
- **templates/project/.husky/commit-msg**: Hook comment updated from "Strips AI-generated attribution trailers" to "Strips auto-injected tool footers — keeps history clean and human-authored in tone" (with note on how to disable)
- **templates/project/.husky/post-commit**: Hook comment updated to match

## Closes

Closes #132

## Test plan

- [ ] 54 bats tests pass (no code changes — docs and hook comments only)
- [ ] README hook table reads clearly without implying dishonesty
- [ ] customizing.md section makes the default + override path obvious

## Notes

`docs/decisions.md` entry #7 ("Commit trailer stripping is aggressive, not selective") already explains this correctly — no change needed there.
