### PR TITLE
feat(docs,commands): docs/INDEX.md + /doc-list + /rig-help + /status [#192]

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,13 @@
+# Docs index
+
+One-liner per file. Keep this current when a doc is added, removed, or substantially changes scope.
+
+| File | What it covers |
+|---|---|
+| [`how-it-works.md`](how-it-works.md) | End-to-end architecture: components, data flow, install mechanics, upgrade strategy |
+| [`customizing.md`](customizing.md) | Configuring and extending The Rig: hooks, commands, rules, settings, tracking modes |
+| [`decisions.md`](decisions.md) | Key design decisions with rationale and tradeoffs — read before changing core behaviour |
+| [`lessons-learned.md`](lessons-learned.md) | Real incidents and the changes they drove — append-only historical record |
+| [`troubleshooting.md`](troubleshooting.md) | Symptoms, causes, and fixes for common issues |
+| [`agent-install.md`](agent-install.md) | Non-interactive and scripted installation patterns |
+| [`features/README.md`](features/README.md) | Index of feature documentation (per-feature end-to-end traces) |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -157,3 +157,27 @@ Why The Rig is built the way it is. Each entry covers what was decided, what was
 **Rationale:** Real teams use Linear, Trello, GUS, and other trackers. The original GitHub-only gate would either force teams to set `issue-tracking: none` (losing all enforcement) or use GitHub issues in addition to their real tracker (double bookkeeping). Per-tracker enforcement extends the discipline — commit messages prove the ticket exists for whichever tracker the team uses.
 
 **Tradeoff accepted:** Each new tracker type requires a regex pattern in `commit-msg` and handling in the `/task` intake wizard. Acceptable — the pattern is simple and each tracker has a well-defined ref format.
+
+---
+
+## 14. Python3 JSON parsing for hook input extraction over grep pipelines
+
+**Decided:** Use `python3 -c "import json,sys; print(json.load(sys.stdin).get(...))"` to extract fields from JSON tool input in `pre-tool.sh`.
+
+**Rejected:** `grep -o '"field_name":"[^"]*"' | head -1 | cut -d'"' -f4` — a grep pipeline that was the original implementation for `PATH_ARG` extraction.
+
+**Rationale:** The grep approach silently fails on any path or command string containing an escaped quote character (`\"`). JSON paths like `"/some/path/with\"quote\"/file"` would produce an empty string, causing the path block and governance protection checks to silently skip. The python3 approach correctly handles all valid JSON input including edge cases, and is consistent with how `BASH_CMD` extraction was already implemented in the same file.
+
+**Tradeoff accepted:** Requires python3 to be present on the host (it is on macOS ≥ 10.15 and most Linux distributions). On a system without python3, the extraction returns an empty string via `|| true`, which causes path checks to pass silently — the same failure mode as the grep approach on malformed input. Acceptable: python3 availability is a reasonable baseline for Claude Code environments.
+
+---
+
+## 15. No pre-compaction hook — /wrap is the sole compaction safeguard
+
+**Decided:** Rely on the agent noticing the "8% until auto-compact" CLI status bar warning and running `/wrap` proactively, as instructed in `CLAUDE.md`.
+
+**Rejected:** A `PreCompact` hook event that would trigger `/wrap` automatically before Claude Code compacts the conversation.
+
+**Rationale:** Investigated whether Claude Code exposes a pre-compaction hook event — it does not (as of 2026). The "8% until auto-compact" indicator in the CLI status bar is a UI element only; there is no corresponding hook in `~/.claude/settings.json` or the hooks system. The closest available mechanism is the `Stop` event (`stop.sh`), which fires at session end — too late for compaction recovery, since compaction happens mid-session. The `CLAUDE.md` rule "when you see a compaction warning, run `/wrap` immediately before the next tool call" is the only viable mechanism.
+
+**Tradeoff accepted:** Depends on agent attention and available context. A session that reaches near-compaction may not have enough remaining context to run `/wrap` effectively. This is a known capability gap in the Claude Code hooks system, not a solvable problem within The Rig. If Claude Code adds a `PreCompact` hook in a future release, this decision should be revisited.

--- a/templates/project/.claude/commands/doc-list.md
+++ b/templates/project/.claude/commands/doc-list.md
@@ -1,0 +1,37 @@
+# Command: /doc-list
+
+Show the documentation index for this project without loading full doc files.
+
+## What this does
+
+> **RIG_DIR resolution (stealth mode):** Resolve `.rig/` path before reading any files.
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+
+1. Read `$REPO/docs/INDEX.md`.
+   - If absent: say "No `docs/INDEX.md` found. Create one with a one-liner per file in `docs/` — see `docs/INDEX.md` in The Rig repo for the format."
+2. Display the table.
+3. Offer: "Which doc should I load into context?"
+
+## Usage
+
+```
+/doc-list
+```
+
+## When to use
+
+Before loading a doc file — use this to identify which file covers the topic you need
+without loading large files unnecessarily.
+
+## Notes
+
+- Reads `docs/INDEX.md` only — does not scan or read the doc files themselves
+- The index is maintained manually; update it when a doc is added or its scope changes
+- Feature doc index is separate: `docs/features/README.md` (managed by `/doc-feature`)

--- a/templates/project/.claude/commands/rig-help.md
+++ b/templates/project/.claude/commands/rig-help.md
@@ -1,0 +1,68 @@
+# Command: /rig-help
+
+Print a reference table of all Rig slash commands with descriptions and key flags.
+
+## Usage
+
+```
+/rig-help
+```
+
+No arguments. Output the table below directly — do not read individual command files to build it.
+
+---
+
+## Task management
+
+| Command | What it does |
+|---|---|
+| `/task` | Start a new unit of work. Runs the intake wizard: goal, area, constraints, issue number, operating mode (autonomy / check-ins / risk). Creates a task file in `.rig/tasks/`. |
+| `/run` | Continue an active task. Reads the task file, confirms operating mode, executes the next step. Surfaces the inline wizard if `## Operating mode` is absent. |
+| `/ship` | Commit and close a task. Sequential gate: task ID → issue → labels → branch → pre-commit cleanup → checklist → testing pause → commit message → commit → post-housekeeping → PR. |
+| `/sprint` | Plan the next sprint. Reviews backlog, active tasks, and recent velocity; proposes a prioritized work order. |
+
+## Session management
+
+| Command | What it does |
+|---|---|
+| `/wrap` | End a session. Writes `CONTEXT_SNAPSHOT.md`, expands `PROGRESS.md` stubs, captures in-flight task state, names the session. |
+| `/status` | Project state dashboard. Shows current branch, active tasks, backlog count, and recent `PROGRESS.md` entries. |
+
+## Research and documentation
+
+| Command | What it does |
+|---|---|
+| `/recon` | Research how a feature works. Checks internal docs first (`DECISIONS.md`, `ERRORS.md`, `PROGRESS.md`), then reads code. Produces an end-to-end trace. |
+| `/doc-feature` | Write a new feature doc. Checks for an existing doc first, then researches and writes to `docs/features/[name].md`. |
+| `/refresh-feature-doc` | Update an existing feature doc after a PR changes its logic. |
+| `/feature-context` | Load an existing feature doc into context before touching related code. |
+| `/doc-list` | Show the docs index (`docs/INDEX.md`) without loading full doc files. |
+
+## Debugging
+
+| Command | What it does |
+|---|---|
+| `/debug` | Structured diagnosis. Hypothesis → reproduce → isolate → fix → log in `ERRORS.md`. No code touched until the bug is reproduced. |
+
+## Project setup
+
+| Command | What it does |
+|---|---|
+| `/kickoff` | Bootstrap a brand new project from `PROJECT_BRIEF.md`. Run once on a fresh repo. |
+
+## Rig maintenance
+
+| Command | What it does | Key flags |
+|---|---|---|
+| `/rig-upgrade` | Upgrade The Rig to the latest version. | `--version` (print versions only, no upgrade), `--scope=project\|global\|both` |
+| `/rig-propose` | Propose a change to Rig governance files (hooks, processes, rules, CLAUDE.md). Writes a diff for human review — never applies it directly. | — |
+| `/rig-gaps` | Log and submit workflow friction observed during a task. | `--push` (append to local Rig repo), `--submit` (create GitHub issue) |
+| `/rig-help` | This command. | — |
+
+---
+
+## Notes
+
+- `/new-feature` is deprecated — use `/task` instead
+- This table is maintained manually; update it when a new command is added or flags change
+- For full command details, read the relevant `.claude/commands/[name].md` file

--- a/templates/project/.claude/commands/status.md
+++ b/templates/project/.claude/commands/status.md
@@ -1,0 +1,86 @@
+# Command: /status
+
+Print a project state dashboard: branch, active tasks, backlog, and recent progress.
+
+## What this does
+
+> **RIG_DIR resolution (stealth mode):** Resolve `.rig/` path before reading any files.
+> ```bash
+> REPO=$(git rev-parse --show-toplevel)
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+> else
+>   RIG_DIR="$REPO/.rig"
+> fi
+> ```
+
+Work through the following in order. Output a clean, scannable dashboard — not walls of text.
+
+### 1. Branch
+
+```bash
+git branch --show-current
+```
+
+Show: `**Branch:** [name]`
+
+### 2. Active tasks
+
+```bash
+ls "$RIG_DIR/tasks/active/" 2>/dev/null
+```
+
+For each file found: read the `## Goal` section (first sentence only) and the `**Status**` field.
+Format as a bullet list:
+
+```
+**Active tasks (N):**
+- TASK_foo.md — [one-sentence goal]
+- TASK_bar.md — [one-sentence goal]
+```
+
+If none: `**Active tasks:** none`
+
+### 3. Backlog
+
+```bash
+ls "$RIG_DIR/tasks/backlog/" 2>/dev/null | wc -l
+```
+
+Show: `**Backlog:** N task(s)` — count only, no details.
+
+### 4. Recent progress
+
+Read `$RIG_DIR/memory/PROGRESS.md`. Show the last 5 `##` section headings and the first line of body under each:
+
+```
+**Recent progress:**
+- [section heading] — [first body line]
+- ...
+```
+
+If the file is absent: skip this section.
+
+### 5. Pending flags
+
+```bash
+[[ -f "$RIG_DIR/memory/.wrap-needed" ]] && echo "wrap-needed"
+[[ -f "$RIG_DIR/memory/.post-merge-pending" ]] && echo "post-merge-pending"
+```
+
+If `.wrap-needed` exists: `⚠️ /wrap needed — last session didn't wrap`
+If `.post-merge-pending` exists: `⚠️ /post-merge pending — a merge landed since last run`
+
+If no flags: omit this section.
+
+## Usage
+
+```
+/status
+```
+
+## When to use
+
+- At the start of a session as a faster alternative to reading full context files
+- After a long task to orient before deciding what's next
+- When the user asks "where are we?", "what's active?", or "what's in the backlog?"


### PR DESCRIPTION
## Summary
Adds a documentation index (`docs/INDEX.md`) and three new slash commands that reduce token burn on orientation tasks and make the full command set discoverable without opening individual files.

## Changes
- `docs/INDEX.md`: one-liner per doc file; maintained manually alongside doc changes
- `docs/decisions.md`: two new audit findings — python3 JSON parsing rationale (#14) and the pre-compaction hook gap (#15)
- `/doc-list`: displays `docs/INDEX.md` without loading full doc files
- `/rig-help`: prints all Rig commands with one-liner descriptions and key flags; table is self-contained in the command file
- `/status`: project state dashboard — branch, active tasks (with goals), backlog count, recent `PROGRESS.md` entries, and pending housekeeping flags

## Closes
Closes #192

## Test plan
- `bats tests/` — 86/86 passing (no installer logic affected)
- Live `.claude/commands/` updated alongside templates for immediate dogfooding
- All three command files reviewed for RIG_DIR resolution and stealth mode compatibility

## Notes
`/rig-help` hardcodes the command table — it does not read individual command files. This is intentional (prevents token burn on self-reference) but means the table needs manual updates when commands are added or flags change.
