### PR TITLE
fix(commands): /recon + /doc-feature check internal docs before external sweep

### DIFF
--- a/templates/project/.claude/commands/doc-feature.md
+++ b/templates/project/.claude/commands/doc-feature.md
@@ -56,7 +56,23 @@ for the user or business. Ask for correction before proceeding if unsure.
 
 ---
 
-### Step 2 — Research end-to-end
+### Step 2 — Check for an existing doc
+
+Derive a slug from the feature name (lowercase, hyphens, no punctuation).
+Check `$DOCS_DIR` for `<slug>.md`.
+
+- **If it exists:** stop and say:
+  > "A doc for this feature already exists at `$DOCS_DIR/<slug>.md`.
+  > Run `/refresh-feature-doc` to update it instead."
+- **If it doesn't exist:** proceed to Step 3.
+
+Also check `$RIG_DIR/memory/ERRORS.md` for any gotchas logged about this feature
+(keyword search). If found, note them — they belong in the final doc's
+`## Known gotchas` section.
+
+---
+
+### Step 3 — Research end-to-end
 
 Trace the full stack for this feature. The exact layer names vary by project —
 use the ones that apply:
@@ -77,18 +93,6 @@ use the ones that apply:
 
 Use only line numbers you have verified by reading the file. Mark anything you
 couldn't confirm with `<!-- TODO: verify -->`.
-
----
-
-### Step 3 — Check for an existing doc
-
-Derive a slug from the feature name (lowercase, hyphens, no punctuation).
-Check `$DOCS_DIR` for `<slug>.md`.
-
-- **If it exists:** stop and say:
-  > "A doc for this feature already exists at `$DOCS_DIR/<slug>.md`.
-  > Run `/refresh-feature-doc` to update it instead."
-- **If it doesn't exist:** proceed.
 
 ---
 

--- a/templates/project/.claude/commands/recon.md
+++ b/templates/project/.claude/commands/recon.md
@@ -42,6 +42,47 @@ If no argument is given, ask: **"What topic or feature should I research?"**
 
 ## What this does
 
+### Step 0 — Internal docs check (before any API calls)
+
+Before hitting the GitHub API or git history, search local knowledge sources for
+the keyword. This saves tokens and surfaces existing documentation immediately.
+
+**0a — Feature docs:**
+```bash
+ls "$RIG_DIR/docs/features/" 2>/dev/null | grep -i "<keyword>" || true
+grep -ril "<keyword>" "$RIG_DIR/docs/features/" 2>/dev/null || true
+```
+If a matching feature doc exists, read its `## Summary` and `## Current state`
+sections and display them. Tell the user:
+> "Found an existing feature doc: `docs/features/<slug>.md` (last updated: [date]).
+> Showing summary below. Continue with full PR/commit sweep? [yes / no]"
+If no: skip Steps 1–3, jump to Step 4 (synthesize from the doc). If yes: continue.
+
+**0b — DECISIONS.md:**
+```bash
+grep -i "<keyword>" "$RIG_DIR/memory/DECISIONS.md" 2>/dev/null | head -10 || true
+```
+If matches found, show the relevant decision entries.
+
+**0c — ERRORS.md:**
+```bash
+grep -i "<keyword>" "$RIG_DIR/memory/ERRORS.md" 2>/dev/null | head -10 || true
+```
+If matches found, show the relevant error/gotcha entries. These are high-signal —
+if the keyword has a known pitfall logged, surface it early.
+
+**0d — PROGRESS.md:**
+```bash
+grep -i "<keyword>" "$RIG_DIR/memory/PROGRESS.md" 2>/dev/null | head -5 || true
+```
+Show any matching progress entries (indicates recent work on this topic).
+
+If **nothing was found** in any internal source: proceed silently to Step 1.
+If **something was found**: display it, then ask whether to continue with the
+external sweep. The user may already have enough context.
+
+---
+
 ### Step 1 — Keyword sweep: merged PR history
 
 Search merged PR titles and bodies for the keyword(s):


### PR DESCRIPTION
## Summary

- `/recon`: adds **Step 0** — searches `docs/features/`, `DECISIONS.md`, `ERRORS.md`, and `PROGRESS.md` locally before hitting the GitHub PR API. Surfaces existing knowledge first; asks whether the full external sweep is still needed.
- `/doc-feature`: fixes **sequencing bug** — existing-doc check (was Step 3, ran after full research) is now Step 2, before any research begins. Adds `ERRORS.md` keyword check to seed the final doc's Known gotchas section.

## Changes

- `templates/project/.claude/commands/recon.md`: new Step 0 with four sub-checks (docs, decisions, errors, progress)
- `templates/project/.claude/commands/doc-feature.md`: Step 3 moved to Step 2; added ERRORS.md check; steps 3–6 renumbered

## Closes

Closes #188

## Test plan

- [ ] `/recon auth` when `docs/features/auth.md` exists → surfaces doc summary first, asks whether to continue
- [ ] `/recon auth` with no matching internal docs → proceeds silently to Step 1 (PR sweep)
- [ ] `/doc-feature auth` when doc exists → stops at Step 2 with refresh suggestion (no research wasted)
- [ ] `/doc-feature auth` when no doc exists → proceeds to research normally

## Notes

No bats tests added — agent instruction text only.