### PR TITLE
fix(install): guard self-install detector against deleting committed source files [#143]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -401,14 +401,14 @@ for event, incoming_hooks in incoming.get("hooks", {}).items():
         for h in entry.get("hooks", []):
             cmd = h.get("command", "")
             if cmd:
-                existing_commands.add(cmd)
+                existing_commands.add(cmd)  # rig-debug-ok
     # Append incoming hooks whose command isn't already present
     for entry in incoming_hooks:
         for h in entry.get("hooks", []):
             cmd = h.get("command", "")
             if cmd not in existing_commands:
                 existing["hooks"][event].append(entry)
-                existing_commands.add(cmd)
+                existing_commands.add(cmd)  # rig-debug-ok
                 break  # each entry is a unit; add it once
 
 with open(output_path, "w") as f:
@@ -1169,34 +1169,38 @@ fi
 if [[ "$DO_PROJECT" == true && -n "${TARGET_ABS:-}" ]]; then
   SCRIPT_ABS="$(cd "$SCRIPT_DIR" && pwd)"
   if [[ "$SCRIPT_ABS" == "$TARGET_ABS" ]]; then
-    echo ""
-    warn "The installer was run from inside the target project directory."
-    echo "  The following The Rig source files are no longer needed in your project:"
-    echo ""
-    echo "    templates/     — scaffolding source (already consumed)"
-    echo "    docs/          — The Rig's own architecture docs"
-    echo "    CHANGELOG.md   — The Rig's changelog"
-    echo "    install.sh     — this installer"
-    echo "    LICENSE        — The Rig's MIT license"
-    echo "    README.md      — The Rig's README (replace with your project's)"
-    echo ""
-    echo "  Your project files (CLAUDE.md, .rig/, .claude/, .husky/, PROJECT_BRIEF.md, etc.)"
-    echo "  are NOT affected."
-    echo ""
-    if confirm "Remove these Rig source files from your project directory?" "y"; then
-      for rig_file in templates docs CHANGELOG.md install.sh LICENSE README.md; do
-        if [[ -e "$TARGET_ABS/$rig_file" ]]; then
-          rm -rf "${TARGET_ABS:?}/$rig_file"
-          success "Removed $rig_file"
-        fi
-      done
+    # Guard: if install.sh is committed in this repo, we're inside The Rig's own
+    # source tree — skip cleanup to avoid deleting project source files.
+    if ! git -C "$SCRIPT_ABS" ls-files --error-unmatch install.sh &>/dev/null 2>&1; then
       echo ""
-      warn "README.md was removed. Create a new one for your project:"
-      echo "  Your project description, setup instructions, and usage go here."
-    else
-      info "Skipped cleanup. Remove them manually when you're ready:"
-      echo "    cd $TARGET_ABS"
-      echo "    rm -rf templates/ docs/ CHANGELOG.md install.sh LICENSE README.md"
+      warn "The installer was run from inside the target project directory."
+      echo "  The following The Rig source files are no longer needed in your project:"
+      echo ""
+      echo "    templates/     — scaffolding source (already consumed)"
+      echo "    docs/          — The Rig's own architecture docs"
+      echo "    CHANGELOG.md   — The Rig's changelog"
+      echo "    install.sh     — this installer"
+      echo "    LICENSE        — The Rig's MIT license"
+      echo "    README.md      — The Rig's README (replace with your project's)"
+      echo ""
+      echo "  Your project files (CLAUDE.md, .rig/, .claude/, .husky/, PROJECT_BRIEF.md, etc.)"
+      echo "  are NOT affected."
+      echo ""
+      if confirm "Remove these Rig source files from your project directory?" "y"; then
+        for rig_file in templates docs CHANGELOG.md install.sh LICENSE README.md; do
+          if [[ -e "$TARGET_ABS/$rig_file" ]]; then
+            rm -rf "${TARGET_ABS:?}/$rig_file"
+            success "Removed $rig_file"
+          fi
+        done
+        echo ""
+        warn "README.md was removed. Create a new one for your project:"
+        echo "  Your project description, setup instructions, and usage go here."
+      else
+        info "Skipped cleanup. Remove them manually when you're ready:"
+        echo "    cd $TARGET_ABS"
+        echo "    rm -rf templates/ docs/ CHANGELOG.md install.sh LICENSE README.md"
+      fi
     fi
   fi
 fi

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -565,3 +565,45 @@ _is_rig_protected() {
   run _is_rig_protected "/repo/.rig/tasks/active/TASK_my-feature.md"
   [ "$status" -ne 0 ]
 }
+
+# ── Self-install detector ─────────────────────────────────────────────────────
+
+@test "self-install detector: skips cleanup when install.sh is git-tracked" {
+  local rig_dir="$TEMP_DIR/rig-self"
+  mkdir -p "$rig_dir"
+  cp "$INSTALLER" "$rig_dir/install.sh"
+  cp -r "$REPO_ROOT/templates" "$rig_dir/templates"
+  git -C "$rig_dir" init -q
+  git -C "$rig_dir" config user.email "test@test.com"
+  git -C "$rig_dir" config user.name "Test"
+  git -C "$rig_dir" add install.sh
+  git -C "$rig_dir" commit -q -m "init"
+
+  run bash "$rig_dir/install.sh" --project-only \
+    --target "$rig_dir" \
+    --project-name "TestProject" \
+    --strategy skip
+
+  [ "$status" -eq 0 ]
+  [ -f "$rig_dir/install.sh" ]
+  [[ "$output" != *"run from inside the target"* ]]
+}
+
+@test "self-install detector: offers cleanup when install.sh is not git-tracked" {
+  local rig_dir="$TEMP_DIR/rig-self"
+  mkdir -p "$rig_dir"
+  cp "$INSTALLER" "$rig_dir/install.sh"
+  cp -r "$REPO_ROOT/templates" "$rig_dir/templates"
+  git -C "$rig_dir" init -q
+  git -C "$rig_dir" config user.email "test@test.com"
+  git -C "$rig_dir" config user.name "Test"
+  # install.sh intentionally not committed — artifact scenario
+
+  run bash "$rig_dir/install.sh" --project-only \
+    --target "$rig_dir" \
+    --project-name "TestProject" \
+    --strategy skip
+
+  [ "$status" -eq 0 ]
+  [ ! -f "$rig_dir/install.sh" ]
+}


### PR DESCRIPTION
## Summary

- Adds a `git ls-files --error-unmatch install.sh` guard to the in-place cleanup block in `install.sh`
- When `install.sh` is a committed file in the target repo (i.e. The Rig installed onto its own repo), cleanup is silently skipped — no prompt, no deletion
- Untracked-artifact cleanup path is unchanged — users who clone the installer into a fresh project still get the offer
- Adds `# rig-debug-ok` annotations to two pre-existing Python `set.add()` calls in the `merge_settings_json` heredoc — false positives for the `dd()` debug pattern check

## Test plan

- [x] `bats tests/` — 56/56 passing (2 new tests added)
- [x] New test: self-install detector skips cleanup when `install.sh` is git-tracked
- [x] New test: self-install detector offers cleanup when `install.sh` is not git-tracked (regression guard)
- [x] `bash -n install.sh` — syntax clean

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)