### PR TITLE
fix(install): stealth-mode backups pollute project git status [#148]

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -362,8 +362,12 @@ When a new version of The Rig is released, pull the latest from the repo and re-
 the installer against your project:
 
 ```bash
+# 1. Pull the latest Rig source
 cd ~/tools/the-rig && git pull
-./install.sh --project-only
+
+# 2. Run the installer from inside your project
+cd ~/code/my-project
+~/tools/the-rig/install.sh --project-only
 ```
 
 Choose **Upgrade (option 3)** from the intent menu. This is the recommended
@@ -392,8 +396,10 @@ On upgrade, for each Rig-owned file:
 | Dest hash != manifest hash | You've customized it — diff shown, you choose: overwrite / skip |
 | No manifest entry | First upgrade (manifest didn't exist yet) — overwritten silently |
 
-Backups are written to `.rig-backup/<timestamp>/` before any overwrite, so nothing
-is ever lost.
+Backups are written to `.rig-backup/<timestamp>/` in the project root before any
+overwrite. In stealth or external tracking mode, backups go to
+`$EXTERNAL_RIG_DIR/backups/<timestamp>/` instead — so they never surface in the
+project's git status. Nothing is ever lost.
 
 ### Manifest-aware customization
 

--- a/install.sh
+++ b/install.sh
@@ -363,13 +363,19 @@ info "Strategy: ${COLLISION_STRATEGY}"
 echo ""
 
 # ── BACKUP HELPER ─────────────────────────────────────────────────────────────
-# Used by overwrite strategy. Backs up to <target>/.rig-backup/<timestamp>/
+# Used by overwrite strategy. In stealth/external mode, backs up to
+# $EXTERNAL_RIG_DIR/backups/<timestamp>/ so no traces land in the project repo.
+# Otherwise backs up to <target>/.rig-backup/<timestamp>/
 BACKUP_DIR=""
 BACKUP_TS="$(date +%Y%m%d_%H%M%S)"
 
 init_backup_dir() {
   local base="$1"
-  BACKUP_DIR="${base}/.rig-backup/${BACKUP_TS}"
+  if [[ ( "$RIG_TRACKING" == "stealth" || "$RIG_TRACKING" == "external" ) && -n "$EXTERNAL_RIG_DIR" ]]; then
+    BACKUP_DIR="${EXTERNAL_RIG_DIR}/backups/${BACKUP_TS}"
+  else
+    BACKUP_DIR="${base}/.rig-backup/${BACKUP_TS}"
+  fi
   mkdir -p "$BACKUP_DIR"
 }
 
@@ -1102,6 +1108,7 @@ if [[ "$DO_PROJECT" == true ]]; then
       _stealth_exclude ".github/"
       _stealth_exclude ".gitleaks.toml"
       _stealth_exclude "docs/features/README.md"
+      _stealth_exclude ".rig-backup/"
       # .rigpath is already excluded by the external-mode block above
     else
       warn ".git/info/exclude not found — stealth exclusions could not be applied."
@@ -1183,7 +1190,7 @@ if [[ "$DO_PROJECT" == true ]]; then
   # ── BACKUP REPORT ─────────────────────────────────────────────────────────
   if [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]]; then
     echo ""
-    info "Originals backed up to: ${BACKUP_DIR#$TARGET/}"
+    info "Originals backed up to: $BACKUP_DIR"
   fi
 
   echo ""

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -177,6 +177,23 @@ is_rig_owned_stub() {
   [ "$backup_count" -gt 0 ]
 }
 
+@test "overwrite strategy in stealth mode: backs up to external rig dir, not project" {
+  local rig_ext="$TEMP_DIR/rig-external"
+  mkdir -p "$TEST_PROJECT/.claude/hooks"
+  echo "STALE" > "$TEST_PROJECT/.claude/hooks/pre-tool.sh"
+
+  run_installer --strategy overwrite --tracking stealth --rig-dir "$rig_ext"
+  [ "$status" -eq 0 ]
+
+  # Backup must land in the external rig dir
+  local backup_count
+  backup_count="$(find "$rig_ext/backups" -name "pre-tool.sh" 2>/dev/null | wc -l | tr -d ' ')"
+  [ "$backup_count" -gt 0 ]
+
+  # No backup traces in the project repo
+  [ ! -d "$TEST_PROJECT/.rig-backup" ]
+}
+
 # ── Upgrade strategy ──────────────────────────────────────────────────────────
 
 @test "upgrade strategy: creates manifest on fresh install" {


### PR DESCRIPTION
## Summary

- `init_backup_dir()` now redirects backups to `$EXTERNAL_RIG_DIR/backups/<timestamp>/` in stealth and external tracking modes. Previously, backups always landed in `$TARGET/.rig-backup/`, which polluted the project's git status — defeating the purpose of stealth mode.
- `.rig-backup/` added to the stealth `.git/info/exclude` list as belt-and-suspenders.
- Backup report now shows the full absolute path (the previous `${BACKUP_DIR#$TARGET/}` strip was wrong for external paths).

## Docs

- `docs/customizing.md` upgrade snippet fixed: was running `./install.sh --project-only` from `~/tools/the-rig` (wrong directory, no `--target`). Now matches the correct two-step form already in README.md.
- Added a note that stealth/external backups go to the external rig path, not the project root.

## Closes
Closes #148

## Test plan
- [ ] `bats tests/` passes (62 total, including new test for stealth backup path)
- [ ] New test: "overwrite strategy in stealth mode: backs up to external rig dir, not project" — verifies backup in `$EXTERNAL_RIG_DIR/backups/` and no `.rig-backup/` in project
- [ ] Manually run stealth upgrade on a project and confirm no `.rig-backup/` in git status

## Notes

Reported from live stealth upgrade of `tableau-www`: `.rig-backup/` diff appeared in Sourcetree after upgrade.
