### PR TITLE
docs: update stale documentation for v1.13.0 state [#160]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `mktemp /tmp/rig-global-claude-XXXXXX.md` used non-portable suffix (X's must be at end on macOS); replaced with bare `mktemp`
 - `BACKUP_DIR` reset between global and project layer so each layer uses its correct base path
 
+### Changed
+
+- **Documentation updated for v1.13.0 state** (`README.md`, `docs/how-it-works.md`, `docs/customizing.md`, `docs/decisions.md`): commit-msg hook description now includes Conventional Commits validation and per-tracker issue ref enforcement; `/rig-upgrade` added to command lists; installer flags section in how-it-works documents `--tracking`, `--target`, `--strategy`; issue-tracking settings table expanded to all five values; `--rig-dir` → `--tracking external` corrected in customizing.md; three new decision entries (#11–#13) for `--tracking` flag decoupling, global upgrade manifest, and multi-tracker issue enforcement. Closes #160.
+
 ---
 
 ## [1.12.0] — 2026-05-07

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 /session-name →  derive a session name from current work and present it as a suggestion
 /wrap         →  write CONTEXT_SNAPSHOT, ensure memory is current, log any Rig gaps before closing
 /rig-gaps     →  compile workflow friction from RIG_GAPS.md + ERRORS.md; format for submission to The Rig dev session
+/rig-upgrade  →  pull latest Rig source and re-run the installer with --strategy upgrade
 ```
 
 ---
@@ -248,7 +249,8 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 | `post-tool.sh` | After every Claude Code tool call | PROGRESS.md being skipped after a commit; clears commit sentinel after use |
 | `stop.sh` | When the agent finishes its final response | CONTEXT_SNAPSHOT going stale — updates `Last updated:` and appends a session-end boundary to PROGRESS.md without requiring `/wrap` |
 | `pre-commit` | Before every git commit | Secrets reaching the repository |
-| `commit-msg` + `post-commit` | On every git commit | Auto-injected tool footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.) from embedding in commit messages — keeps history clean |
+| `commit-msg` | On every git commit | (1) Strips auto-injected tool footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.) from commit messages; (2) validates Conventional Commits subject-line format; (3) requires a tracker-specific issue reference (`[#N]` for GitHub, `[TEAM-123]` for Linear, etc.) when `issue-tracking:` is set in `CLAUDE.md` |
+| `post-commit` | After every git commit | Re-applies footer stripping in case the git client re-injected footers after `commit-msg` ran |
 
 ---
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -12,13 +12,13 @@ in the project `CLAUDE.md`. Set these once and every session inherits them:
 ```
 base-branch: main          # integration branch all PRs target
 housekeeping: direct-push  # direct-push | pr-required (how /post-merge commits)
-issue-tracking: github     # github | none (skip issue gate for personal/prototype repos)
+issue-tracking: github     # github | linear | trello | gus | none
+issue-creator: user        # user (default) | agent — GitHub only: agent auto-creates issues
 secret-scanner: gitleaks   # gitleaks | none
 commit-cleanup: yes        # yes | no (strip auto-injected tool footers from commits)
 ```
 
-**`issue-tracking: none`** is the most common override for non-GitHub or personal projects.
-It disables the issue-number requirement in `/task`, `/ship`, and commit messages.
+**`issue-tracking:`** shapes the entire task intake and commit workflow. The ref format enforced in the `commit-msg` hook (`[#N]`, `[TEAM-123]`, `[trello:ID]`, `[W-N]`) and the intake question in `/task` both follow the configured tracker. Set to `none` for personal projects, prototypes, or repos without an issue tracker.
 
 For deeper customization of individual components, see the sections below.
 
@@ -206,11 +206,10 @@ echo ".rig/" >> .git/info/exclude
 
 ### Option B — External directory
 
-Install `.rig/` to a path outside the repo entirely. Pass `--rig-dir` to the
-installer:
+Install `.rig/` to a path outside the repo entirely. Use `--tracking external` with an optional `--rig-dir` to specify the path:
 
 ```bash
-~/tools/the-rig/install.sh --project-only --rig-dir ~/.rig/projects/my-project
+~/tools/the-rig/install.sh --project-only --tracking external --rig-dir ~/.rig/projects/my-project
 ```
 
 Or choose option 3 in the interactive tracking prompt. The installer will:
@@ -229,7 +228,7 @@ The project root stays clean. The agent finds its memory and rules via
 > ⚠️ **Re-clone warning:** when you clone the project on a new machine, the
 > external `.rig/` directory doesn't travel with it. You must manually restore
 > the external directory on the new machine — either by re-running the installer
-> with `--rig-dir` pointing to the same path, or by copying it from a backup.
+> with `--tracking external --rig-dir <same-path>`, or by copying it from a backup.
 > See `docs/troubleshooting.md` → "CONTEXT_SNAPSHOT.md is missing after a re-clone"
 > for the full recovery steps.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -121,3 +121,39 @@ Why The Rig is built the way it is. Each entry covers what was decided, what was
 **Rationale:** Agents under time pressure or approaching a context limit routinely skip housekeeping. The auto-stub means there's always a placeholder entry after every commit — the agent expands it during wrap-up, but if the session ends abruptly, the record still exists. The stub is idempotent (won't duplicate if the hash is already in the file) and clearly marked as auto-logged.
 
 **Tradeoff accepted:** Heuristic-based detection (hash in brackets) could produce false positives if non-commit bash output happens to match the pattern. Accepted — a spurious stub is much less harmful than a missing entry.
+
+---
+
+## 11. `--tracking` flag is orthogonal to `--target`
+
+**Decided:** `--tracking repo|local|external|stealth` is a separate flag that sets the tracking mode independently of `--target` (which only sets the destination path).
+
+**Rejected:** Using `--target` as the signal for tracking mode (i.e. "if `--target` is provided, use local tracking"), which was the original behaviour.
+
+**Rationale:** The original coupling meant that any non-interactive install with `--target` would silently default to local tracking, even when the user intended stealth or external. Decoupling lets users run fully non-interactive stealth installs: `./install.sh --target <path> --tracking stealth --strategy merge`. The interactive prompt still exists when neither flag is provided.
+
+**Tradeoff accepted:** One more flag to remember for scripted installs. Documented in `docs/agent-install.md` with full non-interactive examples.
+
+---
+
+## 12. Global layer now tracked by a separate upgrade manifest
+
+**Decided:** The global layer (`~/.claude/CLAUDE.md`, `~/.claude/skills/`) has its own manifest file (`~/.claude/.rig-global-manifest`) separate from the project-layer `.rig/memory/.rig-manifest`.
+
+**Rejected:** Re-using the project manifest for global files, or having no manifest for the global layer (leaving it unprotected from silent overwrites on upgrade).
+
+**Rationale:** The global and project layers have different file locations and lifecycles. Sharing a manifest would conflate two unrelated sets of files. Without a global manifest, every upgrade run would either silently overwrite `~/.claude/CLAUDE.md` (losing user customizations) or never update it (leaving Rig rule changes undelivered). The separate manifest gives the same upsert/detect-customization behaviour for both layers.
+
+**Tradeoff accepted:** Two manifest files to maintain. Acceptable — they are in different directories and the same `write_manifest_entry()` / `read_manifest_hash()` functions handle both (via temporary `MANIFEST_FILE` redirection).
+
+---
+
+## 13. Issue tracking is configurable per project with per-tracker commit ref enforcement
+
+**Decided:** `issue-tracking: github|linear|trello|gus|none` controls the entire intake and commit workflow. The `commit-msg` hook validates the ref format for the configured tracker at every commit.
+
+**Rejected:** GitHub-only enforcement (the original design), or treating all non-GitHub trackers as `none` (no enforcement).
+
+**Rationale:** Real teams use Linear, Trello, GUS, and other trackers. The original GitHub-only gate would either force teams to set `issue-tracking: none` (losing all enforcement) or use GitHub issues in addition to their real tracker (double bookkeeping). Per-tracker enforcement extends the discipline — commit messages prove the ticket exists for whichever tracker the team uses.
+
+**Tradeoff accepted:** Each new tracker type requires a regex pattern in `commit-msg` and handling in the `/task` intake wizard. Acceptable — the pattern is simple and each tracker has a well-defined ref format.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -34,6 +34,13 @@ Three locations work together. The installer repo produces the other two:
 │  ~/tools/the-rig/templates/    ← source files for both layers   │
 │  ~/tools/the-rig/VERSION       ← current Rig version            │
 │                                                                 │
+│  Key flags (for non-interactive / agent-driven installs):       │
+│    --global-only               install only global layer        │
+│    --project-only              install only project layer       │
+│    --target <path>             project directory to install to  │
+│    --tracking repo|local|external|stealth  tracking mode        │
+│    --strategy merge|upgrade|overwrite|skip  file handling       │
+│                                                                 │
 │  To upgrade: cd ~/tools/the-rig && git pull                     │
 │  Then re-run install.sh with --strategy upgrade                 │
 └───────────────┬─────────────────────────┬───────────────────────┘
@@ -294,6 +301,15 @@ git commit
      │     Apply filter-commit-message-inplace.sh to message file
      │     Strips: Co-authored-by, Signed-off-by, Made-with trailers
      │     Strips: "Generated with Claude/Cursor/Copilot" footer lines
+     │     Validates Conventional Commits subject-line format
+     │       (type(scope): description — skips Merge/Revert/fixup/squash)
+     │     Requires tracker-specific issue reference when issue-tracking: is set:
+     │       github → [#N] or (#N)
+     │       linear → [TEAM-123]
+     │       trello → [trello:CARD-ID]
+     │       gus    → [W-1234567]
+     │       none   → no requirement
+     │     Bypass: SKIP_COMMIT_VALIDATION=1
      │
      └─► post-commit
            Re-read committed message
@@ -397,7 +413,7 @@ proportion to the complexity of the work — not because of Rig overhead.
 
 ## The command set
 
-Thirteen slash commands covering the full development lifecycle:
+Fourteen slash commands covering the full development lifecycle:
 
 ### Project bootstrap
 | Command | Triggers | Key behaviour |
@@ -431,6 +447,7 @@ Thirteen slash commands covering the full development lifecycle:
 | `/session-name` | Session naming | Derives a session name from current PROGRESS entries and presents it as a suggestion — callable at any time, not just at wrap |
 | `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, runs self-improvement check (logs Rig gaps), trims PROGRESS/ERRORS, suggests session name, surfaces next priority |
 | `/rig-gaps` | Self-improvement | Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats a report with submission instructions for The Rig dev session |
+| `/rig-upgrade` | Upgrade workflow | Pulls latest Rig source (`git pull` in installer repo) and re-runs `install.sh` against the current project with `--strategy upgrade` |
 | `/new-feature` | *(deprecated)* | Redirects to `/task`. Kept for backward compatibility only. |
 
 ---
@@ -463,13 +480,12 @@ These sit alongside the existing `base-branch:` and `housekeeping:` fields:
 |---|---|---|---|
 | `base-branch:` | `main` | Any branch name | The integration branch all PRs target |
 | `housekeeping:` | `direct-push` | `direct-push` \| `pr-required` | How `/post-merge` handles memory-update commits |
-| `issue-tracking:` | `github` | `github` \| `none` | Whether GitHub issues are required before code; skips issue gate if `none` |
+| `issue-tracking:` | `github` | `github` \| `linear` \| `trello` \| `gus` \| `none` | Which issue tracker is required; shapes ref format in commit messages and intake wizard |
+| `issue-creator:` | `user` | `user` \| `agent` | GitHub only: whether the agent creates issues itself (`agent`) or waits for the user to provide a number (`user`) |
 | `secret-scanner:` | `gitleaks` | `gitleaks` \| `none` | Secret scanning on commit; disabling requires editing `.husky/pre-commit` |
 | `commit-cleanup:` | `yes` | `yes` \| `no` | Whether auto-injected tool footers are stripped from commit messages |
 
-The `issue-tracking: none` setting is the most impactful: it disables the issue-number
-gate in `/task`, `/ship`, `SHIP_WORKFLOW`, and `NEW_TASK_WORKFLOW`. Use it for personal
-projects, prototypes, or repos that don't use GitHub issues.
+The `issue-tracking:` setting shapes the entire task intake and commit workflow: the ref format expected in commit messages (`[#N]`, `[TEAM-123]`, `[trello:ID]`, `[W-N]`) and the intake question in `/task` both follow the configured tracker. Set to `none` for personal projects, prototypes, or repos without an issue tracker.
 
 Branch creation behavior is also parameterized by autonomy level:
 - **Low/Medium**: always confirm the base branch before `git checkout -b`


### PR DESCRIPTION
## Summary

- **README.md**: expands `commit-msg` hook row to include Conventional Commits validation + per-tracker issue ref enforcement; adds `/rig-upgrade` to command list
- **docs/how-it-works.md**: `commit-msg` hook diagram updated with validation steps and all tracker ref formats; installer section documents `--tracking`, `--target`, `--strategy` flags; `/rig-upgrade` added to command table; `issue-tracking` settings table expanded to all five values + `issue-creator`
- **docs/customizing.md**: project settings quick reference updated with all `issue-tracking` values and `issue-creator` field; `--rig-dir` → `--tracking external` corrected; re-clone warning updated
- **docs/decisions.md**: three new entries — #11 `--tracking` flag decoupling, #12 global upgrade manifest, #13 multi-tracker issue enforcement

## Test plan

- [x] Docs-only change — no code modified
- [x] All links and cross-references verified manually
- [x] `bash -n install.sh` still passes (install.sh untouched)

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)