### PR TITLE
fix(installer): auto-detect .rigpath tracking mode on upgrade; add .rig/ to stealth exclude [#217]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -988,6 +988,16 @@ if [[ "$DO_PROJECT" == true ]]; then
   elif [[ -n "$EXTERNAL_RIG_DIR" ]]; then
     # --rig-dir was provided (without --tracking): backward-compatible external mode.
     RIG_TRACKING="external"
+  elif [[ -f "$TARGET/.rigpath" ]]; then
+    # Existing .rigpath detected — auto-detect tracking mode without prompting.
+    # Avoids writing .rig/ files to the wrong location when --tracking is omitted.
+    EXTERNAL_RIG_DIR=$(tr -d '[:space:]' < "$TARGET/.rigpath")
+    if [[ "$EXTERNAL_RIG_DIR" == "${HOME}/.rig/projects/"* ]]; then
+      RIG_TRACKING="stealth"
+    else
+      RIG_TRACKING="external"
+    fi
+    info "Detected .rigpath — using ${RIG_TRACKING} mode: $EXTERNAL_RIG_DIR"
   else
     echo "How should .rig/ be tracked in git?"
     echo ""
@@ -1260,6 +1270,7 @@ if [[ "$DO_PROJECT" == true ]]; then
       _stealth_exclude ".gitleaks.toml"
       _stealth_exclude "docs/features/README.md"
       _stealth_exclude ".rig-backup/"
+      _stealth_exclude ".rig/"
       # .rigpath is already excluded by the external-mode block above
     else
       warn ".git/info/exclude not found — stealth exclusions could not be applied."

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -760,6 +760,27 @@ _is_rig_protected() {
   [ ! -f "$TEST_PROJECT/.rigpath" ]
 }
 
+@test "upgrade without --tracking auto-detects stealth mode from .rigpath" {
+  # Simulate a project previously installed with --tracking stealth:
+  # .rigpath exists pointing at an external directory.
+  local rig_ext="$TEMP_DIR/rig-external"
+  mkdir -p "$rig_ext"
+  echo "$rig_ext" > "$TEST_PROJECT/.rigpath"
+
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+  # .rig/ files must land in external dir, not project dir
+  [ -f "$rig_ext/memory/PROGRESS.md" ]
+  [ ! -f "$TEST_PROJECT/.rig/memory/PROGRESS.md" ]
+}
+
+@test "stealth install adds .rig/ to .git/info/exclude" {
+  local rig_ext="$TEMP_DIR/rig-external"
+  run_installer --strategy skip --tracking stealth --rig-dir "$rig_ext"
+  [ "$status" -eq 0 ]
+  grep -qF ".rig/" "$TEST_PROJECT/.git/info/exclude"
+}
+
 # ── Gap 4: stop.sh writes .wrap-needed on 2+ commits ─────────────────────────
 
 @test "stop.sh: writes .wrap-needed when session log has 2+ commits" {


### PR DESCRIPTION
## Summary

- When `--tracking` is omitted on an upgrade run, the installer now checks for `.rigpath` and infers `stealth` or `external` mode automatically, preventing `.rig/` files from landing in the wrong location
- Adds `.rig/` to the stealth `.git/info/exclude` entries so a misplaced local `.rig/` directory does not appear as untracked in git clients

## Root cause

Discovered during the v1.16.0 machine-wide upgrade. Running `--strategy upgrade` without `--tracking stealth` on a stealth project defaulted to in-repo mode and wrote `.rig/` files to the project directory instead of the external path pointed to by `.rigpath`.

## Test plan

- [x] ok 72: upgrade without --tracking auto-detects stealth mode from .rigpath
- [x] ok 73: stealth install adds .rig/ to .git/info/exclude
- [x] All 111 tests passing

Closes #217

Generated with [Claude Code](https://claude.com/claude-code)