### PR TITLE
feat(commands): /task test intake + /ship pre-commit cleanup + PR update detection

### DIFF
--- a/.rig-debug-scan-exclude
+++ b/.rig-debug-scan-exclude
@@ -10,3 +10,7 @@
 
 # Template hook files contain debug pattern definitions as string literals
 templates/project/.husky/*
+
+# Template command files document debug patterns as examples — exclude to prevent
+# false positives when the patterns themselves appear in documentation text
+templates/project/.claude/commands/*

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -135,6 +135,48 @@ Wait for confirmation. High autonomy: state the base and proceed immediately.
 
 ---
 
+## Step 3.8 — Pre-commit cleanup
+
+Before presenting the checklist, actively clean up the diff. Do not ask permission —
+this cleanup is always required.
+
+**3.8a — Remove debug statements.** Scan staged and unstaged changes for:
+- `console.log`, `console.debug`, `console.warn`, `console.error` (JavaScript/TypeScript)
+- `print(`, `pprint(`, `logging.debug(` used as one-off debug output (Python)
+- `debugger;` statements
+- `# DEBUG`, `# TEMP`, `// DEBUG`, `// TEMP` inline comments
+- `dd(`, `dump(`, `ray(` (PHP debug helpers)
+- Any other obvious debug instrumentation added during development
+
+For each one found: remove it, stage the change, note it in your next message.
+If unsure whether a statement is intentional debug output or production logging,
+leave it and flag it in Step 4 for the user to decide.
+
+**3.8b — Run the linter** (if one is configured for this project):
+```bash
+# Read test-command from CLAUDE.md, or try common linters:
+# npm run lint / eslint . / ruff check . / flake8 / shellcheck
+```
+If the linter fails: fix the issues before continuing. Do not proceed to Step 4
+with failing lint. If no linter is configured, note it and skip.
+
+**3.8c — Run tests** (conditional):
+Read the active task file's `## Testing` field.
+- **`Required: yes`**: run the test suite now. If tests fail: fix them before
+  continuing. Do not proceed to Step 4 with failing tests.
+- **`Required: optional`**: run tests if the command is fast (< 60s); report results.
+- **`Required: no`** or field absent: skip.
+
+```bash
+# Use the test command from CLAUDE.md or the project's standard:
+# npm test / pytest / bats tests/ / etc.
+```
+
+Report what was cleaned, what linting found, and test results (pass/fail/skip)
+in a single summary line before continuing.
+
+---
+
 ## Step 4 — Pre-ship checklist
 
 Work through the following. Report the result of each check:
@@ -231,11 +273,44 @@ In this order:
 
 ---
 
-## Step 9 — Open the PR
+## Step 9 — Open or update the PR
 
 **The PR body must describe what was actually built — not the original plan.**
 If scope changed during implementation, note it explicitly. Reviewers read the PR
 description to understand what landed, not what was intended.
+
+**First: check if a PR already exists for this branch.**
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number,title,url --jq '.[0]' 2>/dev/null || echo "")
+```
+
+**If a PR already exists:**
+
+> "PR #[N] already exists for this branch: [title]
+> [URL]
+>
+> Options:
+> - **[u] Update** — revise title, body, labels, and linked issues to reflect the new work
+> - **[k] Keep as-is** — the existing PR is accurate, no changes needed"
+
+If user chooses **[u]**:
+1. Show the current PR title and body (run `gh pr view [N] --json title,body`)
+2. Draft the updated title and body based on ALL work on this branch (not just the latest commit)
+3. Show the proposed changes and ask for approval
+4. Run:
+   ```bash
+   gh pr edit [N] --title "[updated title]" --body-file /tmp/ship-pr-body.md
+   ```
+5. Check labels: `gh pr view [N] --json labels` — add any missing labels for new work areas
+6. Verify the `Closes #[issue]` line covers all linked issues for the full scope of work
+
+If user chooses **[k]**: skip to Notes. Done.
+
+**If no PR exists:** continue with template detection and PR creation below.
+
+---
 
 **Template detection — this is a hard gate:**
 

--- a/templates/project/.claude/commands/task.md
+++ b/templates/project/.claude/commands/task.md
@@ -40,6 +40,12 @@ Ask the user the following. Collect all answers before moving to Part 2.
 3. **Hard constraints?** Any deadline, off-limits paths, technology restrictions, or
    things that must not change?
 4. **Issue/ticket?** Read `issue-tracking:` and `issue-creator:` from `CLAUDE.md` first.
+5. **Tests required?** Should this task include tests?
+   - **yes** — tests are required before this task can ship
+   - **no** — tests are explicitly out of scope (state why, e.g. "pure config change")
+   - **optional** — write tests if the logic warrants it; no hard gate
+   Record the answer in the task file under `## Testing`. The `/ship` pre-commit step
+   reads this field — if `yes`, tests must exist before the commit is allowed.
 
    - **`issue-tracking: github`** (or field absent — default):
      - Also read `issue-creator:` (default: `user`).
@@ -63,7 +69,8 @@ Ask the user the following. Collect all answers before moving to Part 2.
 After collecting all answers, confirm back:
 
 > "Got it. You want to [restate task in one sentence], working in [area], with
-> [constraints or 'no hard constraints']. Issue: [ref]. Let's configure how I'll operate."
+> [constraints or 'no hard constraints']. Issue: [ref]. Tests: [yes/no/optional].
+> Let's configure how I'll operate."
 
 ---
 

--- a/templates/project/.rig/tasks/backlog/TASK_example.md
+++ b/templates/project/.rig/tasks/backlog/TASK_example.md
@@ -103,6 +103,15 @@ updates at milestones, and flag any change that touches more than 5 files.
 
 ---
 
+## Testing
+
+> Set during `/task` intake. Read by `/ship` Step 3.8.
+
+**Required**: `yes` | `no` | `optional`
+**What to test**: [describe what tests are expected, or "N/A"]
+
+---
+
 ## Done notes
 
 > Filled in when the task is complete, before moving to `tasks/done/`.


### PR DESCRIPTION
## Summary

- **`/task`**: new question 5 in Part 1 intake — 'Tests required?' (yes/no/optional). Answer written to task file under `## Testing`. Confirmation summary updated to include it.
- **`/ship` Step 3.8**: active pre-commit cleanup — removes debug statements, runs linter, runs tests if `## Testing: yes`. Active action, not just a checklist item.
- **`/ship` Step 9**: checks for existing PR on current branch before creating a new one. If found, offers to update title/body/labels/linked issues to reflect additional work pushed to the branch.
- **`TASK_example.md`**: adds `## Testing` section to the task template.
- **`.rig-debug-scan-exclude`**: adds `templates/.claude/commands/*` to prevent false positives when command documentation references debug pattern strings.

## Changes

- `templates/project/.claude/commands/task.md`: question 5, confirmation update
- `templates/project/.claude/commands/ship.md`: Step 3.8, Step 9 renamed + existing PR detection
- `templates/project/.rig/tasks/backlog/TASK_example.md`: `## Testing` section
- `.rig-debug-scan-exclude`: template command exclusion

## Closes

Closes #189

## Test plan

- [ ] `/task` intake: question 5 appears, answer written to task file
- [ ] `/ship` on a branch with debug code: Step 3.8 removes it before checklist
- [ ] `/ship` on task with `Testing: yes`: tests run at Step 3.8; failure blocks checklist
- [ ] `/ship` on branch with existing PR: Step 9 offers update path
- [ ] `/ship` on fresh branch: Step 9 creates new PR as before

## Notes

The `.rig-debug-scan-exclude` fix is a bug correction — the pre-commit hook was flagging its own documentation text as a debug artifact.