### PR TITLE
fix(hooks,install): # no-issue trailer, git-in-hook warning, drift check, stop checkpoint [#170] [#171] [#172] [#173]

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -182,6 +182,41 @@ fallback. This is slower but correct. No data is lost.
 
 ---
 
+## 7. Hook crashes with "fatal: cannot lock ref" or "index.lock" on Git 2.39+
+
+**Symptom:** A commit fails with a message like:
+
+```
+error: cannot lock ref 'HEAD': unable to resolve reference 'HEAD'
+fatal: cannot lock ref
+```
+
+or:
+
+```
+fatal: Unable to create '.../.git/index.lock': File exists.
+```
+
+**Cause:** In Git 2.39+, the index is locked for the duration of the commit
+operation. If a hook inside that operation calls `git add` to stage a file,
+Git tries to acquire a second lock — which fails because the first lock is
+still held.
+
+**Fix:** Replace any `git add <file>` calls inside hooks with:
+
+```bash
+git update-index --add <file>
+```
+
+`git update-index` writes directly to the index without acquiring the full lock,
+making it safe to call from within a hook. It accepts `--add` to stage new files,
+`--remove` to unstage, and `--chmod=+x` to mark executable bits.
+
+If you're writing a custom hook for this project and need to stage a file, always
+use `git update-index --add` instead of `git add`.
+
+---
+
 ## Still stuck?
 
 Check the session log first (`/tmp/the-rig-session.log`). If the log shows the hook

--- a/install.sh
+++ b/install.sh
@@ -138,6 +138,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GLOBAL_TEMPLATES="$SCRIPT_DIR/templates/global"
 PROJECT_TEMPLATES="$SCRIPT_DIR/templates/project"
 
+# ── Installer branch drift check ─────────────────────────────────────────────
+# If the installer lives inside a git repo, check whether it's behind its
+# remote tracking branch. A stale installer installs stale templates.
+# Runs silently if there's no remote, no network, or no git.
+# Tests can override _RIG_DRIFT_DIR to point to a mock repo.
+_DRIFT_DIR="${_RIG_DRIFT_DIR:-$SCRIPT_DIR}"
+if git -C "$_DRIFT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  git -C "$_DRIFT_DIR" fetch --quiet 2>/dev/null || true
+  _TRACKING=$(git -C "$_DRIFT_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+  if [[ -n "$_TRACKING" ]]; then
+    _BEHIND=$(git -C "$_DRIFT_DIR" rev-list "HEAD..${_TRACKING}" --count 2>/dev/null || echo 0)
+    if [[ "$_BEHIND" -gt 0 ]]; then
+      warn "The installer is ${_BEHIND} commit(s) behind ${_TRACKING}."
+      warn "Run: git -C \"$_DRIFT_DIR\" pull   to get the latest version first."
+      warn "Proceeding with the current version..."
+      echo ""
+    fi
+  fi
+fi
+
 # ── Parse flags ───────────────────────────────────────────────────────────────
 DO_GLOBAL=true
 DO_PROJECT=true

--- a/templates/project/.claude/hooks/stop.sh
+++ b/templates/project/.claude/hooks/stop.sh
@@ -107,4 +107,43 @@ if [[ ! -f "$WRAP_NEEDED" ]]; then
   fi
 fi
 
+# ── Write minimal checkpoint to CONTEXT_SNAPSHOT when .wrap-needed is set ────
+# If /wrap hasn't run and the session had meaningful commits, write a minimal
+# orientation block to CONTEXT_SNAPSHOT.md so the next session isn't flying blind.
+# This is not a full /wrap — it just records branch, last commit, and active task.
+# /wrap overwrites this with a complete snapshot; this is a safety net only.
+if [[ -f "$WRAP_NEEDED" ]]; then
+  _BRANCH=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  _COMMIT=$(git -C "$REPO" log -1 --format="%h %s" 2>/dev/null || echo "none")
+  _ACTIVE_TASK=""
+  _ACTIVE_DIR="$RIG_DIR/tasks/active"
+  if [[ -d "$_ACTIVE_DIR" ]]; then
+    _ACTIVE_TASK=$(ls "$_ACTIVE_DIR"/*.md 2>/dev/null | head -1 | xargs basename 2>/dev/null || true)
+  fi
+
+  {
+    echo "# Context Snapshot — auto-checkpoint"
+    echo ""
+    echo "> This is a minimal checkpoint written by stop.sh — not a full /wrap snapshot."
+    echo "> Run \`/wrap\` to replace this with a complete context snapshot."
+    echo ""
+    echo "**Last updated:** $NOW — auto-checkpoint (stop.sh)"
+    echo "**Branch:** $_BRANCH"
+    echo "**Last commit:** $_COMMIT"
+    if [[ -n "$_ACTIVE_TASK" ]]; then
+      echo "**Active task:** $_ACTIVE_TASK"
+    fi
+    echo ""
+    echo "---"
+    echo ""
+    echo "## Status"
+    echo ""
+    echo "Session ended without running \`/wrap\`. Run \`/wrap\` at the start of the"
+    echo "next session to capture full context before starting new work."
+  } > "$SNAPSHOT"
+
+  echo "[$(date +%H:%M:%S)] STOP: minimal checkpoint written to CONTEXT_SNAPSHOT.md" \
+    >> "$SESSION_LOG"
+fi
+
 exit 0

--- a/templates/project/.husky/commit-msg
+++ b/templates/project/.husky/commit-msg
@@ -9,6 +9,8 @@
 #
 # To disable format validation: set SKIP_COMMIT_VALIDATION=1 before committing.
 # To disable footer stripping: remove or comment out the filter block below.
+# To skip the issue reference check for a single commit (no ticket exists):
+#   add  # no-issue  as a line in the commit message body.
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 COMMIT_MSG_FILE="$1"
@@ -56,6 +58,14 @@ if [ -f "$CLAUDE_MD" ]; then
 fi
 # Default to github if not set
 : "${ISSUE_TRACKING:=github}"
+
+# Allow the # no-issue trailer to skip the ref check for any tracker.
+# Used when a commit legitimately has no associated ticket (e.g. one-off fixes,
+# chores on personal projects with issue-tracking: github but no issue worth
+# opening). Add  # no-issue  as a standalone line in the commit body.
+if grep -q "^# no-issue" "$COMMIT_MSG_FILE" 2>/dev/null; then
+  exit 0
+fi
 
 case "$ISSUE_TRACKING" in
   github)

--- a/templates/project/.husky/pre-commit
+++ b/templates/project/.husky/pre-commit
@@ -12,6 +12,11 @@
 # NOTE: Git hooks run with a stripped PATH. Never assume `command -v` will
 # find a binary that works in your interactive shell. Always check known
 # install locations explicitly.
+#
+# NOTE (Git 2.39+): Do NOT call `git add` inside a hook to stage files. In
+# Git 2.39+ this triggers a "fatal: cannot lock ref" error because the index
+# is already locked by the in-progress commit. Use `git update-index --add`
+# to stage individual files if a hook needs to modify the index.
 
 # ── 1. Secret scanning ────────────────────────────────────────────────────────
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1016,3 +1016,104 @@ _sha256() {
   [ "$status" -eq 0 ]
   grep -q '# user customization' "$fake_home/.claude/CLAUDE.md"
 }
+
+# ── commit-msg: # no-issue trailer ───────────────────────────────────────────
+
+@test "commit-msg: # no-issue trailer skips issue ref check for github tracker" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: github\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  # Conventional commit but no issue ref — would normally fail
+  # Body contains # no-issue → should pass
+  printf 'chore(deps): bump library version\n\n# no-issue\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: # no-issue trailer skips issue ref check for linear tracker" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: linear\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  printf 'chore(deps): bump library version\n\n# no-issue\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: without # no-issue, github tracker still requires ref" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local hook="$TEST_PROJECT/.husky/commit-msg"
+  local msg_file="$TEMP_DIR/COMMIT_EDITMSG"
+
+  printf 'issue-tracking: github\n' > "$TEST_PROJECT/CLAUDE.md"
+
+  # No # no-issue, no ref → must still fail
+  printf 'chore(deps): bump library version\n\nSome body text.\n' > "$msg_file"
+  run bash -c "cd '$TEST_PROJECT' && sh '$hook' '$msg_file'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"issue reference"* ]]
+}
+
+# ── install.sh: branch drift warning ─────────────────────────────────────────
+
+@test "installer drift check: warns when installer repo is behind remote" {
+  # Create a bare remote repo and a local clone that's 1 commit behind
+  local remote_repo="$TEMP_DIR/rig-remote"
+  local local_repo="$TEMP_DIR/rig-local"
+
+  git init -q "$remote_repo"
+  git -C "$remote_repo" config user.email "test@test.com"
+  git -C "$remote_repo" config user.name "Test"
+  touch "$remote_repo/placeholder"
+  git -C "$remote_repo" add placeholder
+  git -C "$remote_repo" commit -q -m "initial commit"
+
+  git clone -q "$remote_repo" "$local_repo"
+  git -C "$local_repo" config user.email "test@test.com"
+  git -C "$local_repo" config user.name "Test"
+
+  # Add a commit to the remote that the local doesn't have
+  touch "$remote_repo/newfile"
+  git -C "$remote_repo" add newfile
+  git -C "$remote_repo" commit -q -m "new commit on remote"
+
+  # Run installer with _RIG_DRIFT_DIR pointing to the local (stale) repo
+  run bash -c "_RIG_DRIFT_DIR='$local_repo' bash '$INSTALLER' --project-only \
+    --target '$TEST_PROJECT' --project-name 'TestProject' --strategy skip"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"behind"* ]]
+}
+
+@test "installer drift check: no warning when installer repo is up to date" {
+  # A git repo with a remote that matches HEAD — no warning expected
+  local remote_repo="$TEMP_DIR/rig-remote"
+  local local_repo="$TEMP_DIR/rig-local"
+
+  git init -q "$remote_repo"
+  git -C "$remote_repo" config user.email "test@test.com"
+  git -C "$remote_repo" config user.name "Test"
+  touch "$remote_repo/placeholder"
+  git -C "$remote_repo" add placeholder
+  git -C "$remote_repo" commit -q -m "initial commit"
+
+  git clone -q "$remote_repo" "$local_repo"
+  git -C "$local_repo" config user.email "test@test.com"
+  git -C "$local_repo" config user.name "Test"
+
+  # Local and remote are in sync
+  run bash -c "_RIG_DRIFT_DIR='$local_repo' bash '$INSTALLER' --project-only \
+    --target '$TEST_PROJECT' --project-name 'TestProject' --strategy skip"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"behind"* ]]
+}


### PR DESCRIPTION
## Summary

- **#170** — commit-msg: `# no-issue` body line bypasses the issue ref check for any tracker. Useful for one-off chores with no ticket.
- **#171** — pre-commit: header warns against `git add` inside hooks (Git 2.39+ index lock). troubleshooting.md gets item #7.
- **#172** — install.sh: warns when installer repo is behind its remote tracking branch. `_RIG_DRIFT_DIR` env var for test injection.
- **#173** — stop.sh: writes a minimal CONTEXT_SNAPSHOT checkpoint (branch, last commit, active task) when .wrap-needed is set.

5 new bats tests added (86 total, all passing).

## Test plan
- [x] `bats tests/` — 86/86 passing
- [x] Syntax checks pass for all modified hook scripts
- [x] `# no-issue` trailer tested for github and linear trackers
- [x] Drift warning tested: behind-remote triggers warning, in-sync does not

Generated with [Claude Code](https://claude.com/claude-code)