### PR TITLE
feat(commands): rename /propose → /rig-propose [#163]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **`/propose` renamed to `/rig-propose`** (`templates/project/.claude/commands/propose.md` → `rig-propose.md`): aligns with the `rig-` prefix convention used by `/rig-gaps` and `/rig-upgrade`. All cross-file references updated: `pre-tool.sh`, `kickoff.md`, `run.md`, `task.md`, `docs/how-it-works.md`, `docs/customizing.md`, `README.md`. Closes #163.
+
 ---
 
 ## [1.13.0] — 2026-05-09

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 **Governance and housekeeping**
 ```
 /post-merge   →  post-merge hygiene: pull main, update memory, move task file, housekeeping commit
-/propose      →  submit a change to governance files for human approval before anything is touched
+/rig-propose  →  submit a change to governance files for human approval before anything is touched
 /session-name →  derive a session name from current work and present it as a suggestion
 /wrap         →  write CONTEXT_SNAPSHOT, ensure memory is current, log any Rig gaps before closing
 /rig-gaps     →  compile workflow friction from RIG_GAPS.md + ERRORS.md; format for submission to The Rig dev session

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -77,7 +77,7 @@ Keep entries specific enough to not accidentally block legitimate paths.
 
 The `RIG_PROTECTED` block above `BLOCKED_PATHS` protects The Rig's own governance files
 (`.rig/processes/`, `.rig/rules/`, `.husky/`, `CLAUDE.md`, `.claude/hooks/`).
-Don't modify it directly — use `/propose` instead.
+Don't modify it directly — use `/rig-propose` instead.
 
 ---
 
@@ -141,14 +141,14 @@ preferred settings.
 
 ---
 
-## Configuring protected paths for /propose
+## Configuring protected paths for /rig-propose
 
-The governance gate in `/propose` mirrors the `RIG_PROTECTED` list in `pre-tool.sh`.
+The governance gate in `/rig-propose` mirrors the `RIG_PROTECTED` list in `pre-tool.sh`.
 If you add new governance files that should require a proposal before modification,
 add them to both places:
 
 1. `pre-tool.sh` → `RIG_PROTECTED` array
-2. `commands/propose.md` → "When to use it" section
+2. `commands/rig-propose.md` → "When to use it" section
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -443,7 +443,7 @@ Fourteen slash commands covering the full development lifecycle:
 | Command | Triggers | Key behaviour |
 |---|---|---|
 | `/post-merge` | `POST_MERGE_WORKFLOW` | Post-merge hygiene: pull base branch, update PROGRESS, move task file, housekeeping commit, suggest session name, surface next priority |
-| `/propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
+| `/rig-propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
 | `/session-name` | Session naming | Derives a session name from current PROGRESS entries and presents it as a suggestion — callable at any time, not just at wrap |
 | `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, runs self-improvement check (logs Rig gaps), trims PROGRESS/ERRORS, suggests session name, surfaces next priority |
 | `/rig-gaps` | Self-improvement | Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats a report with submission instructions for The Rig dev session |
@@ -466,7 +466,7 @@ The configuration is written to `## Operating mode` in the task file and persist
 across sessions. `/run` reads the stored mode and executes accordingly — chaining
 tasks without interruption at High autonomy, pausing between tasks at Medium and Low.
 
-Governance (protected paths, `/propose` gate, pre-ship checklist) applies at all
+Governance (protected paths, `/rig-propose` gate, pre-ship checklist) applies at all
 autonomy levels. "High Autonomous" means fewer interruptions, not fewer safeguards.
 
 ---

--- a/templates/project/.claude/commands/kickoff.md
+++ b/templates/project/.claude/commands/kickoff.md
@@ -232,7 +232,7 @@ After scaffolding is complete:
   the existing `CLAUDE.md` and `.rig/tasks/` first.
 - The task backlog generated here is a starting point, not a contract. Adjust
   priorities, split tasks, or add new ones freely as the project develops.
-- All governance rules apply during scaffolding. Protected paths, the `/propose`
+- All governance rules apply during scaffolding. Protected paths, the `/rig-propose`
   gate, and secret handling are all still active.
 - `.rig/memory/RIG_GAPS.md` ships with the project scaffold. As you build, the agent
   logs workflow friction to it during `/wrap`. Use `/rig-gaps` to compile and submit

--- a/templates/project/.claude/commands/rig-propose.md
+++ b/templates/project/.claude/commands/rig-propose.md
@@ -1,4 +1,4 @@
-# Command: /propose
+# Command: /rig-propose
 
 Use this command when you believe a change to The Rig's governance files would
 improve the system. Governance files — `.rig/processes/`, `.rig/rules/`, `.husky/`,
@@ -40,7 +40,7 @@ After applying: tell the agent it's done. It will log the change in
 ## Usage
 
 ```
-/propose
+/rig-propose
 ```
 
 Claude will ask:
@@ -55,7 +55,7 @@ for your review. **No governance file is touched until you say "apply it".**
 
 ## When to use it
 
-Use `/propose` when you've noticed:
+Use `/rig-propose` when you've noticed:
 - A step in a workflow that consistently gets skipped or causes confusion
 - A rule that's either too strict or not strict enough for this project
 - A hook behaviour that needs adjustment
@@ -65,7 +65,7 @@ Use `/propose` when you've noticed:
 
 ## When NOT to use it
 
-Do not use `/propose` for:
+Do not use `/rig-propose` for:
 - Application code changes — edit those directly
 - Memory files (`PROGRESS.md`, `ERRORS.md`, `CONTEXT_SNAPSHOT.md`) — update those directly
 - Task files — manage those directly

--- a/templates/project/.claude/commands/run.md
+++ b/templates/project/.claude/commands/run.md
@@ -180,7 +180,7 @@ If the queue is exhausted, always surface to the user regardless of autonomy lev
 Regardless of autonomy level, all of the following always apply:
 
 - Pre-tool hooks run on every file write. Governance files remain protected.
-- Changes to The Rig's own processes, rules, hooks, or CLAUDE.md require `/propose`.
+- Changes to The Rig's own processes, rules, hooks, or CLAUDE.md require `/rig-propose`.
 - The pre-ship checklist (`/ship`) must pass before any PR is opened.
 - Secrets and credentials are never written to files.
 - Irreversible actions always require explicit confirmation — even at High autonomy.

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -180,7 +180,7 @@ Wait for explicit go-ahead before proceeding.
 
 Regardless of autonomy level:
 - Pre-tool hooks still run. Governance files (listed in `pre-tool.sh`) are still protected.
-- Changes to The Rig's own `.rig/processes/`, `.rig/rules/`, hooks, or CLAUDE.md still require `/propose`.
+- Changes to The Rig's own `.rig/processes/`, `.rig/rules/`, hooks, or CLAUDE.md still require `/rig-propose`.
 - Secrets and credentials are never written to files.
 - The pre-ship checklist (`/ship`) still runs before any PR is opened.
 - At task completion, any Rig workflow friction or gaps observed must be logged to

--- a/templates/project/.claude/hooks/pre-tool.sh
+++ b/templates/project/.claude/hooks/pre-tool.sh
@@ -91,10 +91,10 @@ if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
 
   # ── THE RIG'S OWN GOVERNANCE FILES (self-protection) ─────────────────────
   # The agent must not rewrite the rules it is supposed to follow.
-  # These paths are protected unconditionally — even after a /propose approval.
+  # These paths are protected unconditionally — even after a /rig-propose approval.
   #
   # APPROVED CHANGE FLOW:
-  #   1. Run /propose — agent writes proposal to /tmp/rig-proposal-[name].md
+  #   1. Run /rig-propose — agent writes proposal to /tmp/rig-proposal-[name].md
   #      and shows the exact before/after diff.
   #   2. Review and approve the proposal in chat.
   #   3. The agent cannot apply the change itself (this block stops it).
@@ -119,7 +119,7 @@ if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
     if [[ "$PATH_ARG" == *"$protected"* ]]; then
       echo "Blocked: '$PATH_ARG' is a The Rig governance file." >&2
       echo "The agent must not modify its own rules directly." >&2
-      echo "Use /propose to stage a change for human review, or edit manually." >&2
+      echo "Use /rig-propose to stage a change for human review, or edit manually." >&2
       exit 1
     fi
   done


### PR DESCRIPTION
## Summary

- Renames `/propose` → `/rig-propose` to match the naming convention already established by `/rig-gaps` and `/rig-upgrade`
- `/propose` is a Rig-governance command, not a general project command — the `rig-` prefix makes that clear
- All cross-file references updated: `pre-tool.sh`, `kickoff.md`, `run.md`, `task.md`, `how-it-works.md`, `customizing.md`, `README.md`

## Test plan

- [x] No remaining `/propose` references (excluding CHANGELOG history)
- [x] 81 bats tests passing
- [x] `bash -n` syntax check passes on all modified scripts

Closes #163
