### PR TITLE
test(commands): structural linting bats coverage [#201]

### DIFF
--- a/templates/project/.claude/commands/new-feature.md
+++ b/templates/project/.claude/commands/new-feature.md
@@ -21,3 +21,10 @@ When this command is triggered, say:
 > Run `/task` to start the intake wizard."
 
 Do not proceed with the old workflow. Redirect only.
+
+---
+
+## Notes
+
+Deprecated in favour of `/task`, which adds an intake wizard for autonomy level,
+check-in frequency, and risk tolerance on top of the same `NEW_TASK_WORKFLOW`.

--- a/tests/test_command_lint.bats
+++ b/tests/test_command_lint.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+#
+# tests/test_command_lint.bats — Structural linting for command markdown files
+#
+# Run with: bats tests/test_command_lint.bats
+#
+# Enforces four structural invariants across every .md file in
+# templates/project/.claude/commands/:
+#   1. H1 first line matches "# Command: /slug"
+#   2. Slug in H1 matches the filename (debug.md → /debug)
+#   3. At least one H2 section exists
+#   4. No H2 header is missing a space after "##"
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+COMMAND_DIR="$REPO_ROOT/templates/project/.claude/commands"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_fail_with_list() {
+  local label="$1"
+  shift
+  printf '%s:\n' "$label"
+  printf '  %s\n' "$@"
+  return 1
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+@test "command files: H1 first line matches '# Command: /slug' format" {
+  local failures=()
+  for f in "$COMMAND_DIR"/*.md; do
+    local first
+    first="$(head -1 "$f")"
+    if ! echo "$first" | grep -qE '^# Command: /[a-z-]+$'; then
+      failures+=("$(basename "$f"): got '${first}'")
+    fi
+  done
+  [ "${#failures[@]}" -eq 0 ] || _fail_with_list "Malformed H1" "${failures[@]}"
+}
+
+@test "command files: slug in H1 matches filename" {
+  local failures=()
+  for f in "$COMMAND_DIR"/*.md; do
+    local name first slug
+    name="$(basename "$f" .md)"
+    first="$(head -1 "$f")"
+    slug="${first#\# Command: /}"
+    if [[ "$slug" != "$name" ]]; then
+      failures+=("$(basename "$f"): expected /${name}, H1 says /${slug}")
+    fi
+  done
+  [ "${#failures[@]}" -eq 0 ] || _fail_with_list "Slug mismatch" "${failures[@]}"
+}
+
+@test "command files: all files have at least one H2 section" {
+  local failures=()
+  for f in "$COMMAND_DIR"/*.md; do
+    if ! grep -q "^## " "$f"; then
+      failures+=("$(basename "$f")")
+    fi
+  done
+  [ "${#failures[@]}" -eq 0 ] || _fail_with_list "Missing H2 section" "${failures[@]}"
+}
+
+@test "command files: no H2 header missing space after '##'" {
+  local failures=()
+  for f in "$COMMAND_DIR"/*.md; do
+    # Matches ## at line start followed by a char that is not # or space.
+    # This catches "##Foo" but not "### Foo" (H3) or "## Foo" (valid H2).
+    if grep -qE '^##[^# ]' "$f"; then
+      failures+=("$(basename "$f")")
+    fi
+  done
+  [ "${#failures[@]}" -eq 0 ] || _fail_with_list "H2 missing space after ##" "${failures[@]}"
+}


### PR DESCRIPTION
## Summary

- Adds `tests/test_command_lint.bats` with 4 structural lint rules enforced across all 20 command files in `templates/project/.claude/commands/`
- Fixes `new-feature.md` — the only command file missing an H2 section (deprecated redirect; adds `## Notes`)
- Suite grows from 105 → 109 tests, all passing

## Rules enforced

| Test | What it catches |
|---|---|
| H1 format | First line must match `# Command: /slug` exactly |
| Slug matches filename | `debug.md` → `/debug`; catches copy-paste errors |
| H2 presence | Every command file must have at least one `##` section |
| H2 spacing | No `##Foo` — space required after `##` |

## Test plan

- [x] `bats tests/` — 109 tests, all pass
- [x] No existing tests broken
- [x] New test file follows existing bats conventions (loop-per-rule, `_fail_with_list` helper, diagnostic output on failure)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)