### PR TITLE
feat(config): expand issue-tracking to Linear/Trello/GUS + issue-creator field [#155]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Global upgrade: auto-extracts existing `PROFILE_PATH` from installed `~/.claude/CLAUDE.md` (no prompt)
 - Global upgrade: `PROFILE.md` is never touched (personal data, always off-limits)
 - 2 new bats tests for global upgrade behavior (75 total)
+- **Multi-tracker issue enforcement** (`templates/project/CLAUDE.md`, `templates/project/.claude/commands/task.md`, `templates/project/.rig/processes/NEW_TASK_WORKFLOW.md`, `templates/project/.husky/commit-msg`): expanded issue-tracking support from GitHub-only to Linear, Trello, and GUS. `CLAUDE.md` now documents all five `issue-tracking:` values (`github`, `linear`, `trello`, `gus`, `none`) with per-tracker ref formats. Added `issue-creator:` field (`user` | `agent`) with `agent` only applying to GitHub. The `/task` intake wizard handles all tracker types in question 4. `NEW_TASK_WORKFLOW.md` Step 0 updated to document all trackers and their required ticket validation rules. `commit-msg` hook Step 3 now validates per-tracker ref format (`[#N]` for GitHub, `[TEAM-123]` for Linear, `[trello:ID]` for Trello, `[W-N]` for GUS, no check for `none`). 6 new bats tests (79 total). Closes #155.
 
 ### Fixed
 - `RIG_TRACKING` was unbound during `--global-only` runs, crashing `init_backup_dir` under `set -u`

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -39,20 +39,31 @@ Ask the user the following. Collect all answers before moving to Part 2.
    the codebase (what service, module, or directory will this touch?).
 3. **Hard constraints?** Any deadline, off-limits paths, technology restrictions, or
    things that must not change?
-4. **GitHub issue number?** Read `issue-tracking:` from `CLAUDE.md` first.
-   - **If `issue-tracking: github`** (or field is absent — default): an issue is required.
-     - If the user provides a number (e.g. `#42`): note it and continue.
-     - If no issue exists yet: **stop here.** Say exactly:
-       > "Every task needs a GitHub issue before we start. Create one now and share
-       > the number — I'll wait. It goes in the task file and every commit."
+4. **Issue/ticket?** Read `issue-tracking:` and `issue-creator:` from `CLAUDE.md` first.
+
+   - **`issue-tracking: github`** (or field absent — default):
+     - Also read `issue-creator:` (default: `user`).
+     - **`issue-creator: user`**: A GitHub issue is required. If the user already provided a number (e.g. `#42`), note it and continue. If none exists yet, stop and say exactly:
+       > "Every task needs a GitHub issue before we start. Create one now and share the number — I'll wait. It goes in the task file and every commit."
        Do not proceed to Part 2 until a real issue number is provided.
-   - **If `issue-tracking: none`**: skip the issue requirement. Note in the task file:
-     `**GitHub issue**: N/A (issue-tracking: none)`. Continue to Part 2 immediately.
+     - **`issue-creator: agent`**: Create the GitHub issue now using the task description from question 1. Run:
+       ```bash
+       gh issue create --title "[task title]" --body "[one-line context]"
+       ```
+       Note the number, tell the user: "Created issue #[N]. Proceeding." If the user already provided a number, use that instead — skip creation.
+
+   - **`issue-tracking: linear`**: Ask for the existing Linear ticket ID (e.g. `ENG-123`). Note in the task file: `**Issue**: ENG-123`. Agent never creates Linear tickets. If no ticket exists, stop and ask the user to create one.
+
+   - **`issue-tracking: trello`**: Ask for the existing Trello card ID or short URL. Note in the task file: `**Issue**: trello:CARD-ID`. Agent never creates Trello cards.
+
+   - **`issue-tracking: gus`**: Ask for the existing GUS work item ID (e.g. `W-1234567`). Note in the task file: `**Issue**: W-1234567`. Agent never creates GUS items.
+
+   - **`issue-tracking: none`**: Skip the issue requirement. Note in the task file: `**Issue**: N/A (issue-tracking: none)`. Continue to Part 2 immediately.
 
 After collecting all answers, confirm back:
 
 > "Got it. You want to [restate task in one sentence], working in [area], with
-> [constraints or 'no hard constraints']. Issue: #[N]. Let's configure how I'll operate."
+> [constraints or 'no hard constraints']. Issue: [ref]. Let's configure how I'll operate."
 
 ---
 

--- a/templates/project/.husky/commit-msg
+++ b/templates/project/.husky/commit-msg
@@ -4,8 +4,8 @@
 # 1. Strips auto-injected tool footers (Co-Authored-By, Made-with-Claude, etc.)
 #    to keep history clean and human-authored in tone.
 # 2. Validates Conventional Commits subject-line format.
-# 3. If issue-tracking: github (the default), requires a GitHub issue reference
-#    ([#N] or (#N)) in the subject line.
+# 3. Requires an issue/ticket reference in the subject line, format depending on
+#    issue-tracking: in CLAUDE.md (github | linear | trello | gus | none).
 #
 # To disable format validation: set SKIP_COMMIT_VALIDATION=1 before committing.
 # To disable footer stripping: remove or comment out the filter block below.
@@ -48,7 +48,7 @@ if ! echo "$SUBJECT" | grep -qE "^($VALID_TYPES)(\(.+\))?: .+"; then
   exit 1
 fi
 
-# ── Step 3: Require issue reference if issue-tracking: github ────────────────
+# ── Step 3: Require issue/ticket reference based on issue-tracking setting ───
 CLAUDE_MD="${ROOT}/CLAUDE.md"
 ISSUE_TRACKING=""
 if [ -f "$CLAUDE_MD" ]; then
@@ -57,19 +57,63 @@ fi
 # Default to github if not set
 : "${ISSUE_TRACKING:=github}"
 
-if [ "$ISSUE_TRACKING" = "github" ]; then
-  # Accept both [#N] (convention) and (#N) (GitHub squash-merge auto-format)
-  if ! echo "$SUBJECT" | grep -qE '(\[#[0-9]+\]|\(#[0-9]+\))'; then
-    echo ""
-    echo "ERROR: Commit message must include a GitHub issue reference."
-    echo "  Expected: type(scope): description [#N]"
-    echo "  Got:      $SUBJECT"
-    echo "  Create the issue first, then reference it: gh issue create ..."
-    echo ""
-    echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
-    echo ""
-    exit 1
-  fi
-fi
+case "$ISSUE_TRACKING" in
+  github)
+    # Accept both [#N] (convention) and (#N) (GitHub squash-merge auto-format)
+    if ! echo "$SUBJECT" | grep -qE '(\[#[0-9]+\]|\(#[0-9]+\))'; then
+      echo ""
+      echo "ERROR: Commit message must include a GitHub issue reference."
+      echo "  Expected: type(scope): description [#N]"
+      echo "  Got:      $SUBJECT"
+      echo "  Create the issue first: gh issue create ..."
+      echo ""
+      echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
+      echo ""
+      exit 1
+    fi
+    ;;
+  linear)
+    # Linear ticket format: [TEAM-123] where TEAM is one or more uppercase letters
+    if ! echo "$SUBJECT" | grep -qE '\[[A-Z]+-[0-9]+\]'; then
+      echo ""
+      echo "ERROR: Commit message must include a Linear ticket reference."
+      echo "  Expected: type(scope): description [TEAM-123]"
+      echo "  Got:      $SUBJECT"
+      echo ""
+      echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
+      echo ""
+      exit 1
+    fi
+    ;;
+  trello)
+    # Trello card format: [trello:CARD-ID]
+    if ! echo "$SUBJECT" | grep -qE '\[trello:[^]]+\]'; then
+      echo ""
+      echo "ERROR: Commit message must include a Trello card reference."
+      echo "  Expected: type(scope): description [trello:CARD-ID]"
+      echo "  Got:      $SUBJECT"
+      echo ""
+      echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
+      echo ""
+      exit 1
+    fi
+    ;;
+  gus)
+    # GUS work item format: [W-1234567]
+    if ! echo "$SUBJECT" | grep -qE '\[W-[0-9]+\]'; then
+      echo ""
+      echo "ERROR: Commit message must include a GUS work item reference."
+      echo "  Expected: type(scope): description [W-1234567]"
+      echo "  Got:      $SUBJECT"
+      echo ""
+      echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
+      echo ""
+      exit 1
+    fi
+    ;;
+  none|*)
+    # No tracker configured — no reference required
+    ;;
+esac
 
 exit 0

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -13,30 +13,41 @@
 
 ---
 
-## Step 0 — GitHub issue first
+## Step 0 — Issue/ticket first
 
 **Read `issue-tracking:` from `CLAUDE.md` before proceeding.**
 
-- **If `issue-tracking: none`:** skip this step. No issue number is required in the task file or commit messages. Continue to Step 1.
-- **If `issue-tracking: github`** (or field absent — default): follow the full step below.
+| `issue-tracking` value | Required before Step 1 |
+|---|---|
+| `github` (or absent) | GitHub issue `#N`; read `issue-creator:` to decide who creates it |
+| `linear` | Linear ticket ID (e.g. `ENG-123`); user always provides |
+| `trello` | Trello card ID; user always provides |
+| `gus` | GUS work item ID (e.g. `W-1234567`); user always provides |
+| `none` | No ticket required — skip this step |
 
-Before any code is written, a GitHub issue must exist and be linked in the task file.
-The `/task` wizard enforces this: it will not proceed to Part 2 without an issue number.
-If you are running this workflow without going through `/task`, stop and create the issue now.
+**If `issue-tracking: github`** (or absent):
 
-**Issue validation — required before Step 1.** Open the task file and find the
-`**GitHub issue**: #[N]` field. Apply these rules:
+Also read `issue-creator:` (default: `user`).
+- `issue-creator: user`: block until the user provides `#N`. Do not proceed without it.
+- `issue-creator: agent`: create the issue now with `gh issue create`, note the `#N`, proceed.
+  If the user already provided a number, use that instead — skip creation.
+
+**Ticket validation — required before Step 1.** Open the task file and find the
+`**Issue**: [ref]` field. Apply these rules:
 - If the field is empty, `N/A`, `TBD`, or absent: **stop. Do not proceed to Step 1.**
-  Either run `/task` to create a proper intake, or create the GitHub issue manually
-  and update the field before continuing. A task without a linked issue cannot be activated.
-- If the field contains a valid issue number (e.g. `#42`): proceed.
+  Either run `/task` to create a proper intake, or add the ticket reference manually.
+- If the field contains a valid reference for the configured tracker: proceed.
 
-This check applies whether the task was opened via `/task`, picked from the backlog
-manually, or resumed from `.rig/tasks/active/`.
+This check applies whether the task was opened via `/task`, picked from the backlog,
+or resumed from `.rig/tasks/active/`.
 
-The issue number belongs in:
-- The task file's `**GitHub issue**: #[N]` field
-- Every commit message on this branch: `feat(scope): description [#N]`
+The ticket reference belongs in:
+- The task file's `**Issue**: [ref]` field
+- Every commit message on this branch (format per tracker):
+  - GitHub: `feat(scope): description [#N]`
+  - Linear: `feat(scope): description [ENG-123]`
+  - Trello: `feat(scope): description [trello:CARD-ID]`
+  - GUS: `feat(scope): description [W-1234567]`
 
 ---
 

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -112,8 +112,20 @@ issue-tracking: github
 
 | Value | Behaviour |
 |---|---|
-| `github` | GitHub issues are required before any code is written. `/task` blocks until an issue number is provided. Issue number goes in every commit. `gh` CLI is used for all PR/issue operations. |
-| `none` | No issue tracker in use. Issue number requirement is skipped in `/task`, `/ship`, and commit messages. Use for personal projects, prototypes, or non-GitHub repos. |
+| `github` | GitHub issues required. `/task` blocks until issue number provided (or agent creates one if `issue-creator: agent`). Ref format: `[#N]`. `gh` CLI used for all PR/issue operations. |
+| `linear` | Linear tickets required. User provides existing ticket ID (e.g. `ENG-123`). Ref format: `[ENG-123]`. Agent never creates Linear tickets. |
+| `trello` | Trello cards required. User provides existing card ID. Ref format: `[trello:CARD-ID]`. Agent never creates Trello cards. |
+| `gus` | GUS work items required. User provides existing item ID (e.g. `W-1234567`). Ref format: `[W-1234567]`. Agent never creates GUS items. |
+| `none` | No issue tracker. Issue requirement is skipped in `/task`, `/ship`, and commit messages. Use for personal projects or prototypes. |
+
+```
+issue-creator: user
+```
+
+| Value | Behaviour |
+|---|---|
+| `user` | (Default) Agent blocks and waits for the user to provide a ticket number before starting any task. |
+| `agent` | Agent creates the GitHub issue itself using the task description, then proceeds immediately. **Only applies when `issue-tracking: github`.** For all other trackers, `user` behavior is always used regardless of this setting. |
 
 ```
 secret-scanner: gitleaks

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -852,6 +852,93 @@ _is_rig_protected() {
   [ "$status" -eq 0 ]
 }
 
+@test "commit-msg: rejects message missing Linear ref when issue-tracking: linear" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: linear\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Linear"* ]]
+}
+
+@test "commit-msg: accepts message with Linear ref when issue-tracking: linear" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: linear\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow [ENG-123]\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: rejects message missing Trello ref when issue-tracking: trello" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: trello\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Trello"* ]]
+}
+
+@test "commit-msg: accepts message with Trello ref when issue-tracking: trello" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: trello\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow [trello:abc123]\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: rejects message missing GUS ref when issue-tracking: gus" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: gus\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"GUS"* ]]
+}
+
+@test "commit-msg: accepts message with GUS ref when issue-tracking: gus" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: gus\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'feat(auth): add login flow [W-1234567]\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
 # ── pre-commit: .rig-debug-scan-exclude path exclusions ──────────────────────
 
 @test "pre-commit: .rig-debug-scan-exclude skips matched paths" {


### PR DESCRIPTION
## Summary

- Expands `issue-tracking:` in the `CLAUDE.md` template from GitHub-only to all five values: `github`, `linear`, `trello`, `gus`, `none`
- Adds `issue-creator:` field (`user` | `agent`; `agent` applies to GitHub only)
- Updates `/task` intake wizard (Part 1, question 4) to branch per tracker type — Linear/Trello/GUS block until user provides existing ticket ID; GitHub routes through `issue-creator` logic
- Overhauled `NEW_TASK_WORKFLOW.md` Step 0 with tracker table, `issue-creator:` handling, and per-tracker commit ref formats (`[#N]`, `[TEAM-123]`, `[trello:ID]`, `[W-N]`)
- `commit-msg` hook Step 3 replaced with `case "$ISSUE_TRACKING"` block validating ref format per tracker; `none`/unknown skips validation
- 6 new bats tests (79 total, all passing)

## Test plan

- [x] `bats tests/` — 79/79 pass
- [x] New tests cover reject + accept for Linear, Trello, and GUS
- [x] Existing GitHub and `none` tests unchanged and passing

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)