### PR TITLE
fix(hooks,commands): python3 fallback + rig-upgrade parse + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 | [Claude Code](https://docs.anthropic.com/claude-code) | The AI coding CLI this system wraps |
 | bash 3.2+ | For `install.sh` and hook scripts |
 | git | For hooks and version control |
+| python3 | Required by `pre-tool.sh` for JSON parsing. Standard on macOS 12+ and most Linux distros. |
 | [gitleaks](https://github.com/gitleaks/gitleaks) | Secret scanning (`brew install gitleaks`) |
 | npm / npx | For Husky initialization (optional if not using Node projects) |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -217,6 +217,39 @@ use `git update-index --add` instead of `git add`.
 
 ---
 
+## 8. "Commit to 'main' blocked by The Rig"
+
+**Symptom:** The agent tries to commit and receives:
+
+```
+Commit to 'main' blocked by The Rig.
+Committing directly to 'main' is not allowed.
+Create a feature branch first: git checkout -b feat/your-description
+```
+
+**Cause:** The main-branch commit guard in `pre-tool.sh` blocks all direct commits
+to `main` or `master` unless the project explicitly allows them.
+
+**Fix for feature branch projects:** this is the correct behavior. Create a branch
+before committing:
+
+```bash
+git checkout -b feat/your-change
+```
+
+**Fix for solo or housekeeping projects** that legitimately commit directly to `main`
+(e.g. post-merge housekeeping commits): add this line to your project's `CLAUDE.md`:
+
+```
+housekeeping: direct-push
+```
+
+This setting tells the guard that direct commits are intentional for this project.
+It is already set in The Rig's own `CLAUDE.md` as it uses direct-push for
+housekeeping commits.
+
+---
+
 ## Still stuck?
 
 Check the session log first (`/tmp/the-rig-session.log`). If the log shows the hook

--- a/templates/project/.claude/commands/rig-upgrade.md
+++ b/templates/project/.claude/commands/rig-upgrade.md
@@ -327,13 +327,15 @@ installer_output=$("$INSTALLER_SRC/install.sh" \
 echo "$installer_output"  # show full output to user
 ```
 
-Parse the captured output to populate result accumulators:
+Parse the captured output to populate result accumulators. The installer's
+`success()` function prefixes every line with ANSI color codes and a status
+symbol (`✓ `), so match on substring rather than prefix:
 
 ```bash
 while IFS= read -r line; do
   case "$line" in
-    Updated:*)
-      UPGRADED+=("${line#Updated: }") ;;
+    *"Updated: "*)
+      UPGRADED+=("${line#*Updated: }") ;;
   esac
 done <<< "$installer_output"
 ```

--- a/templates/project/.claude/hooks/pre-tool.sh
+++ b/templates/project/.claude/hooks/pre-tool.sh
@@ -60,10 +60,15 @@ echo "[$(date +%H:%M:%S)] PRE  $TOOL" >> /tmp/the-rig-session.log
 
 if [[ "$TOOL" == "Bash" ]]; then
   # Parse the command string from the JSON input.
-  # python3 handles embedded quotes and escapes correctly.
-  BASH_CMD=$(python3 -c \
-    "import json,sys; print(json.load(sys.stdin).get('command',''))" \
-    <<< "$INPUT" 2>/dev/null || true)
+  # python3 handles embedded quotes and escapes correctly; falls back to grep
+  # on systems where python3 is absent so the guard is never silently disabled.
+  if command -v python3 >/dev/null 2>&1; then
+    BASH_CMD=$(python3 -c \
+      "import json,sys; print(json.load(sys.stdin).get('command',''))" \
+      <<< "$INPUT" 2>/dev/null || true)
+  else
+    BASH_CMD=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | cut -d'"' -f4)
+  fi
 
   # ── Gate git commit on sentinel file ───────────────────────────────────
   COMMIT_OK="$RIG_DIR/memory/.rig-commit-ok"
@@ -109,11 +114,15 @@ fi
 if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]]; then
 
   # Extract the target file path from the JSON input.
-  # python3 handles embedded quotes and escapes correctly — the grep approach
-  # silently fails on paths containing escaped quote characters.
-  PATH_ARG=$(python3 -c \
-    "import json,sys; print(json.load(sys.stdin).get('file_path',''))" \
-    <<< "$INPUT" 2>/dev/null || true)
+  # python3 handles embedded quotes and escapes correctly; falls back to grep
+  # on systems where python3 is absent so write protection is never silently disabled.
+  if command -v python3 >/dev/null 2>&1; then
+    PATH_ARG=$(python3 -c \
+      "import json,sys; print(json.load(sys.stdin).get('file_path',''))" \
+      <<< "$INPUT" 2>/dev/null || true)
+  else
+    PATH_ARG=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+  fi
 
   # ── THE RIG'S OWN GOVERNANCE FILES (self-protection) ─────────────────────
   # The agent must not rewrite the rules it is supposed to follow.


### PR DESCRIPTION
## Summary

Four fixes from the pre-release review for v1.16.0. Closes #212.

- **`pre-tool.sh`**: `python3 ... || true` silently disabled both the commit gate and write-path protection when `python3` is absent. Added `command -v python3` check with grep fallback so neither guard can be silently bypassed.
- **`rig-upgrade.md` Phase 2**: `Updated:*` case pattern never matched because `install.sh`'s `success()` prefixes lines with ANSI codes + checkmark. Changed to substring match. `UPGRADED[]` now populates correctly; Phase 5 summary accurate.
- **`docs/troubleshooting.md`**: added item #8 for the main-branch commit guard error message.
- **`README.md`**: added `python3` to the requirements table.

## Test plan

- [x] `bats tests/` — 109/109 passing
- [x] Diff reviewed — no unintended changes
