### PR TITLE
feat(hooks,processes): enforce 6 workflow gaps + 8 new bats tests [#149]

### DIFF
--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -63,17 +63,21 @@ Do not summarise these back to me unless asked.
 - **When you see a compaction warning** (e.g. "8% until auto-compact"), run `/wrap`
   immediately — before the next tool call. Compaction destroys in-flight context.
   A timely `/wrap` means the next session can resume cleanly.
-- **Gate freeform change requests through `/task`.** Before acting on any user
-  request that reads like a change request, apply this scope check:
+- **Gate freeform change requests through `/task`.** This check fires **before
+  the first Write, Edit, or Bash tool call** of any new request — not as a reminder
+  afterward. Read the user's message, apply the scope check, then act:
   - **Proceed directly** if the change is a one-liner or touches a single known file
     and can be verified in under 5 minutes. Offer to log it as a task file afterward.
-  - **Redirect to `/task`** if the change is likely to touch more than 2–3 files,
-    or would take more than one exchange to complete. Say:
+  - **Redirect to `/task`** if the request uses language like "add", "implement",
+    "build", "fix", "refactor", "clean up", "update X to handle Y" — and the scope
+    likely touches more than 2–3 files or takes more than one exchange to complete.
+    Say exactly:
     > "This looks like a task worth tracking. Should I open a `/task` intake?"
-    Wait for the user's response before touching any code.
-  - **If `issue-tracking: github`** (the default): never proceed on a multi-file change
-    without an issue number. If `issue-tracking: none` is set in the project `CLAUDE.md`:
-    proceed without one — but still redirect through `/task` for scope tracking.
+    **Wait for the user's response. Do not invoke any tool until they answer.**
+  - **If `issue-tracking: github`** (the default): never invoke a Write, Edit, or
+    Bash tool on a multi-file change without a linked issue number. If
+    `issue-tracking: none` is set in the project `CLAUDE.md`: proceed without one —
+    but still redirect through `/task` for scope tracking.
 
 ---
 
@@ -93,8 +97,12 @@ Do not summarise these back to me unless asked.
 8. **Never touch files outside the current task scope** unless explicitly asked.
 9. **Never make architectural decisions silently** — surface them for discussion first.
 10. **Never assume continuity from a prior session** — always re-read context files.
-11. **Never run `git commit` without the user's explicit go-ahead.** Before committing:
-    show the proposed commit message, then pause and say:
+11. **Never run `git commit` without the pre-ship checklist AND the user's explicit
+    go-ahead.** Before presenting the commit prompt:
+    (a) Confirm you have worked through the SHIP_WORKFLOW.md Step 1 checklist: no debug
+        statements, no commented-out code, no hardcoded secrets, error cases handled.
+        If you cannot confirm this, work through the list now — do not skip to the gate.
+    (b) Show the proposed commit message, then pause and say:
     > "Ready to commit. Test locally, then say **'commit approved'** (or 'ship it',
     > 'lgtm', 'go') and I'll commit and push immediately."
     When the user says one of those trigger phrases, create `$RIG_DIR/memory/.rig-commit-ok`,

--- a/templates/project/.claude/hooks/post-tool.sh
+++ b/templates/project/.claude/hooks/post-tool.sh
@@ -73,6 +73,23 @@ if [[ "$TOOL" == "Bash" ]]; then
       fi
     fi
   fi
+
+  # ── Branch naming convention check ───────────────────────────────────────
+  # After any Bash call that creates a new branch, warn if the name doesn't
+  # follow the project's naming conventions. Warning only — the branch already
+  # exists at this point. Agent should relay the warning to the user.
+  if echo "$RESULT" | grep -qE "Switched to a new branch '"; then
+    BRANCH_NAME=$(echo "$RESULT" \
+      | grep -oE "Switched to a new branch '[^']+'" \
+      | sed "s/Switched to a new branch '//;s/'$//")
+    VALID_BRANCH_PATTERN="^(feat|fix|chore|refactor|docs|test|perf|devops|style)/"
+    if [[ -n "$BRANCH_NAME" ]] && ! echo "$BRANCH_NAME" | grep -qE "$VALID_BRANCH_PATTERN"; then
+      echo "⚠️  Branch '$BRANCH_NAME' doesn't follow naming conventions."
+      echo "   Expected prefix: feat/ fix/ chore/ refactor/ docs/ test/ perf/ devops/ style/"
+      echo "   To rename: git branch -m '$BRANCH_NAME' '<type>/$BRANCH_NAME'"
+      echo "[$(date +%H:%M:%S)] BRANCH-WARN: '$BRANCH_NAME' — non-conventional name" >> "$SESSION_LOG"
+    fi
+  fi
 fi
 
 exit 0

--- a/templates/project/.claude/hooks/stop.sh
+++ b/templates/project/.claude/hooks/stop.sh
@@ -35,7 +35,8 @@ fi
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
 PROGRESS="$RIG_DIR/memory/PROGRESS.md"
 WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
-SESSION_LOG="/tmp/the-rig-session.log"
+# Allow tests to inject a custom session log path via RIG_SESSION_LOG env var.
+SESSION_LOG="${RIG_SESSION_LOG:-/tmp/the-rig-session.log}"
 NOW=$(date +%Y-%m-%d)
 NOW_FULL=$(date "+%Y-%m-%d %H:%M")
 
@@ -90,6 +91,20 @@ elif [[ ! -f "$SNAPSHOT" ]] && [[ -f "$PROGRESS" ]]; then
   touch "$WRAP_NEEDED"
   echo "[$(date +%H:%M:%S)] STOP: .wrap-needed written (no CONTEXT_SNAPSHOT.md)" \
     >> "$SESSION_LOG"
+fi
+
+# ── Write .wrap-needed if 2+ commits landed this session ──────────────────────
+# Even if stubs are expanded, 2+ commits means enough context has accumulated
+# to warrant capturing it. The session log records one "PROGRESS stub:" entry
+# per commit (written by post-tool.sh). If the flag is already set from above,
+# skip — no need to write it twice.
+if [[ ! -f "$WRAP_NEEDED" ]]; then
+  SESSION_COMMIT_COUNT=$(grep -c "PROGRESS stub:" "$SESSION_LOG" 2>/dev/null || echo 0)
+  if [[ "$SESSION_COMMIT_COUNT" -ge 2 ]]; then
+    touch "$WRAP_NEEDED"
+    echo "[$(date +%H:%M:%S)] STOP: .wrap-needed written (${SESSION_COMMIT_COUNT} commits this session — wrap recommended)" \
+      >> "$SESSION_LOG"
+  fi
 fi
 
 exit 0

--- a/templates/project/.husky/commit-msg
+++ b/templates/project/.husky/commit-msg
@@ -1,24 +1,75 @@
 #!/bin/sh
 # commit-msg
 #
-# Strips auto-injected tool footers from commit messages before they are
-# written to the repository — keeps history clean and human-authored in tone.
-# Remove this hook if you want tool footers (Co-Authored-By, Made-with-Claude, etc.)
-# to remain in your commit history.
+# 1. Strips auto-injected tool footers (Co-Authored-By, Made-with-Claude, etc.)
+#    to keep history clean and human-authored in tone.
+# 2. Validates Conventional Commits subject-line format.
+# 3. If issue-tracking: github (the default), requires a GitHub issue reference
+#    ([#N] or (#N)) in the subject line.
 #
-# Delegates to filter-commit-message-inplace.sh for the actual filtering.
-# Falls back to inline grep if the filter script is not present.
+# To disable format validation: set SKIP_COMMIT_VALIDATION=1 before committing.
+# To disable footer stripping: remove or comment out the filter block below.
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+COMMIT_MSG_FILE="$1"
 FILTER="${ROOT}/.husky/filter-commit-message-inplace.sh"
 
+# ── Step 1: Strip tool-injected footers ──────────────────────────────────────
 if [ -f "$FILTER" ]; then
-  sh "$FILTER" "$1"
+  sh "$FILTER" "$COMMIT_MSG_FILE"
 else
-  # Inline fallback — strips the most common trailer patterns
-  FILE="$1"
   tmp=$(mktemp) || exit 1
-  grep -viE '^[[:space:]]*(co-authored-by|signed-off-by|reviewed-by|acked-by|tested-by|helped-by|on-behalf-of|made-with)[[:space:]]*:' "$FILE" \
+  grep -viE '^[[:space:]]*(co-authored-by|signed-off-by|reviewed-by|acked-by|tested-by|helped-by|on-behalf-of|made-with)[[:space:]]*:' "$COMMIT_MSG_FILE" \
     | sed 's/\r$//' > "$tmp"
-  mv "$tmp" "$FILE"
+  mv "$tmp" "$COMMIT_MSG_FILE"
 fi
+
+# ── Step 2: Validate Conventional Commits format ─────────────────────────────
+[ "${SKIP_COMMIT_VALIDATION:-0}" = "1" ] && exit 0
+
+SUBJECT=$(head -1 "$COMMIT_MSG_FILE" | sed 's/\r//')
+
+# Skip validation for auto-generated commit types
+case "$SUBJECT" in
+  "Merge "* | "Revert "* | "fixup! "* | "squash! "* | "Initial commit"*)
+    exit 0 ;;
+esac
+
+VALID_TYPES="feat|fix|chore|refactor|docs|test|perf|devops|style"
+if ! echo "$SUBJECT" | grep -qE "^($VALID_TYPES)(\(.+\))?: .+"; then
+  echo ""
+  echo "ERROR: Commit message does not follow Conventional Commits format."
+  echo "  Expected: type(scope): description"
+  echo "  Types:    feat | fix | chore | refactor | docs | test | perf | devops | style"
+  echo "  Got:      $SUBJECT"
+  echo ""
+  echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
+  echo ""
+  exit 1
+fi
+
+# ── Step 3: Require issue reference if issue-tracking: github ────────────────
+CLAUDE_MD="${ROOT}/CLAUDE.md"
+ISSUE_TRACKING=""
+if [ -f "$CLAUDE_MD" ]; then
+  ISSUE_TRACKING=$(grep "^issue-tracking:" "$CLAUDE_MD" | awk '{print $2}' | tr -d '[:space:]' | head -1)
+fi
+# Default to github if not set
+: "${ISSUE_TRACKING:=github}"
+
+if [ "$ISSUE_TRACKING" = "github" ]; then
+  # Accept both [#N] (convention) and (#N) (GitHub squash-merge auto-format)
+  if ! echo "$SUBJECT" | grep -qE '(\[#[0-9]+\]|\(#[0-9]+\))'; then
+    echo ""
+    echo "ERROR: Commit message must include a GitHub issue reference."
+    echo "  Expected: type(scope): description [#N]"
+    echo "  Got:      $SUBJECT"
+    echo "  Create the issue first, then reference it: gh issue create ..."
+    echo ""
+    echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
+    echo ""
+    exit 1
+  fi
+fi
+
+exit 0

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -24,6 +24,16 @@ Before any code is written, a GitHub issue must exist and be linked in the task 
 The `/task` wizard enforces this: it will not proceed to Part 2 without an issue number.
 If you are running this workflow without going through `/task`, stop and create the issue now.
 
+**Issue validation — required before Step 1.** Open the task file and find the
+`**GitHub issue**: #[N]` field. Apply these rules:
+- If the field is empty, `N/A`, `TBD`, or absent: **stop. Do not proceed to Step 1.**
+  Either run `/task` to create a proper intake, or create the GitHub issue manually
+  and update the field before continuing. A task without a linked issue cannot be activated.
+- If the field contains a valid issue number (e.g. `#42`): proceed.
+
+This check applies whether the task was opened via `/task`, picked from the backlog
+manually, or resumed from `.rig/tasks/active/`.
+
 The issue number belongs in:
 - The task file's `**GitHub issue**: #[N]` field
 - Every commit message on this branch: `feat(scope): description [#N]`

--- a/templates/project/.rig/processes/SHIP_WORKFLOW.md
+++ b/templates/project/.rig/processes/SHIP_WORKFLOW.md
@@ -95,12 +95,17 @@ If any answer gives you pause, fix it before committing.
 
 ---
 
-## Step 2.5 — Pause for local testing
+## Step 2.5 — Checklist confirmation + pause for local testing
 
-**Stop. Do not commit yet.**
+**Before presenting this prompt, confirm you have worked through the Step 1 checklist.**
+Do not jump here from Step 0 or mid-implementation — the checklist is not optional.
+
+If you skipped Step 1 for any reason: run through it now before continuing.
+
+Then stop. Do not commit yet.
 
 Ask the user:
-> "Ready to commit. Test the changes locally, then say **'commit approved'**
+> "Pre-ship checklist complete. Test the changes locally, then say **'commit approved'**
 > (or 'ship it', 'lgtm', 'go') and I'll proceed."
 
 Wait for one of those trigger phrases (or equivalent clear confirmation).

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -656,3 +656,142 @@ _is_rig_protected() {
   [ -f "$TEST_PROJECT/.rig/memory/PROGRESS.md" ]
   [ ! -f "$TEST_PROJECT/.rigpath" ]
 }
+
+# ── Gap 4: stop.sh writes .wrap-needed on 2+ commits ─────────────────────────
+
+@test "stop.sh: writes .wrap-needed when session log has 2+ commits" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local rig_dir="$TEST_PROJECT/.rig"
+  local stop_hook="$TEST_PROJECT/.claude/hooks/stop.sh"
+  local session_log="$TEMP_DIR/test-session.log"
+  local wrap_needed="$rig_dir/memory/.wrap-needed"
+
+  # Provide a snapshot so the "no snapshot" trigger doesn't fire first,
+  # and ensure PROGRESS.md has no stubs (skip install creates none).
+  # Together these isolate to the 2+ commits path.
+  printf '**Last updated:** 2026-01-01 — test snapshot\n' \
+    > "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+
+  # Simulate two commits having been logged this session
+  printf '[10:00:00] PROGRESS stub: abc1234 feat(x): first commit [#1]\n' >> "$session_log"
+  printf '[10:01:00] PROGRESS stub: def5678 feat(x): second commit [#1]\n' >> "$session_log"
+
+  rm -f "$wrap_needed"
+
+  # Run stop.sh from inside the test project so git rev-parse resolves correctly
+  ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$stop_hook" )
+
+  [ -f "$wrap_needed" ]
+}
+
+@test "stop.sh: does not write .wrap-needed when session has fewer than 2 commits" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local rig_dir="$TEST_PROJECT/.rig"
+  local stop_hook="$TEST_PROJECT/.claude/hooks/stop.sh"
+  local session_log="$TEMP_DIR/test-session.log"
+  local wrap_needed="$rig_dir/memory/.wrap-needed"
+
+  # Same isolation: snapshot present, no stubs, only 1 commit in session log
+  printf '**Last updated:** 2026-01-01 — test snapshot\n' \
+    > "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+
+  printf '[10:00:00] PROGRESS stub: abc1234 feat(x): first commit [#1]\n' >> "$session_log"
+
+  rm -f "$wrap_needed"
+
+  ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$stop_hook" )
+
+  [ ! -f "$wrap_needed" ]
+}
+
+# ── Gap 5: commit-msg validates Conventional Commits format ───────────────────
+
+@test "commit-msg: rejects non-conventional commit message" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  # Overwrite CLAUDE.md with minimal content; hook only reads issue-tracking
+  printf 'issue-tracking: none\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'fixed stuff\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Conventional Commits"* ]]
+}
+
+@test "commit-msg: accepts valid conventional commit message" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: none\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: rejects message missing issue ref when issue-tracking: github" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  # Overwrite with controlled minimal content so first grep match is github
+  printf 'issue-tracking: github\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"issue reference"* ]]
+}
+
+@test "commit-msg: accepts message with [#N] issue ref when issue-tracking: github" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: github\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow [#42]\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: skips validation for merge commits" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: github\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf "Merge branch 'feat/foo' into main\n" > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: bypass with SKIP_COMMIT_VALIDATION=1" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'this is not conventional\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && SKIP_COMMIT_VALIDATION=1 sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- **Gap 1 (auto-gate)**: `templates/global/CLAUDE.md` — scope check now fires before the first tool call; explicit trigger-word list; agent must wait for user response before invoking any tool
- **Gap 2 (ship checklist)**: `SHIP_WORKFLOW.md` Step 2.5 renamed to "Checklist confirmation + pause"; Hard Rule #11 updated to require working through Step 1 checklist before presenting the commit prompt
- **Gap 3 (task issue validation)**: `NEW_TASK_WORKFLOW.md` — issue validation block added at top of Step 0; blocks activation of any task lacking a linked issue number
- **Gap 4 (proactive wrap trigger)**: `stop.sh` — SESSION_LOG injectable via env var for testability; writes .wrap-needed when 2+ commits land in a session
- **Gap 5 (commit-msg validation)**: `commit-msg` hook — Conventional Commits format check added; SKIP_COMMIT_VALIDATION=1 bypass; merge/revert/fixup/squash commits exempted; accepts [#N] and (#N) issue ref forms
- **Gap 6 (branch naming check)**: `post-tool.sh` — warns on non-conventional branch names after checkout
- **Tests**: 8 new bats tests, 69 total; covers all of gaps 4 and 5

## Test plan

- [x] `bats tests/` — 69/69 passing before commit
- [x] All 8 new tests pass in isolation
- [ ] Smoke-test commit-msg hook on a real project after install

Closes #149

Generated with Claude Code