### PR TITLE
docs: currency update for improvement batch PRs #193–#200 [#204]

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 **Daily work**
 ```
-/task              →  intake wizard: define the task + configure autonomy, check-ins, and risk
-/run               →  execute the backlog; respects per-task operating mode; chains at High autonomy
+/task              →  intake wizard: goal + autonomy/check-ins/risk/testing configuration
+/run               →  execute active task; surfaces operating mode wizard if absent; chains at High autonomy
 /run [slug]        →  run a single specific task
 /sprint            →  conflict-aware sprint planner: groups tasks into waves, runs wave by wave
 /sprint [slug …]   →  sprint over a specific set of tasks only
@@ -220,28 +220,37 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 **Ship and debug**
 ```
-/ship         →  pre-ship checklist, commit, open PR
+/ship         →  pre-commit cleanup + checklist + commit + open or update PR
 /debug        →  hypothesis-first diagnosis, mandatory ERRORS.md entry
 ```
 
 **Feature knowledge**
 ```
-/recon [topic]               →  sweep PR history + commits + codebase for a keyword; synthesize an evolution timeline
+/recon [topic]               →  check internal docs first, then sweep PR history + codebase; synthesize timeline
 /feature-context [name]      →  load an existing feature doc into context before starting work on that feature
-/doc-feature [name]          →  research a feature end-to-end; produce a structured doc in docs/features/
+/doc-feature [name]          →  check for existing doc, then research end-to-end; produce doc in docs/features/
 /refresh-feature-doc [name]  →  re-verify an existing feature doc against current code; correct stale claims
+```
+
+**Orientation and docs**
+```
+/status       →  project dashboard: branch, active tasks, backlog count, recent progress, pending flags
+/doc-list     →  show docs/INDEX.md without loading full doc files
+/rig-help     →  print all Rig commands with descriptions and key flags
 ```
 
 **Governance and housekeeping**
 ```
-/post-merge   →  post-merge hygiene: pull main, update memory, move task file, housekeeping commit
-/rig-propose  →  submit a change to governance files for human approval before anything is touched
-/session-name →  derive a session name from current work and present it as a suggestion
-/wrap         →  write CONTEXT_SNAPSHOT, ensure memory is current, log any Rig gaps before closing
-/rig-gaps          →  compile workflow friction from RIG_GAPS.md + ERRORS.md; format for submission to The Rig dev session
-/rig-gaps --push   →  append unsubmitted entries to local Rig repo (same-machine shortcut; requires rig-gaps-push-target: in CLAUDE.md)
+/post-merge        →  post-merge hygiene: pull main, update memory, move task file, housekeeping commit
+/rig-propose       →  submit a change to governance files for human approval before anything is touched
+/session-name      →  derive a session name from current work and present it as a suggestion
+/wrap              →  write CONTEXT_SNAPSHOT, capture in-flight task state, ensure memory is current
+/rig-gaps          →  compile workflow friction from RIG_GAPS.md + ERRORS.md; format for submission
+/rig-gaps --push   →  append unsubmitted entries to local Rig repo (requires rig-gaps-push-target: in CLAUDE.md)
 /rig-gaps --submit →  create public GitHub issues in laudtetteh/the-rig (opt-in; requires .rig-contribute-enabled + gh auth)
-/rig-upgrade  →  pull latest Rig source and re-run the installer with --strategy upgrade
+/rig-upgrade                →  pull latest Rig source and re-run installer with --strategy upgrade
+/rig-upgrade --version      →  print installed vs. available version without upgrading
+/rig-upgrade --scope=global →  upgrade global layer only; --scope=project for project layer only
 ```
 
 ---
@@ -250,7 +259,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 | Hook | Trigger | What it prevents |
 |---|---|---|
-| `pre-tool.sh` | Before every Claude Code tool call | Writes to protected paths; blocks `git commit` until user gives explicit go-ahead |
+| `pre-tool.sh` | Before every Claude Code tool call | Writes to protected paths; blocks `git commit` until user gives explicit go-ahead; blocks commits directly to `main`/`master` unless `housekeeping: direct-push` is set |
 | `post-tool.sh` | After every Claude Code tool call | PROGRESS.md being skipped after a commit; clears commit sentinel after use |
 | `stop.sh` | When the agent finishes its final response | CONTEXT_SNAPSHOT going stale — updates `Last updated:` and appends a session-end boundary to PROGRESS.md without requiring `/wrap` |
 | `pre-commit` | Before every git commit | Secrets reaching the repository |

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -280,9 +280,10 @@ entries and `.git/hooks/` scripts are per-clone and must be set up on each machi
 > **Single-session assumption:** The Rig is designed around one active Claude Code
 > session at a time per project. Running two sessions simultaneously against the same
 > repo is untested — hooks write to shared files (`PROGRESS.md`, the session log)
-> without locking, so concurrent sessions can produce race conditions in PROGRESS.md
-> auto-stubs. For team use, each engineer should work in their own branch with their
-> own active task file.
+> and concurrent auto-stubs in PROGRESS.md can race. `/wrap` includes a lock file
+> guard (`.wrap-in-progress`) that detects a concurrent or crashed wrap and aborts
+> rather than corrupting the snapshot. For team use, each engineer should work in
+> their own branch with their own active task file.
 
 The Rig was designed for solo or small-team use. For larger teams:
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -256,6 +256,9 @@ Every tool call
      │       Blocked → agent shows commit message, asks for trigger phrase
      │       ("commit approved" / "ship it" / "lgtm" / "go")
      │       Agent creates sentinel → commit succeeds → post-tool.sh deletes it
+     │     Guards git commit on main/master:
+     │       Blocked unless CLAUDE.md sets housekeeping: direct-push
+     │       Prevents accidental direct commits to protected branches
      │     Exit 1 (block) if any check fails
      │
      └─► post-tool.sh (PostToolUse)
@@ -418,7 +421,7 @@ proportion to the complexity of the work — not because of Rig overhead.
 
 ## The command set
 
-Seventeen slash commands covering the full development lifecycle:
+Twenty slash commands covering the full development lifecycle:
 
 ### Project bootstrap
 | Command | Triggers | Key behaviour |
@@ -428,23 +431,30 @@ Seventeen slash commands covering the full development lifecycle:
 ### Daily work
 | Command | Triggers | Key behaviour |
 |---|---|---|
-| `/task` | `NEW_TASK_WORKFLOW` | Three-part intake wizard: goal → autonomy/check-ins/risk configuration → confirmation. Persists operating mode in task file. |
-| `/run` | Task execution loop | Surveys backlog, builds dependency-aware priority queue, executes tasks respecting per-task operating mode. Chains automatically at High autonomy. |
+| `/task` | `NEW_TASK_WORKFLOW` | Three-part intake wizard: goal → autonomy/check-ins/risk/testing configuration → confirmation. Persists operating mode and test requirement in task file. |
+| `/run` | Task execution loop | Executes the active task respecting its stored operating mode. If `## Operating mode` is absent from the task file, surfaces an inline wizard to configure it before proceeding. Chains automatically at High autonomy. |
 | `/sprint` | Conflict-aware planner | Groups tasks into conflict-free waves by analysing `## Files likely affected`; runs waves in sequence. Accepts `/sprint [slug …]` or `/sprint --issues #N …` for a targeted set. |
 
 ### Ship and debug
 | Command | Triggers | Key behaviour |
 |---|---|---|
-| `/ship` | `SHIP_WORKFLOW` | Sequential hard gate: task confirm → issue (with template detection) → labels → branch/stale-main check → checklist → local test pause → commit approval → commit → housekeeping → PR (with template detection) |
+| `/ship` | `SHIP_WORKFLOW` | Sequential hard gate: task confirm → issue → labels → branch/stale-main check → pre-commit cleanup (removes debug statements, runs linter, runs tests if required) → checklist → local test pause → commit approval → commit → housekeeping → open or update PR |
 | `/debug` | `DEBUG_WORKFLOW` | Hypothesis before code, mandatory ERRORS.md entry |
 
 ### Feature knowledge
 | Command | Triggers | Key behaviour |
 |---|---|---|
 | `/feature-context` | Context loader | Loads an existing feature doc from `docs/features/` into context before starting work — avoids stale assumptions about a documented feature's internals |
-| `/recon` | Keyword research | Sweeps merged PR history, commit messages, and live codebase for a keyword. Synthesizes an evolution timeline + current state. `--depth shallow` (default) or `--depth full`. Natural precursor to `/doc-feature`. |
-| `/doc-feature` | Research + write | Traces a named feature end-to-end (entry point → data layer → render logic) and produces a structured doc in `docs/features/`. Guards against duplicates; updates the README index. |
+| `/recon` | Keyword research | Checks internal docs first (`DECISIONS.md`, `ERRORS.md`, `PROGRESS.md`) before reading code. If nothing found internally, sweeps merged PR history, commit messages, and live codebase for a keyword. Synthesizes an evolution timeline + current state. |
+| `/doc-feature` | Research + write | Checks for an existing doc first, then traces a named feature end-to-end and produces a structured doc in `docs/features/`. Guards against duplicates; updates the README index. |
 | `/refresh-feature-doc` | Re-verify + update | Re-reads every claim in an existing feature doc against current code; corrects stale paths/line numbers; logs bugs found to `ERRORS.md`. Run after any PR that touches a documented feature. |
+
+### Orientation and docs
+| Command | Triggers | Key behaviour |
+|---|---|---|
+| `/status` | State dashboard | Shows current branch, active tasks (with goals), backlog count, recent PROGRESS entries, and any pending housekeeping flags. Fast alternative to loading full context files. |
+| `/doc-list` | Docs index | Reads `docs/INDEX.md` and displays the table. Use before loading a full doc file to identify which one covers what you need. |
+| `/rig-help` | Command reference | Prints all Rig commands with one-liner descriptions and key flags. Self-contained — no individual command files are loaded. |
 
 ### Governance and housekeeping
 | Command | Triggers | Key behaviour |
@@ -452,9 +462,9 @@ Seventeen slash commands covering the full development lifecycle:
 | `/post-merge` | `POST_MERGE_WORKFLOW` | Post-merge hygiene: pull base branch, update PROGRESS, move task file, housekeeping commit, suggest session name, surface next priority |
 | `/rig-propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
 | `/session-name` | Session naming | Derives a session name from current PROGRESS entries and presents it as a suggestion — callable at any time, not just at wrap |
-| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, updates PROGRESS, runs self-improvement check (logs Rig gaps), trims PROGRESS/ERRORS, suggests session name, surfaces next priority |
+| `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, captures in-flight task state, updates PROGRESS, trims PROGRESS/ERRORS, suggests session name, surfaces next priority. Concurrent session guard prevents race conditions on PROGRESS.md. |
 | `/rig-gaps` | Self-improvement | Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats report for submission. `--push` appends directly to the local Rig repo (requires `rig-gaps-push-target:` in `CLAUDE.md`); `--submit` creates public GitHub issues in `laudtetteh/the-rig` (opt-in; requires `.rig-contribute-enabled` sentinel + `gh` auth) |
-| `/rig-upgrade` | Upgrade workflow | Pulls latest Rig source (`git pull` in installer repo) and re-runs `install.sh` against the current project with `--strategy upgrade` |
+| `/rig-upgrade` | Upgrade workflow | Pulls latest Rig source and re-runs `install.sh` with `--strategy upgrade`. `--version` prints installed vs. available versions without upgrading. `--scope=project\|global\|both` limits which layers are upgraded. |
 | `/new-feature` | *(deprecated)* | Redirects to `/task`. Kept for backward compatibility only. |
 
 ---


### PR DESCRIPTION
## Summary
Brings README.md, docs/how-it-works.md, and docs/customizing.md up to date after the 8-PR improvement batch (#193–#200). No behaviour changes — documentation only.

## Changes

**docs/how-it-works.md**
- Command count: "Seventeen" → "Twenty"
- New "Orientation and docs" table section: `/status`, `/doc-list`, `/rig-help`
- `/task`: added test intake (autonomy/check-ins/risk/testing)
- `/run`: inline operating mode wizard when `## Operating mode` absent
- `/ship`: pre-commit cleanup step + "open or update PR"
- `/recon`: checks internal docs first before code sweep
- `/rig-upgrade`: `--version` and `--scope` flags documented
- `/wrap`: concurrent session guard noted
- `pre-tool.sh` diagram: main-branch guard added

**README.md**
- "Orientation and docs" command group added (`/status`, `/doc-list`, `/rig-help`)
- `/rig-upgrade` flag variants added (`--version`, `--scope`)
- `pre-tool.sh` hook row: main-branch guard added
- All updated command descriptions trimmed to match new behaviour

**docs/customizing.md**
- Concurrent session note updated: wrap lock guard (`.wrap-in-progress`) now mentioned as the mechanism that prevents corruption

## Closes
Closes #204

## Test plan
- `bats tests/` — 86/86 passing (docs-only change, no installer logic affected)
- Diff reviewed line-by-line against the 8 source PRs for accuracy

## Notes
docs/decisions.md was already updated this session (decisions #14 and #15). docs/lessons-learned.md is append-only and had nothing to add.
