### PR TITLE
feat(commands): gap triage batch -- /feature-context, doc freshness, rig-gaps push, session compression + branch creation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 **Feature knowledge**
 ```
 /recon [topic]               →  sweep PR history + commits + codebase for a keyword; synthesize an evolution timeline
+/feature-context [name]      →  load an existing feature doc into context before starting work on that feature
 /doc-feature [name]          →  research a feature end-to-end; produce a structured doc in docs/features/
 /refresh-feature-doc [name]  →  re-verify an existing feature doc against current code; correct stale claims
 ```

--- a/templates/project/.claude/commands/doc-feature.md
+++ b/templates/project/.claude/commands/doc-feature.md
@@ -33,6 +33,22 @@ If no argument is given, ask: **"Which feature should I document?"**
 
 ## What this does
 
+> **RIG_DIR resolution (stealth mode):** Before reading or writing any feature doc path,
+> resolve where `.rig/` actually lives. If `.rigpath` exists at the project root, read
+> it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> DOCS_DIR="$RIG_DIR/docs/features"
+> ```
+>
+> Substitute `$DOCS_DIR` for `docs/features/` in every step below.
+
 ### Step 1 — Confirm the feature
 
 Restate in one sentence what you understand the feature to be and what it does
@@ -67,10 +83,10 @@ couldn't confirm with `<!-- TODO: verify -->`.
 ### Step 3 — Check for an existing doc
 
 Derive a slug from the feature name (lowercase, hyphens, no punctuation).
-Check `docs/features/` for `<slug>.md`.
+Check `$DOCS_DIR` for `<slug>.md`.
 
 - **If it exists:** stop and say:
-  > "A doc for this feature already exists at `docs/features/<slug>.md`.
+  > "A doc for this feature already exists at `$DOCS_DIR/<slug>.md`.
   > Run `/refresh-feature-doc` to update it instead."
 - **If it doesn't exist:** proceed.
 
@@ -78,7 +94,7 @@ Check `docs/features/` for `<slug>.md`.
 
 ### Step 4 — Write the doc
 
-Create `docs/features/<slug>.md` using the template below.
+Create `$DOCS_DIR/<slug>.md` using the template below.
 Fill in every section. Delete sections that genuinely don't apply rather than
 leaving them empty. Never leave placeholder brackets in the final file.
 
@@ -86,7 +102,7 @@ leaving them empty. Never leave placeholder brackets in the final file.
 
 ### Step 5 — Update the index
 
-Add a row to the index table in `docs/features/README.md`:
+Add a row to the index table in `$DOCS_DIR/README.md`:
 
 ```
 | <Feature name> | [<slug>.md](<slug>.md) | YYYY-MM-DD |

--- a/templates/project/.claude/commands/feature-context.md
+++ b/templates/project/.claude/commands/feature-context.md
@@ -1,0 +1,113 @@
+# Command: /feature-context
+
+Load a feature doc into context before starting work on that feature.
+
+Run this before touching code that overlaps with a documented feature. It surfaces
+the entry points, data model, business rules, and gotchas so you understand the full
+chain before making a change.
+
+---
+
+## Usage
+
+```
+/feature-context <feature name or keyword>
+```
+
+Examples:
+```
+/feature-context auth
+/feature-context stripe webhooks
+/feature-context PDF export
+/feature-context upcoming grants feed
+```
+
+If no argument is given, list available feature docs and ask which to load.
+
+---
+
+## What this does
+
+> **RIG_DIR resolution (stealth mode):** Before searching for any feature doc,
+> resolve where `.rig/` actually lives. If `.rigpath` exists at the project root, read
+> it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> DOCS_DIR="$RIG_DIR/docs/features"
+> ```
+
+### Step 1 — Find the doc
+
+Check whether `$DOCS_DIR` exists. If not, say:
+> "No feature docs exist yet for this project. Run `/doc-feature <name>` to create the first one."
+Stop.
+
+Read `$DOCS_DIR/README.md` (the index) to get the list of documented features.
+
+Match the argument against:
+1. **Exact slug match** — `$DOCS_DIR/<arg>.md`
+2. **Partial slug match** — any filename containing the argument
+3. **Title match** — any feature whose `# Feature: <title>` line contains the argument (case-insensitive)
+
+If multiple docs match, list them and ask: **"Which feature did you mean?"**
+
+If no docs match, say:
+> "No feature doc found for `<arg>`. Available docs:"
+> [list from README.md]
+> "Run `/doc-feature <name>` to document this feature."
+Stop.
+
+---
+
+### Step 2 — Load and display the doc
+
+Read the matched `$DOCS_DIR/<slug>.md` in full.
+
+Output a structured summary:
+
+**Feature: [Name]** — `$DOCS_DIR/<slug>.md`
+*(Last verified: YYYY-MM-DD)*
+
+**Entry points:**
+[bullet list from ## Entry points section]
+
+**Data model:**
+[table or field list from ## Data model section, if present]
+
+**Business rules:**
+[bullet list from ## Business rules section]
+
+**Known gotchas:**
+[bullet list from ## Known gotchas section — these are highest priority]
+
+---
+
+### Step 3 — Check for staleness
+
+If `Last verified:` date in the doc is more than 60 days ago, note:
+> "⚠ This doc was last verified on [date] — [N] days ago. Some details may be stale.
+> Consider running `/refresh-feature-doc <name>` if you're making significant changes."
+
+---
+
+### Step 4 — Report
+
+Confirm the doc was loaded:
+> "Loaded feature doc for **[Name]**. Entry points, business rules, and gotchas are
+> now in context. Proceed with the task."
+
+---
+
+## Notes
+
+- This command is a read-only context loader — it does not create or modify any files.
+- Use `/doc-feature <name>` to create a new feature doc.
+- Use `/refresh-feature-doc <name>` to update an existing doc after a PR lands.
+- The full doc content is loaded into context so the agent can reference specific
+  line numbers and paths when making changes.

--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -20,10 +20,11 @@ Follows `.rig/processes/POST_MERGE_WORKFLOW.md`:
 2. Adds an entry at the top of `.rig/memory/PROGRESS.md` for the merged PR
 3. Moves the task file from `.rig/tasks/active/` → `.rig/tasks/done/`; marks `**Status**` as `done`
 4. Overwrites `.rig/memory/CONTEXT_SNAPSHOT.md` with the current project state
-5. Checks `.rig/memory/ERRORS.md` and `.rig/memory/RIG_GAPS.md` — prompts you to log anything unexpected or any workflow friction observed
-6. Makes a housekeeping commit if memory updates weren't included in the PR
-7. **Suggests a session name** based on the merged PR via `/session-name` logic (see below)
-8. Surfaces the next priority and asks: **"What's next?"**
+5. **Checks feature doc freshness** — detects if merged changes overlap with documented features (see below)
+6. Checks `.rig/memory/ERRORS.md` and `.rig/memory/RIG_GAPS.md` — prompts you to log anything unexpected or any workflow friction observed
+7. Makes a housekeeping commit if memory updates weren't included in the PR
+8. **Suggests a session name** based on the merged PR via `/session-name` logic (see below)
+9. Surfaces the next priority and asks: **"What's next?"**
 
 ---
 
@@ -73,9 +74,34 @@ will `git checkout [BASE_BRANCH] && git pull`, but flag it now so the user is aw
 
 ---
 
+## Feature doc freshness step
+
+After updating PROGRESS.md (step 2), check whether the merged PR touched any files
+that are covered by an existing feature doc.
+
+**How:**
+
+1. Resolve `$RIG_DIR` and `$DOCS_DIR` (see RIG_DIR resolution block above).
+2. If `$DOCS_DIR` doesn't exist or has no `.md` files (other than `README.md`): skip this step silently.
+3. Get the set of files changed in the merged commit:
+   ```bash
+   git diff --name-only HEAD~1 HEAD
+   ```
+4. For each `.md` file in `$DOCS_DIR` (excluding `README.md`):
+   - Read its `## Entry points` section and collect all file paths mentioned.
+   - Check if any of the merged-PR changed files match (partial path match is fine — e.g. `src/auth.py` matches `auth` in the entry points).
+5. If any feature docs have matching entry points, say:
+   > "⚠ The following feature docs may be stale after this merge:
+   > - `[feature-name]` (`$DOCS_DIR/<slug>.md`) — entry points overlap with changed files
+   > Run `/refresh-feature-doc <name>` to re-verify."
+   Do not block the rest of /post-merge — this is advisory only.
+6. If no overlap: skip silently.
+
+---
+
 ## Session naming step
 
-After the housekeeping commit (step 6), derive a session name suggestion using the
+After the housekeeping commit (step 7), derive a session name suggestion using the
 same logic as `/session-name`. The merged PR number is always known here, which
 makes this the most reliable naming signal in the system. Do **not** apply it
 automatically — present it for the user to confirm or tweak.
@@ -103,13 +129,13 @@ Read the `**Session name:**` field from `.rig/memory/CONTEXT_SNAPSHOT.md`.
 
 ### Format
 
-```
-type short-desc #N | type short-desc #N | ...
-```
+Use the **tiered format** from `/session-name` (same logic — see that command for full detail):
 
-- `type` matches the git commit type (`fix`, `feat`, `chore`, `refactor`, `devops`, `docs`, `test`)
-- `short-desc` is 3–6 words — enough to identify the work at a glance
-- Keep the full string under ~100 characters
+- **≤5 units:** `type short-desc #N | type short-desc #N | ...`
+- **6–15 units:** `type(area, area) | type(area) x3 | type x2`
+- **16+ units:** `sprint: N issues · feat/X fix/Y chore/Z · #A–#B`
+
+Keep under ~100 characters.
 
 ### Output
 

--- a/templates/project/.claude/commands/refresh-feature-doc.md
+++ b/templates/project/.claude/commands/refresh-feature-doc.md
@@ -24,15 +24,31 @@ Examples:
 
 If no argument is given, ask: **"Which feature doc should I refresh?"**
 If the argument doesn't match any existing doc, list the docs in
-`docs/features/` and ask the user to confirm which one.
+`$DOCS_DIR` and ask the user to confirm which one.
 
 ---
 
 ## What this does
 
+> **RIG_DIR resolution (stealth mode):** Before reading or writing any feature doc path,
+> resolve where `.rig/` actually lives. If `.rigpath` exists at the project root, read
+> it — it contains the absolute path to the external `.rig/` directory.
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> DOCS_DIR="$RIG_DIR/docs/features"
+> ```
+>
+> Substitute `$DOCS_DIR` for `docs/features/` in every step below.
+
 ### Step 1 — Load the existing doc
 
-Read `docs/features/<slug>.md` in full. Note the `Last updated:` date and every
+Read `$DOCS_DIR/<slug>.md` in full. Note the `Last updated:` date and every
 claim made — entry point paths, line numbers, field names, flow steps, business
 rules, and gotchas.
 
@@ -75,7 +91,7 @@ If nothing changed, say so and stop — don't update the doc needlessly.
 
 ### Step 4 — Rewrite the doc
 
-Update `docs/features/<slug>.md`:
+Update `$DOCS_DIR/<slug>.md`:
 - Correct all stale paths, line numbers, field names, and flow steps
 - Add new sections or entries for anything that was added
 - Remove entries for anything that was deleted or fixed
@@ -93,7 +109,7 @@ Do **not** rewrite the Summary unless the feature's fundamental purpose changed.
 
 2. **Log bugs to ERRORS.md** — if re-verifying the doc revealed a real bug
    (not a doc inaccuracy — an actual code problem), log it in
-   `.rig/memory/ERRORS.md` using the standard format:
+   `$RIG_DIR/memory/ERRORS.md` using the standard format:
    - Symptom / Root cause / Fix / Watch for
 
 3. **Report** — output what changed, what stayed the same, and any remaining

--- a/templates/project/.claude/commands/rig-gaps.md
+++ b/templates/project/.claude/commands/rig-gaps.md
@@ -91,3 +91,64 @@ If the user confirms:
 - Confirm: "[N] entries marked as submitted."
 
 If the user declines or there's nothing to mark, skip silently.
+
+---
+
+## Push mode (developer shortcut)
+
+If the user says **"push"**, **"--push"**, or **"submit to rig"**, run this flow instead
+of (or after) displaying the report. This is a same-machine shortcut — it works only
+when The Rig's own repo is accessible on disk.
+
+### Step P1 — Resolve the destination
+
+Read `rig-gaps-push-target:` from `CLAUDE.md`:
+
+```bash
+PUSH_TARGET=$(grep "^rig-gaps-push-target:" "$REPO/CLAUDE.md" | awk '{print $2}' | head -1)
+```
+
+If the field is absent or empty, fail gracefully:
+> "No `rig-gaps-push-target:` set in `CLAUDE.md`. Add a line like:
+> `rig-gaps-push-target: /Users/you/.rig/projects/the-rig/memory/RIG_GAPS.md`
+> Then retry."
+Stop.
+
+Verify the target file exists:
+```bash
+[[ -f "$PUSH_TARGET" ]] || { echo "Target not found: $PUSH_TARGET"; exit 1; }
+```
+
+If it doesn't exist, fail gracefully:
+> "Target file not found: `$PUSH_TARGET`. Check the path in `rig-gaps-push-target:` and retry."
+Stop.
+
+### Step P2 — Preview and confirm
+
+Display the entries that will be pushed (same format as Step 3 report).
+Ask:
+> "Push [N] entries to `$PUSH_TARGET`? These will be appended to the Rig dev session's
+> RIG_GAPS.md for triage. Review entries above — strip any project-specific details
+> before submitting. Confirm? (yes / no)"
+
+Wait for explicit confirmation. Do not push without it.
+
+### Step P3 — Append entries
+
+Append each unsubmitted entry verbatim to `$PUSH_TARGET`:
+
+```bash
+echo "" >> "$PUSH_TARGET"
+echo "## [ENTRY CONTENT]" >> "$PUSH_TARGET"
+```
+
+One blank line before each entry. Do not duplicate entries that already exist in
+the destination (check for matching `## [date] —` header lines before appending).
+
+### Step P4 — Mark as submitted
+
+Append ` [submitted YYYY-MM-DD]` to each pushed entry's `## [date]` header in the
+**source** `RIG_GAPS.md` (the current project's file, not the destination).
+
+Confirm:
+> "[N] entries pushed to `$PUSH_TARGET` and marked as submitted."

--- a/templates/project/.claude/commands/session-name.md
+++ b/templates/project/.claude/commands/session-name.md
@@ -57,7 +57,10 @@ Read the `**Session name:**` field from `.rig/memory/CONTEXT_SNAPSHOT.md`.
 
 ### 3 — Derive the name
 
-Format:
+Use a **tiered format** based on how many meaningful units of work this session produced.
+Count one "unit" per merged PR, completed task, or significant fix.
+
+#### Tier 1 — ≤5 units (list format)
 
 ```
 type short-desc #N | type short-desc #N | ...
@@ -66,7 +69,40 @@ type short-desc #N | type short-desc #N | ...
 - `type` matches a git commit type: `fix`, `feat`, `chore`, `refactor`, `devops`, `docs`, `test`
 - `short-desc` is 3–6 words — enough to identify the work at a glance
 - Include the PR or issue number when known
-- Keep the full string under ~100 characters
+- Keep under ~100 characters
+
+Example: `fix step accordion layout #184 | feat custom-permissions #152`
+
+#### Tier 2 — 6–15 units (grouped format)
+
+Group by commit type. For each type, list the 1–3 most significant feature areas
+affected (omit the rest). Include a count if there were more.
+
+```
+type(area, area) | type(area) x3 | type x2
+```
+
+Example: `feat(auth, dashboard) | fix(billing x4, ui) | chore x3`
+
+- Use the scope area, not individual issue numbers
+- `x N` suffix means N items of that type; omit if N = 1
+- Keep under ~100 characters; drop the smallest groups if over
+
+#### Tier 3 — 16+ units (sprint summary format)
+
+```
+sprint: N issues · feat/X fix/Y chore/Z · #A–#B
+```
+
+- `N` is the total issue/PR count
+- `feat/X fix/Y chore/Z` shows the count per dominant type (omit types with 0)
+- `#A–#B` is the issue number range (lowest to highest)
+- Keep to one line
+
+Example: `sprint: 23 issues · feat/4 fix/15 chore/4 · #130–#152`
+
+If the session covered a named milestone or sprint (e.g. a GitHub milestone), use
+the milestone name as a prefix: `milestone: Sprint 3 · 23 issues · feat/4 fix/15 · #130–#152`
 
 ### 4 — Present the suggestion
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -114,9 +114,32 @@ not content).
 
 ---
 
+## Feature doc freshness check
+
+After updating PROGRESS.md, run a lightweight check to detect if any commits this
+session touched files covered by documented features.
+
+**How:**
+
+1. Resolve `$RIG_DIR` and `$DOCS_DIR` (see RIG_DIR resolution block above).
+2. If `$DOCS_DIR` doesn't exist or has no `.md` files (other than `README.md`): skip silently.
+3. Get commits from this session — use the same session boundary logic as the Session naming step (session-end markers or snapshot date).
+4. Collect all files changed across those commits:
+   ```bash
+   git log --name-only --format="" <boundary>..HEAD | sort -u
+   ```
+5. For each feature doc, check if any changed file path overlaps with the paths in its `## Entry points` section.
+6. If overlap found, note:
+   > "Feature docs that may need a refresh after this session's changes:
+   > - `[feature name]` — run `/refresh-feature-doc <name>`"
+   Advisory only — do not block the rest of /wrap.
+7. If no overlap or no docs: skip silently.
+
+---
+
 ## Self-improvement check
 
-After logging new ERRORS.md entries, run a brief Rig retrospective:
+After the feature doc freshness check, run a brief Rig retrospective:
 
 **Scan ERRORS.md** for entries that describe friction with The Rig's own workflow
 (not project bugs). Ask: did anything about The Rig slow you down, produce wrong
@@ -240,21 +263,21 @@ snapshot, before this /wrap rewrites it).
 
 ### Build the name
 
-For each meaningful unit of work (PR merged, task completed, significant fix shipped):
-- **type** — git commit type: `fix`, `feat`, `chore`, `refactor`, `devops`, `docs`, `test`
-- **short-desc** — 3–6 words that identify the work at a glance
-- **#N** — PR or issue number; omit if none
+Count one "unit" per merged PR, completed task, or significant fix. Use the
+**tiered format** from `/session-name` (same logic — see that command for full detail):
 
-Combine with ` | `. Keep under ~100 characters — truncate from the right by
-dropping whole segments, never mid-word.
+- **≤5 units:** `type short-desc #N | type short-desc #N | ...`
+- **6–15 units:** `type(area, area) | type(area) x3 | type x2`
+- **16+ units:** `sprint: N issues · feat/X fix/Y chore/Z · #A–#B`
+
+Keep under ~100 characters. Drop smallest groups if over.
 
 ### Examples
 
 ```
 fix step accordion layout #184 | fix h3.steps remaining partials #186
-feat custom-permissions per-post levels #152 | fix picker regressions #150
-devops cypress ci speedup #170 | devops ci cleanup #171
-chore upgrade next to 14.2.1 | fix null user on profile fetch #88
+feat(auth, dashboard) | fix(billing x4, ui) | chore x3
+sprint: 23 issues · feat/4 fix/15 chore/4 · #130–#152
 ```
 
 ### Output

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -87,6 +87,35 @@ For the full protocol (what to do at each autonomy level), see `SHIP_WORKFLOW.md
 
 ---
 
+### 1b — Create the branch
+
+**Do this before writing a single file.** No `Write`, `Edit`, or `Bash` tool calls
+that modify project files until this step is complete.
+
+Derive a branch name from the task type and slug:
+
+```
+feat/short-description    fix/short-description    chore/short-description
+```
+
+Create and switch to it:
+
+```bash
+git checkout -b <branch-name>
+```
+
+**Autonomy notes:**
+- **Low / Medium:** confirm the branch name with the user before running `git checkout -b`.
+- **High:** state the name you're creating ("Creating `feat/my-feature` off `main`"), then
+  branch immediately — no wait.
+
+**If already on a non-base branch:** verify it belongs to this task. If not, ask the user
+before proceeding — you may be on a leftover branch from a prior task.
+
+> This step has no exception. Even a one-line fix needs a branch. Hard Rule #3.
+
+---
+
 ## Step 2 — Orient
 
 Read these files before anything else, in this order:

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -145,6 +145,19 @@ commit-cleanup: yes
 | `yes` | Auto-injected tool footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.) are stripped from commit messages by the `commit-msg` and `post-commit` hooks. |
 | `no` | Footers are kept. Comment out or remove `.husky/commit-msg` and `.husky/post-commit` to disable the stripping. |
 
+```
+rig-gaps-push-target:
+```
+
+Optional. Absolute path to a `RIG_GAPS.md` file in The Rig's own repo on this machine.
+When set, `/rig-gaps --push` appends unsubmitted gap entries directly to that file
+instead of requiring manual copy-paste. Only useful for developers who maintain The Rig
+(or a fork) on the same machine.
+
+Example: `rig-gaps-push-target: /Users/you/.rig/projects/the-rig/memory/RIG_GAPS.md`
+
+Leave blank (or omit the line) if you don't have The Rig repo on this machine.
+
 ---
 
 ## Off-limits — never touch without explicit instruction
@@ -194,10 +207,14 @@ When starting a new session, read in this order:
 
 ## Feature documentation
 
-End-to-end traces for business-critical features live in `docs/features/`.
+End-to-end traces for business-critical features. Feature docs live in
+`$RIG_DIR/docs/features/` — for repo-tracked projects this is `docs/features/`;
+for stealth/external projects it resolves to the external `.rig/` directory via
+`.rigpath`. The `/doc-feature`, `/refresh-feature-doc`, and `/feature-doc` commands
+all resolve this path automatically.
 
-- **Before touching code** that overlaps with a documented feature, read the
-  relevant doc — it captures the full chain, data model, business rules, and gotchas
+- **Before touching code** that overlaps with a documented feature, run
+  `/feature-context <feature>` to load the doc into context
 - **After any PR** that changes a documented feature's logic, run
   `/refresh-feature-doc <feature>` to keep the doc current
 - **To document a new feature**, run `/doc-feature <feature name>` immediately


### PR DESCRIPTION
## Summary

- Fixes 5 open gaps from RIG_GAPS.md (#165–#169) — all command/markdown files, no installer changes
- Fixes the systemic process gap that caused this batch to be committed directly to main (#176)

## Changes

**#165 — `/doc-feature` + `/refresh-feature-doc` stealth mode fix**
Both commands hardcoded `docs/features/` with no RIG_DIR resolution. Added standard `.rigpath` resolution block and `DOCS_DIR=$RIG_DIR/docs/features` to both. CLAUDE.md template Feature documentation section updated to reference stealth path.

**#166 — New `/feature-context` command**
Loads an existing feature doc into context before starting work on a feature. Fuzzy-matches on slug/title, shows entry points + gotchas, staleness warning if doc >60 days old, graceful fallback to `/doc-feature` if no match found.

**#167 — Feature doc freshness in `/post-merge` and `/wrap`**
`/post-merge` now diffs merged PR files against feature doc entry points and surfaces matches as a prompt to run `/refresh-feature-doc`. `/wrap` has a lighter version covering recent session commits.

**#168 — `/rig-gaps` push mode**
New `--push` flow appends unsubmitted entries to `rig-gaps-push-target:` path (configurable in CLAUDE.md). Includes dedup check, preview + explicit confirmation before append, marks entries submitted in source file. `rig-gaps-push-target:` field documented in CLAUDE.md template.

**#169 — Tiered session name compression**
Updated `/session-name`, `/wrap`, and `/post-merge` with three-tier naming: ≤5 units: list format; 6–15: grouped by type with areas; 16+: sprint summary (`sprint: N issues · feat/X fix/Y · #A–#B`).

**#176 — NEW_TASK_WORKFLOW.md missing branch creation step (systemic fix)**
Root cause of the direct-to-main push. Step 1a had no follow-through to actually create the branch. Added Step 1b as an explicit hard gate: no file writes until `git checkout -b` is done, with autonomy-level notes and a guard for leftover branches from prior tasks.

## Test plan

- [x] 81 bats tests pass (no install.sh or hook changes in this PR)
- [ ] `/feature-context` resolves `$DOCS_DIR` correctly in a stealth project
- [ ] `/doc-feature` writes to `$RIG_DIR/docs/features/` not repo `docs/features/` in stealth
- [ ] `/post-merge` surfaces feature doc overlap after a relevant merge
- [ ] `/rig-gaps` push flow fails gracefully when `rig-gaps-push-target:` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)