### PR TITLE
feat: configurable project settings + context/token management docs

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -316,6 +316,79 @@ staged only from `.rig/tasks/done/` in a separate housekeeping commit.
 
 ---
 
+## Context and token management
+
+The Rig is designed to work within a bounded context budget across long sessions
+and many tasks. This section documents what loads, when it loads, and what keeps
+the budget in check.
+
+### What loads at session start (always)
+
+These files are injected by Claude Code unconditionally via `@` import or direct
+load — the agent cannot skip them:
+
+| Source | Typical size | Notes |
+|---|---|---|
+| `~/.claude/CLAUDE.md` (global) | ~10 KB | Hard rules, working style, conventions |
+| Project `CLAUDE.md` | ~6 KB | Stack, structure, off-limits |
+| `.rig/rules/` (4 files, via `@`) | ~11 KB | Coding standards, git, security, verification |
+| `docs/features/README.md` (via `@`) | ~1 KB | Feature index |
+| `CONTEXT_SNAPSHOT.md` | ~2 KB | Session state — the most important gate |
+
+**Session-start baseline: ~30 KB (~7,000 tokens).** Well within Claude's usable window.
+
+### What loads on demand (not at startup)
+
+These are read only when a command is invoked or a workflow is followed:
+
+| File | Size | When |
+|---|---|---|
+| `ship.md` | ~10 KB | `/ship` command |
+| `wrap.md` | ~11 KB | `/wrap` command |
+| `SHIP_WORKFLOW.md` | ~10 KB | When `/ship` directs agent to follow it |
+| `NEW_TASK_WORKFLOW.md` | ~6 KB | When starting a new task |
+| Active task file | ~1–3 KB | One per active task |
+| `PROGRESS.md` | variable | Only if CONTEXT_SNAPSHOT is absent or stale |
+| `ERRORS.md` | variable | Only if CONTEXT_SNAPSHOT is absent or stale |
+
+### The CONTEXT_SNAPSHOT gate
+
+The most important token-management mechanism. When `CONTEXT_SNAPSHOT.md` exists
+and is current, the agent is instructed to stop reading context — it skips PROGRESS.md,
+ERRORS.md, and deeper history entirely. This keeps repeat sessions cheap.
+
+The `/wrap` command writes the snapshot at session end. **Running `/wrap` before
+ending a session is the single most effective way to keep future sessions lean.**
+
+### Trim limits
+
+`PROGRESS.md` and `ERRORS.md` grow over time. The `/wrap` command enforces limits:
+
+- `PROGRESS.md` → trimmed to 20 entries; older entries moved to `PROGRESS_archive.md`
+- `ERRORS.md` → trimmed to 30 entries; older entries moved to `ERRORS_archive.md`
+
+Archive files are gitignored (history preserved locally, not loaded at session start).
+
+A full `PROGRESS.md` at the 20-entry limit is ~4,000–6,000 tokens. A full `ERRORS.md`
+at 30 entries is ~3,000–5,000 tokens. Both are well within budget even when stacked.
+
+**Important:** the trim only runs when `/wrap` is invoked — it is not automatic.
+Projects that skip `/wrap` regularly will see these files grow without bound.
+
+### What actually drives context growth
+
+The dominant cost is not Rig files — it's **tool call accumulation** mid-session.
+Every `Read`, `Edit`, `Bash`, and `Grep` result stays in context for the rest of the
+session. A task with 40 tool calls, averaging 1 KB of output each, adds ~40 KB
+(~10,000 tokens) beyond the baseline. This is normal and expected — it is why
+Claude Code auto-compacts around 80–90% of the context window.
+
+The Rig's design assumption is that a well-structured session (clear task file, current
+CONTEXT_SNAPSHOT, invoked commands only as needed) will consume the context window in
+proportion to the complexity of the work — not because of Rig overhead.
+
+---
+
 ## The command set
 
 Thirteen slash commands covering the full development lifecycle:

--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -68,11 +68,12 @@ Do not summarise these back to me unless asked.
   - **Proceed directly** if the change is a one-liner or touches a single known file
     and can be verified in under 5 minutes. Offer to log it as a task file afterward.
   - **Redirect to `/task`** if the change is likely to touch more than 2–3 files,
-    requires a GitHub issue, or would take more than one exchange to complete. Say:
-    > "This looks like a task worth tracking. Does it have an issue number I can
-    > reference — or should I open a `/task` intake?"
+    or would take more than one exchange to complete. Say:
+    > "This looks like a task worth tracking. Should I open a `/task` intake?"
     Wait for the user's response before touching any code.
-  - **Never proceed** on a multi-file change request without an issue number.
+  - **If `issue-tracking: github`** (the default): never proceed on a multi-file change
+    without an issue number. If `issue-tracking: none` is set in the project `CLAUDE.md`:
+    proceed without one — but still redirect through `/task` for scope tracking.
 
 ---
 
@@ -159,7 +160,7 @@ Body: explain WHY, not what. The diff shows what.
 Types: `feat` | `fix` | `refactor` | `test` | `docs` | `chore` | `style` | `perf` | `devops`
 
 Max subject line: 72 characters.
-Always reference the GitHub issue number (`[#N]`) when one exists.
+Reference the GitHub issue number (`[#N]`) when one exists and `issue-tracking: github` is set.
 Never commit directly to `main` or `master`.
 
 ---

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -39,10 +39,17 @@ Wait for the user to confirm this is the right task before continuing.
 
 ## Step 2 — Confirm the GitHub issue
 
+First, read `issue-tracking:` from `CLAUDE.md`.
+
+**If `issue-tracking: none`:** skip this step entirely — proceed to Step 3.
+
+**If `issue-tracking: github`** (or field absent — default):
+
 Read the task file's `**GitHub issue**:` field.
 
 - If it contains a real issue number (e.g. `#12`): state it and proceed.
-- If it is empty or still a placeholder: **stop.**
+- If it is `N/A (issue-tracking: none)`: proceed — the project setting was already applied.
+- If it is empty or a placeholder: **stop.**
   Say: "No GitHub issue linked. Per SHIP_WORKFLOW Step 0, the issue must exist
   before committing. Create the issue first, then update the task file."
 
@@ -57,7 +64,7 @@ strip the YAML frontmatter (lines starting with `---`, `name:`, `about:`, `title
 `labels:`, `assignees:`), and use the remaining content as the issue body. **Never
 use a freeform issue body when an issue template exists.**
 
-Do not proceed to Step 3 until a valid issue number is confirmed.
+Do not proceed to Step 3 until a valid issue number is confirmed (or `issue-tracking: none` is set).
 
 ---
 

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -39,15 +39,15 @@ Ask the user the following. Collect all answers before moving to Part 2.
    the codebase (what service, module, or directory will this touch?).
 3. **Hard constraints?** Any deadline, off-limits paths, technology restrictions, or
    things that must not change?
-4. **GitHub issue number?** Every task must be linked to an issue before any code is
-   written — the number goes in the task file and every commit message on this branch.
-   - If the user provides a number (e.g. `#42`): note it and continue.
-   - If no issue exists yet: **stop here.** Say exactly:
-     > "Every task needs a GitHub issue before we start. Create one now and share
-     > the number — I'll wait. It goes in the task file and every commit."
-     Do not proceed to Part 2 until a real issue number is provided.
-   - Exception: if the project has no GitHub remote or the user explicitly says
-     "no issue tracking", note that in the task file and continue without a number.
+4. **GitHub issue number?** Read `issue-tracking:` from `CLAUDE.md` first.
+   - **If `issue-tracking: github`** (or field is absent — default): an issue is required.
+     - If the user provides a number (e.g. `#42`): note it and continue.
+     - If no issue exists yet: **stop here.** Say exactly:
+       > "Every task needs a GitHub issue before we start. Create one now and share
+       > the number — I'll wait. It goes in the task file and every commit."
+       Do not proceed to Part 2 until a real issue number is provided.
+   - **If `issue-tracking: none`**: skip the issue requirement. Note in the task file:
+     `**GitHub issue**: N/A (issue-tracking: none)`. Continue to Part 2 immediately.
 
 After collecting all answers, confirm back:
 

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -15,6 +15,11 @@
 
 ## Step 0 — GitHub issue first
 
+**Read `issue-tracking:` from `CLAUDE.md` before proceeding.**
+
+- **If `issue-tracking: none`:** skip this step. No issue number is required in the task file or commit messages. Continue to Step 1.
+- **If `issue-tracking: github`** (or field absent — default): follow the full step below.
+
 Before any code is written, a GitHub issue must exist and be linked in the task file.
 The `/task` wizard enforces this: it will not proceed to Part 2 without an issue number.
 If you are running this workflow without going through `/task`, stop and create the issue now.

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -14,6 +14,11 @@
 
 ## Step 0 — Create the GitHub issue first
 
+**Read `issue-tracking:` from `CLAUDE.md` before proceeding.**
+
+- **If `issue-tracking: none`:** skip this entire step. Issue numbers are not required in commit messages. Continue to Step 1.
+- **If `issue-tracking: github`** (or field absent — default): follow the full step below.
+
 **Before writing any code, create the GitHub issue.**
 
 The commit message must reference the issue number: `feat(scope): description [#N]`.

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -101,6 +101,40 @@ Change this value to match your project's branching convention.
 
 ---
 
+## Project settings
+
+These fields are read by slash commands and workflow files. Set them once and every
+future session inherits them — no need to re-state preferences in chat.
+
+```
+issue-tracking: github
+```
+
+| Value | Behaviour |
+|---|---|
+| `github` | GitHub issues are required before any code is written. `/task` blocks until an issue number is provided. Issue number goes in every commit. `gh` CLI is used for all PR/issue operations. |
+| `none` | No issue tracker in use. Issue number requirement is skipped in `/task`, `/ship`, and commit messages. Use for personal projects, prototypes, or non-GitHub repos. |
+
+```
+secret-scanner: gitleaks
+```
+
+| Value | Behaviour |
+|---|---|
+| `gitleaks` | `gitleaks --staged` runs on every commit. Requires `gitleaks` to be installed. |
+| `none` | Secret scanning disabled. Remove or comment out the gitleaks block in `.husky/pre-commit`. |
+
+```
+commit-cleanup: yes
+```
+
+| Value | Behaviour |
+|---|---|
+| `yes` | Auto-injected tool footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.) are stripped from commit messages by the `commit-msg` and `post-commit` hooks. |
+| `no` | Footers are kept. Comment out or remove `.husky/commit-msg` and `.husky/post-commit` to disable the stripping. |
+
+---
+
 ## Off-limits — never touch without explicit instruction
 
 - `.husky/` — git hooks are stable; do not modify


### PR DESCRIPTION
## Summary

Two related improvements:

1. **Configurable project settings** — issue tracking, secret scanner, and commit footer cleanup are now first-class settings in the project `CLAUDE.md` template rather than hardcoded assumptions. Not every project uses GitHub issues or gitleaks.

2. **Token economy documentation** — adds a "Context and token management" section to `docs/how-it-works.md` with measured file sizes, the CONTEXT_SNAPSHOT gate, trim limits, and an honest note on what actually drives context growth (tool call accumulation, not Rig files).

## Changes

**`templates/project/CLAUDE.md`** — new `## Project settings` block with three configurable options:
- `issue-tracking: github | none` — whether issues are required before code
- `secret-scanner: gitleaks | none` — secret scanning choice
- `commit-cleanup: yes | no` — tool footer stripping preference

**`templates/project/.claude/commands/task.md`** — Part 1, question 4 reads `issue-tracking:` before blocking; skips requirement if `none`

**`templates/project/.claude/commands/ship.md`** — Step 2 reads `issue-tracking:` and skips the gate if `none`

**`templates/project/.rig/processes/SHIP_WORKFLOW.md`** — Step 0 conditional on `issue-tracking:`

**`templates/project/.rig/processes/NEW_TASK_WORKFLOW.md`** — Step 0 conditional on `issue-tracking:`

**`templates/global/CLAUDE.md`** — "never proceed without issue number" hard rule defers to `issue-tracking:` project setting

**`docs/how-it-works.md`** — new "Context and token management" section with session-start baseline (~7K tokens from measured template sizes), the CONTEXT_SNAPSHOT gate, trim limits, and the real cost driver (tool call accumulation)

## Closes

Closes #134

## Test plan

- [ ] 54 bats tests pass (no code changes — templates and docs only)
- [ ] Verify project CLAUDE.md template settings block is clear and well-explained
- [ ] Verify task.md issue-tracking logic reads correctly

## Notes

`secret-scanner` and `commit-cleanup` are documented for discoverability — action is still "edit the hook file" since that's the right level of control. A future PR could wire these more tightly if demand exists.
