### PR TITLE
fix(wrap): archive blindness + docs full audit

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -4,6 +4,26 @@ How to adapt The Rig for your stack, team size, and workflow preferences.
 
 ---
 
+## Project settings (quick reference)
+
+The fastest way to configure The Rig for a project is the `## Project settings` block
+in the project `CLAUDE.md`. Set these once and every session inherits them:
+
+```
+base-branch: main          # integration branch all PRs target
+housekeeping: direct-push  # direct-push | pr-required (how /post-merge commits)
+issue-tracking: github     # github | none (skip issue gate for personal/prototype repos)
+secret-scanner: gitleaks   # gitleaks | none
+commit-cleanup: yes        # yes | no (strip auto-injected tool footers from commits)
+```
+
+**`issue-tracking: none`** is the most common override for non-GitHub or personal projects.
+It disables the issue-number requirement in `/task`, `/ship`, and commit messages.
+
+For deeper customization of individual components, see the sections below.
+
+---
+
 ## What to customize vs. what to leave alone
 
 | Component | Customize | Leave alone |

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -23,47 +23,53 @@ The Rig solves this at three levels:
 
 ## Two-layer architecture
 
+Three locations work together. The installer repo produces the other two:
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  GLOBAL LAYER  (~/.claude/)                                     │
-│  Installed once per machine. Cross-project.                     │
+│  THE INSTALLER  (~/tools/the-rig/)                              │
+│  Cloned once. Run install.sh to produce the two layers below.   │
 │                                                                 │
-│  ~/.claude/CLAUDE.md                                            │
-│    └─ Hard rules (12), working style, memory discipline,        │
-│       planning discipline, session workflow, git conventions,   │
-│       code quality defaults, skill trigger table                │
+│  ~/tools/the-rig/install.sh    ← interactive setup script      │
+│  ~/tools/the-rig/templates/    ← source files for both layers   │
+│  ~/tools/the-rig/VERSION       ← current Rig version            │
 │                                                                 │
-│  ~/.claude/skills/                                              │
-│    ├─ debug.md          ← "why is this broken"                  │
-│    ├─ code-review.md    ← "review this"                         │
-│    ├─ refactor.md       ← "refactor this to…"                   │
-│    ├─ write-tests.md    ← "write tests for…"                    │
-│    └─ explain.md        ← "explain this to me"                  │
-│                                                                 │
-│  ~/.your-ai-contexts/PROFILE.md                                 │
-│    └─ Personal/professional context — role, stack, projects,    │
-│       working style preferences                                 │
-└────────────────────────────┬────────────────────────────────────┘
-                             │ auto-loaded by Claude Code
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  PROJECT LAYER  (per-repo, version-controlled)                  │
-│                                                                 │
-│  CLAUDE.md              ← project identity + @.rig/rules/ imports│
-│  .rig/                  ← The Rig system files                   │
-│  .rig/processes/        ← step-by-step workflows                │
-│  .rig/rules/            ← coding/git/security/verification      │
-│  .rig/memory/           ← PROGRESS + ERRORS + DECISIONS + SNAPSHOT│
-│  .rig/tasks/            ← backlog → active → done lifecycle     │
-│  .claude/               ← hooks + slash commands                │
-│  .husky/                ← git hooks                             │
-│  .github/               ← PR + issue templates                  │
-└─────────────────────────────────────────────────────────────────┘
+│  To upgrade: cd ~/tools/the-rig && git pull                     │
+│  Then re-run install.sh with --strategy upgrade                 │
+└───────────────┬─────────────────────────┬───────────────────────┘
+                │ installs global layer    │ installs project layer
+                ▼                         ▼
+┌──────────────────────────┐  ┌───────────────────────────────────┐
+│  GLOBAL LAYER            │  │  PROJECT LAYER                    │
+│  (~/.claude/)            │  │  (per-repo, version-controlled)   │
+│  Once per machine.       │  │  Once per project.                │
+│                          │  │                                   │
+│  ~/.claude/CLAUDE.md     │  │  CLAUDE.md       ← project brain  │
+│    └─ Hard rules (12),   │  │  .rig/           ← Rig system     │
+│       working style,     │  │  .rig/processes/ ← workflows      │
+│       memory discipline, │  │  .rig/rules/     ← standards      │
+│       planning, git,     │  │  .rig/memory/    ← PROGRESS +     │
+│       code quality,      │  │                    ERRORS +        │
+│       skill trigger table│  │                    SNAPSHOT        │
+│                          │  │  .rig/tasks/     ← backlog/active/│
+│  ~/.claude/skills/       │  │                    done            │
+│    ├─ debug.md           │  │  .claude/        ← hooks +        │
+│    ├─ code-review.md     │  │                    commands        │
+│    ├─ refactor.md        │  │  .husky/         ← git hooks      │
+│    ├─ write-tests.md     │  │  .github/        ← PR + issue     │
+│    └─ explain.md         │  │                    templates       │
+│                          │  └───────────────────────────────────┘
+│  ~/.your-ai-contexts/    │
+│    PROFILE.md            │
+│    └─ Personal context   │
+│       (path configurable)│
+└──────────────────────────┘
 ```
 
 The global layer is loaded first, automatically, by Claude Code. It provides
 universal context. The project layer is read during orientation and provides
-project-specific context.
+project-specific context. The installer repo never runs during a session — it
+only runs when you install or upgrade.
 
 ---
 
@@ -407,7 +413,7 @@ Thirteen slash commands covering the full development lifecycle:
 ### Ship and debug
 | Command | Triggers | Key behaviour |
 |---|---|---|
-| `/ship` | `SHIP_WORKFLOW` | Sequential 9-step hard gate: task confirm → issue (with template detection) → labels → checklist → local test pause → commit approval → commit → housekeeping → PR (with template detection) |
+| `/ship` | `SHIP_WORKFLOW` | Sequential hard gate: task confirm → issue (with template detection) → labels → branch/stale-main check → checklist → local test pause → commit approval → commit → housekeeping → PR (with template detection) |
 | `/debug` | `DEBUG_WORKFLOW` | Hypothesis before code, mandatory ERRORS.md entry |
 
 ### Feature knowledge
@@ -445,3 +451,30 @@ tasks without interruption at High autonomy, pausing between tasks at Medium and
 
 Governance (protected paths, `/propose` gate, pre-ship checklist) applies at all
 autonomy levels. "High Autonomous" means fewer interruptions, not fewer safeguards.
+
+---
+
+## Project settings
+
+Several Rig behaviors are configurable per project via fields in the project `CLAUDE.md`.
+These sit alongside the existing `base-branch:` and `housekeeping:` fields:
+
+| Field | Default | Options | What it controls |
+|---|---|---|---|
+| `base-branch:` | `main` | Any branch name | The integration branch all PRs target |
+| `housekeeping:` | `direct-push` | `direct-push` \| `pr-required` | How `/post-merge` handles memory-update commits |
+| `issue-tracking:` | `github` | `github` \| `none` | Whether GitHub issues are required before code; skips issue gate if `none` |
+| `secret-scanner:` | `gitleaks` | `gitleaks` \| `none` | Secret scanning on commit; disabling requires editing `.husky/pre-commit` |
+| `commit-cleanup:` | `yes` | `yes` \| `no` | Whether auto-injected tool footers are stripped from commit messages |
+
+The `issue-tracking: none` setting is the most impactful: it disables the issue-number
+gate in `/task`, `/ship`, `SHIP_WORKFLOW`, and `NEW_TASK_WORKFLOW`. Use it for personal
+projects, prototypes, or repos that don't use GitHub issues.
+
+Branch creation behavior is also parameterized by autonomy level:
+- **Low/Medium**: always confirm the base branch before `git checkout -b`
+- **High**: reads `base-branch:` from `CLAUDE.md`, states the base, and branches immediately
+
+A stale-main check (`git fetch` + `rev-list` comparison) runs before any new branch is
+created. If the base branch has advanced, Low/Medium autonomy prompts to rebase; High
+autonomy rebases automatically.

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -152,6 +152,8 @@ Alternatively, edit `.claude/settings.json` directly and update the hook command
 
 **Fix**: The installer now has a dedicated **Upgrade** strategy (option 5). It classifies every file as Rig-owned or user-owned. Rig-owned files (hooks, commands, processes, Husky scripts) are auto-updated when unmodified, or shown a diff with a prompt when customized. User-owned files (CLAUDE.md, rules/, memory/, tasks/, .github/) are always skipped. The Upgrade strategy records a SHA256 manifest at install time so it can detect your customizations on the next run.
 
+The manifest was later extended (v1.10.0) to track **all** files — not just Rig-owned ones. This means the Upgrade strategy can now also detect customizations to user-owned files and protect them, rather than silently skipping all of them. The overwrite strategy received the same manifest-awareness: it warns before touching any user-customized file.
+
 **Watch for**: Never use Merge strategy to upgrade an existing install — only use it for the initial drop-in. When upgrading, always choose Upgrade (5). See `docs/customizing.md` for the full upgrade workflow.
 
 ---

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -10,7 +10,7 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 2. Ensures `.rig/memory/PROGRESS.md` is up to date — expands any auto-stubbed entries
 3. **Trims `.rig/memory/PROGRESS.md`** if it has grown beyond 20 entries (see Trim step below)
 4. **Prunes stale session-end markers** from `PROGRESS.md` (see Marker prune step below)
-5. Checks `.rig/memory/ERRORS.md` — prompts you to log anything unexpected from this session
+5. Checks `.rig/memory/ERRORS.md` — prompts you to log anything unexpected; **checks archive before logging** to prevent duplicate entries (see ERRORS.md logging step below)
 6. **Self-improvement check** — scans for Rig workflow gaps and logs them to `.rig/memory/RIG_GAPS.md`
 7. **Trims `.rig/memory/ERRORS.md`** if it has grown beyond 30 entries (see Trim step below)
 8. Reports what's in `.rig/tasks/active/` so you know what's in flight
@@ -84,7 +84,12 @@ If the user confirms:
 1. Identify the oldest entries (bottom of the file, since entries are newest-first)
 2. Prepend them to `.rig/memory/PROGRESS_archive.md` (create if absent)
 3. Remove them from `.rig/memory/PROGRESS.md`, leaving the 20 most recent entries
-4. Confirm: "`.rig/memory/PROGRESS.md` trimmed to 20 entries. Archive: `.rig/memory/PROGRESS_archive.md`"
+4. **Append a trim stub** at the bottom of the trimmed `PROGRESS.md`:
+   ```
+   <!-- archived YYYY-MM-DD: [N] entries moved to PROGRESS_archive.md. Topics: [3–6 word comma-separated summary of what was archived, e.g. "CI setup, manifest tracking, stealth mode, command rename"] -->
+   ```
+   This lets future sessions know what history exists in the archive without loading it.
+5. Confirm: "`.rig/memory/PROGRESS.md` trimmed to 20 entries. Archive: `.rig/memory/PROGRESS_archive.md`"
 
 Never trim without confirmation. Never delete entries — only move them.
 
@@ -140,6 +145,29 @@ If there is nothing to log, skip silently — do not mention this step.
 
 ---
 
+## ERRORS.md logging step
+
+Ask: "Did anything unexpected, buggy, or footgun-worthy happen this session that isn't
+already documented?"
+
+If yes, **before creating a new entry**:
+
+1. Search the active `.rig/memory/ERRORS.md` for a similar entry (keyword match is enough).
+2. If `ERRORS_archive.md` exists, do a quick search there too:
+   ```bash
+   grep -i "[keyword]" "$RIG_DIR/memory/ERRORS_archive.md" 2>/dev/null | head -5
+   ```
+3. **If a matching entry exists** (in either file): update or append to it rather than
+   creating a duplicate. Note the recurrence date. Duplicates dilute the pitfall log.
+4. **If genuinely new**: add a new `## ` entry at the top of `ERRORS.md`.
+
+> **Why check the archive?** Entries trimmed past the 30-entry limit move to
+> `ERRORS_archive.md` and are never loaded at session start. Without this check,
+> the same pitfall can be re-logged repeatedly across trims, losing the signal that
+> this is a *recurring* problem rather than an isolated one.
+
+---
+
 ## Trim step — ERRORS.md
 
 After checking `.rig/memory/ERRORS.md`, count the number of `## ` entry headers in the file.
@@ -157,7 +185,13 @@ If the user confirms:
 1. Identify the oldest entries (bottom of the file, since entries are newest-first)
 2. Prepend them to `.rig/memory/ERRORS_archive.md` (create if absent)
 3. Remove them from `.rig/memory/ERRORS.md`, leaving the 30 most recent entries
-4. Confirm: "`.rig/memory/ERRORS.md` trimmed to 30 entries. Archive: `.rig/memory/ERRORS_archive.md`"
+4. **Append a trim stub** at the bottom of the trimmed `ERRORS.md`:
+   ```
+   <!-- archived YYYY-MM-DD: [N] entries moved to ERRORS_archive.md. Categories: [3–6 word comma-separated summary, e.g. "bats non-interactive, gitleaks path, Husky sh-e, worktree writes"] -->
+   ```
+   This lets the agent grep for a category keyword without loading the archive, and
+   signals to the ERRORS.md logging step that the archive should be checked.
+5. Confirm: "`.rig/memory/ERRORS.md` trimmed to 30 entries. Archive: `.rig/memory/ERRORS_archive.md`"
 
 Never trim without confirmation. Never delete entries — only move them.
 


### PR DESCRIPTION
## Summary

Two related fixes in one branch:

**#136 — Memory archive blindness (architectural fix)**
The trim mechanism had a silent gap: once ERRORS.md entries move to the archive, future sessions have no awareness of them. An agent logging a new error would never check the archive, so the same pitfall could be re-logged repeatedly — hiding the signal that it's a *recurring* problem, not an isolated one.

Fix: three changes to `wrap.md`:
- New **ERRORS.md logging step** section with explicit "check archive before logging" instruction — search both active file and `ERRORS_archive.md` before creating any new entry; update existing instead of duplicating
- **Trim stub** appended to `PROGRESS.md` after trim: compact comment listing archived topics so future sessions know what history exists
- **Trim stub** appended to `ERRORS.md` after trim: compact comment listing error categories — acts as a grep-able index into the archive without loading it

**#137 — Documentation audit (7 gaps fixed)**
- `how-it-works.md`: two-layer diagram replaced with three-box layout showing `~/tools/the-rig/` (installer) as the origin of both layers — the specific gap the user noticed
- `how-it-works.md`: `/ship` description no longer says "9-step" (Step 3.5 was added in #130)
- `how-it-works.md`: new **Project settings** section documenting all five configurable CLAUDE.md fields with their options and effects
- `how-it-works.md`: PROFILE.md path noted as configurable
- `docs/customizing.md`: new **Project settings (quick reference)** section at top
- `docs/lessons-learned.md` Pitfall #12: added note that manifest tracking was extended to all files in v1.10.0

## Closes

Closes #136
Closes #137

## Test plan

- [ ] 54 bats tests pass (no code changes)
- [ ] how-it-works.md three-box diagram renders correctly in GitHub
- [ ] ERRORS.md logging section in wrap.md reads clearly and actionably
