### PR TITLE
feat(commands): command routing table in global CLAUDE.md [#191]

### DIFF
--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -160,8 +160,9 @@ Read the context profile above silently. No summary unless asked.
 ### Command routing
 
 When a user message implies a specific Rig workflow but doesn't name a command,
-route to the right command rather than handling it ad-hoc. Read the intent, not
-the literal words.
+surface the right command and ask for consent before doing anything. Read the
+intent, not the literal words — but never act on the interpretation without
+the user's explicit confirmation.
 
 | If the user implies… | Route to | Trigger signals |
 |---|---|---|
@@ -174,10 +175,11 @@ the literal words.
 | Sprint or work planning | `/sprint` | "plan the sprint", "what should we tackle", "what's the priority", "let's scope the work" |
 | Wrapping up the session | `/wrap` | "that's it for today", "wrapping up", "save progress", "end of session" |
 
-When you recognize a match, name the command and offer to run it — don't silently
-reroute or handle the request as if the command doesn't exist. Say:
+When you recognize a match, name the command and ask:
 > "This sounds like a `/recon` job — want me to run that?"
-Then wait for confirmation.
+Do not invoke the command or handle the request yourself until the user
+explicitly confirms. A "yes", "go", or restatement of the intent is confirmation;
+silence or an ambiguous reply is not.
 
 ---
 

--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -157,6 +157,30 @@ Read the context profile above silently. No summary unless asked.
 
 ---
 
+### Command routing
+
+When a user message implies a specific Rig workflow but doesn't name a command,
+route to the right command rather than handling it ad-hoc. Read the intent, not
+the literal words.
+
+| If the user implies… | Route to | Trigger signals |
+|---|---|---|
+| Something is broken or misbehaving | `/debug` | "why is X broken", "this isn't working", "something's wrong with", "I'm getting an error" |
+| Understanding how existing code works | `/recon` | "how does X work", "walk me through", "explain the flow", "show me how this is wired" |
+| Frustration with The Rig's own workflow | `/rig-gaps` | "this keeps happening", "rig is blocking me", "that's annoying", friction with a hook or command |
+| Building, fixing, or refactoring (multi-file) | `/task` | "implement", "add", "build", "fix", "refactor", "clean up" — scope > 2–3 files |
+| Resuming in-flight work | `/run` | "continue", "pick up", "resume", "where were we", "what's next on [task]" |
+| Post-merge housekeeping | `/post-merge` | "we just merged", "PR landed", "merge is in", "let's do housekeeping" |
+| Sprint or work planning | `/sprint` | "plan the sprint", "what should we tackle", "what's the priority", "let's scope the work" |
+| Wrapping up the session | `/wrap` | "that's it for today", "wrapping up", "save progress", "end of session" |
+
+When you recognize a match, name the command and offer to run it — don't silently
+reroute or handle the request as if the command doesn't exist. Say:
+> "This sounds like a `/recon` job — want me to run that?"
+Then wait for confirmation.
+
+---
+
 ## Git conventions
 
 ```


### PR DESCRIPTION
## Summary
Adds a `### Command routing` section to the global `CLAUDE.md` template. When a user's freeform message implies a specific Rig workflow, the agent now recognizes the intent and names the right command rather than handling the request ad-hoc or silently absorbing it.

## Changes
- `templates/global/CLAUDE.md`: new `### Command routing` subsection under `## Workflow`, with a routing table mapping intent signals → `/debug`, `/recon`, `/rig-gaps`, `/task`, `/run`, `/post-merge`, `/sprint`, `/wrap`
- Instruction: when a match is found, surface the command by name and ask before running — no silent rerouting

## Closes
Closes #191

## Test plan
- `bats tests/` — 86/86 passing (no installer logic affected)
- Live `~/.claude/CLAUDE.md` updated alongside template for immediate dogfooding
- Routing table reviewed for signal overlap and ambiguity — each row has distinct trigger phrases

## Notes
`/task` routing already had a rule in the "Gate freeform change requests" bullet; this table complements that with the full command set and a consistent tone for surfacing them.
