### PR TITLE
feat(commands,tasks): /sprint command + Batches section promotion [#174] [#175]

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,11 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 **Daily work**
 ```
-/task         →  intake wizard: define the task + configure autonomy, check-ins, and risk
-/run          →  execute the backlog; respects per-task operating mode; chains at High autonomy
-/run [slug]   →  run a single specific task
+/task              →  intake wizard: define the task + configure autonomy, check-ins, and risk
+/run               →  execute the backlog; respects per-task operating mode; chains at High autonomy
+/run [slug]        →  run a single specific task
+/sprint            →  conflict-aware sprint planner: groups tasks into waves, runs wave by wave
+/sprint [slug …]   →  sprint over a specific set of tasks only
 ```
 
 **Ship and debug**

--- a/templates/project/.claude/commands/run.md
+++ b/templates/project/.claude/commands/run.md
@@ -99,13 +99,18 @@ For each task in the confirmed queue:
 
 3. **Execute according to autonomy level.** See the execution guide below.
 
-4. **Complete the task.** When all acceptance criteria are met:
+4. **After each commit in a multi-batch task:** if the task file has a `## Batches`
+   section, fill in the `Commit` column for the batch just completed. Use the short
+   hash (`git log -1 --format="%h"`). If this commit closes a PR checkpoint, record
+   the PR number too.
+
+5. **Complete the task.** When all acceptance criteria are met:
    - Fill in `## Done notes` in the task file
    - Move the task file from `.rig/tasks/active/` (or `.rig/tasks/backlog/`) to `.rig/tasks/done/`
    - Append an entry to `.rig/memory/PROGRESS.md`
    - Run the pre-ship checklist (`/ship`) before opening any PR
 
-5. **Decide whether to continue.** See chaining rules below.
+6. **Decide whether to continue.** See chaining rules below.
 
 ---
 

--- a/templates/project/.claude/commands/sprint.md
+++ b/templates/project/.claude/commands/sprint.md
@@ -1,0 +1,166 @@
+# Command: /sprint
+
+Plan and execute a batch of tasks as a sprint, with conflict detection and
+wave-based ordering to minimize merge friction.
+
+**Use `/sprint` when:** you have several tasks to run in one session and want
+conflict-aware ordering rather than simple sequential execution.
+
+**Use `/run` when:** you just want to work through the queue in priority order
+without conflict analysis.
+
+---
+
+## Usage
+
+```
+/sprint                  # analyze all backlog tasks and propose a sprint plan
+/sprint [slug …]         # analyze only the named tasks (space-separated slugs)
+/sprint --issues #N …    # resolve task slugs from GitHub issue numbers
+```
+
+> **RIG_DIR resolution (stealth mode):** Before reading any `.rig/` path, resolve
+> where `.rig/` actually lives:
+>
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+>
+> Substitute `$RIG_DIR` for `.rig/` in every step below.
+
+---
+
+## Step 1 — Gather tasks
+
+If task slugs are named explicitly, load those task files only.
+Otherwise, load all files in `.rig/tasks/backlog/` and `.rig/tasks/active/`,
+skipping `TASK_example.md`.
+
+For each task, extract:
+- Slug (filename without `.md`)
+- Priority (`P0`–`P3`, default `P2` if absent)
+- `## Files likely affected` — the list of paths this task will touch
+- `## Depends on` — prerequisite tasks
+
+---
+
+## Step 2 — Conflict detection
+
+Build a **conflict graph**:
+
+1. For each task, normalise its `## Files likely affected` paths to a set of
+   strings (one path per line, strip leading `-`, quotes, and inline notes).
+2. Two tasks **conflict** if their path sets share at least one file.
+3. Tasks with a `## Depends on` dependency on another task in this sprint also
+   count as conflicting with that task (ordering constraint, not file overlap).
+
+---
+
+## Step 3 — Wave planning
+
+Group tasks into **waves** using a greedy graph-colouring approach:
+
+1. Start with the highest-priority un-assigned task.
+2. Assign it to the current wave.
+3. For each remaining un-assigned task (in priority order): assign to the current
+   wave if it conflicts with **none** of the tasks already in the wave; otherwise
+   defer to the next wave.
+4. Repeat until all tasks are assigned.
+
+Within a wave, order tasks by priority (P0 first). Dependency-blocked tasks
+(where the prerequisite is not yet in `.rig/tasks/done/`) are excluded from the
+plan entirely and listed as "blocked".
+
+---
+
+## Step 4 — Present the sprint plan
+
+Show the proposed plan:
+
+> "**Sprint plan — [N] tasks across [W] wave(s)**
+>
+> **Wave 1** (conflict-free):
+> | Task | Priority | Files |
+> |---|---|---|
+> | `feat-user-auth` | P0 | `services/auth.py`, `routes/auth.py` |
+> | `fix-email-typo` | P2 | `templates/email.html` |
+>
+> **Wave 2** (depends on Wave 1):
+> | Task | Priority | Conflict with |
+> |---|---|---|
+> | `feat-dashboard` | P1 | — |
+> | `feat-profile` | P2 | `feat-user-auth` (shared: `services/auth.py`) |
+>
+> **Blocked (not in this sprint):**
+> - `feat-export` — waiting on `feat-dashboard` (not in done/)
+>
+> I'll run Wave 1 tasks in order, pause for review, then run Wave 2.
+> Say **go** to start, or adjust the wave groupings."
+
+Wait for the user's confirmation before executing anything.
+
+---
+
+## Step 5 — Execute wave by wave
+
+For each wave in order:
+
+1. **Announce the wave:**
+   > "Starting Wave [N]: [task-slug-1], [task-slug-2], …"
+
+2. **Execute each task in the wave** using the same execution guide as `/run`
+   (autonomy level from the task file, governance rules always apply).
+
+3. **After all tasks in the wave are complete**, pause and report:
+   > "Wave [N] complete. [N] tasks done, [N] PRs opened.
+   > Ready for Wave [N+1]? Say **go** to continue, or adjust before proceeding."
+
+   Wait for confirmation before starting the next wave.
+
+4. If a task in the current wave **fails or is blocked mid-execution**, stop
+   the wave, surface the issue, and ask the user how to proceed. Do not
+   automatically skip to the next task in the wave.
+
+---
+
+## Step 6 — Sprint complete
+
+When all waves are done:
+
+> "Sprint complete. [N] tasks shipped:
+> - Wave 1: feat-user-auth (#12), fix-email-typo (#18)
+> - Wave 2: feat-dashboard (#20), feat-profile (#21)
+>
+> `.rig/tasks/done/` updated. PROGRESS.md updated.
+> Anything to add to the backlog for the next sprint?"
+
+---
+
+## Conflict detection notes
+
+- **`## Files likely affected` is the source of truth.** If a task doesn't have
+  this section, assume it could conflict with anything and place it in its own wave.
+- **Paths are compared by prefix.** A task listing `services/` and another listing
+  `services/auth.py` are considered conflicting.
+- **Wildcard entries** (e.g. `**/*.py`) count as conflicting with every other task
+  that lists any `.py` file.
+- **Conflict detection is conservative.** When in doubt, wave-separate — a false
+  positive (unnecessary sequencing) is safer than a false negative (real merge
+  conflict during execution).
+
+---
+
+## Governance
+
+All `/run` governance rules apply:
+
+- Pre-tool hooks run on every file write.
+- The pre-ship checklist (`/ship`) must pass before any PR is opened.
+- Secrets and credentials are never written to files.
+- Irreversible actions always require explicit confirmation.
+- Changes to The Rig's own processes, rules, hooks, or CLAUDE.md require `/rig-propose`.

--- a/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
+++ b/templates/project/.rig/processes/NEW_TASK_WORKFLOW.md
@@ -206,9 +206,13 @@ In this order:
    *(Was there anything about The Rig itself that slowed you down, was missing, or felt wrong?
    Log it here — see `/rig-gaps` for the submission workflow.)*
 
-7. Commit with a conventional commit message referencing the task name and issue number
+7. **If the task has a `## Batches` section:** verify all batch rows have a commit
+   hash filled in before moving to done. Leave any pending rows blank — do not
+   fabricate hashes.
 
-8. Follow `SHIP_WORKFLOW.md` to open the PR
+8. Commit with a conventional commit message referencing the task name and issue number
+
+9. Follow `SHIP_WORKFLOW.md` to open the PR
 
 > **Staging note:** Stage the task file **only after** it has been moved to `.rig/tasks/done/`.
 > Never commit a task file from `.rig/tasks/active/` — it creates a confusing history where

--- a/templates/project/.rig/tasks/backlog/TASK_example.md
+++ b/templates/project/.rig/tasks/backlog/TASK_example.md
@@ -57,17 +57,15 @@
 
 ---
 
-<!--
-## Batches (optional — add this section for tasks that span multiple commits)
+## Batches *(optional — delete this section for single-commit tasks)*
 
-Use this section when a task spans multiple commits or PR checkpoints.
-Record each sub-goal as it lands. Delete this section for single-commit tasks.
+> Use when a task spans multiple commits. Record each sub-goal as it lands.
+> `/run` updates the Commit column automatically after each commit in the task.
 
 | # | Sub-goal | Commit | PR checkpoint |
 |---|---|---|---|
-| 1 | [What this batch delivers] | `[hash]` *(filled after commit)* | — |
+| 1 | [What this batch delivers] | — | — |
 | 2 | [Next sub-goal] | — | — |
--->
 
 ---
 


### PR DESCRIPTION
## Summary

- **#174** — New `/sprint` command: conflict-aware sprint planner. Reads `## Files likely affected` from each task, builds a conflict graph, groups tasks into conflict-free waves, executes wave by wave with a review pause between waves. Supports `/sprint [slug …]` for targeted sprints.
- **#175** — `## Batches` section promoted from HTML comment to a real optional section in `TASK_example.md`. `/run.md` Step 4 now updates the Commit column after each commit in a multi-batch task. `NEW_TASK_WORKFLOW.md` Step 7 gains a verification step for batch hashes before moving to done.

81 bats tests passing.

## Test plan

- [x] `bats tests/` — 81/81 passing (this branch; 86/86 with PR #178 merged)
- [x] `/sprint` command is self-contained and actionable; no pseudocode
- [x] Batches section renders correctly in Markdown (not an HTML comment)
- [x] `/run.md` step numbering is consistent after new step insertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)