### PR TITLE
fix: P0 improvements — doc-list path, HH:MM timestamps, multi-choice questions

### DIFF
--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -48,7 +48,8 @@ Do not summarise these back to me unless asked.
 - **Plan before acting.** For any task longer than a single file edit, produce a
   numbered plan and wait for approval before touching code.
 - **Ask exactly one clarifying question** if intent is ambiguous — then proceed.
-  Never stack multiple questions in one response.
+  Never stack multiple questions in one response. When asking, present 2–4 numbered
+  options with "Other (describe below)" as the last choice.
 - **Be terse.** Skip preamble. Lead with the answer or the first action.
 - **Never apologise for mistakes** — just fix them and note what changed.
 - **Prefer reversible over irreversible actions.** When in doubt, stage and ask.

--- a/templates/project/.claude/commands/doc-list.md
+++ b/templates/project/.claude/commands/doc-list.md
@@ -13,8 +13,18 @@ Show the documentation index for this project without loading full doc files.
 >   RIG_DIR="$REPO/.rig"
 > fi
 > ```
+>
+> **DOCS_DIR resolution:** Stealth installs keep docs under `$RIG_DIR/docs/`; in-repo
+> installs keep them at `$REPO/docs/`. Resolve before reading any doc paths:
+> ```bash
+> if [[ -f "$REPO/.rigpath" ]]; then
+>   DOCS_DIR="$RIG_DIR/docs"
+> else
+>   DOCS_DIR="$REPO/docs"
+> fi
+> ```
 
-1. Read `$REPO/docs/INDEX.md`.
+1. Read `$DOCS_DIR/INDEX.md`.
    - If absent: say "No `docs/INDEX.md` found. Create one with a one-liner per file in `docs/` — see `docs/INDEX.md` in The Rig repo for the format."
 2. Display the table.
 3. Offer: "Which doc should I load into context?"
@@ -32,6 +42,6 @@ without loading large files unnecessarily.
 
 ## Notes
 
-- Reads `docs/INDEX.md` only — does not scan or read the doc files themselves
+- Reads `$DOCS_DIR/INDEX.md` only — does not scan or read the doc files themselves
 - The index is maintained manually; update it when a doc is added or its scope changes
-- Feature doc index is separate: `docs/features/README.md` (managed by `/doc-feature`)
+- Feature doc index is separate: `$DOCS_DIR/features/README.md` (managed by `/doc-feature`)

--- a/templates/project/.claude/hooks/stop.sh
+++ b/templates/project/.claude/hooks/stop.sh
@@ -46,15 +46,16 @@ NOW_FULL=$(date "+%Y-%m-%d %H:%M")
 # This keeps the freshness signal accurate for the next session without
 # requiring /wrap to have run in this session.
 if [[ -f "$SNAPSHOT" ]] && grep -q "^\*\*Last updated:\*\*" "$SNAPSHOT" 2>/dev/null; then
-  # Extract the description (everything after "YYYY-MM-DD — ")
+  # Extract the description (everything after "YYYY-MM-DD[ HH:MM] — ")
+  # Regex handles both old date-only and new datetime formats for backward compat.
   DESCRIPTION=$(grep "^\*\*Last updated:\*\*" "$SNAPSHOT" \
-    | sed 's/\*\*Last updated:\*\* [0-9-]* — //')
+    | sed 's/\*\*Last updated:\*\*[^—]*— //')
 
   TMP=$(mktemp)
-  sed "s|^\*\*Last updated:\*\*.*|\*\*Last updated:\*\* $NOW — $DESCRIPTION|" \
+  sed "s|^\*\*Last updated:\*\*.*|\*\*Last updated:\*\* $NOW_FULL — $DESCRIPTION|" \
     "$SNAPSHOT" > "$TMP" && mv "$TMP" "$SNAPSHOT"
 
-  echo "[$(date +%H:%M:%S)] STOP: updated Last updated: → $NOW in CONTEXT_SNAPSHOT" \
+  echo "[$(date +%H:%M:%S)] STOP: updated Last updated: → $NOW_FULL in CONTEXT_SNAPSHOT" \
     >> "$SESSION_LOG"
 fi
 
@@ -127,7 +128,7 @@ if [[ -f "$WRAP_NEEDED" ]]; then
     echo "> This is a minimal checkpoint written by stop.sh — not a full /wrap snapshot."
     echo "> Run \`/wrap\` to replace this with a complete context snapshot."
     echo ""
-    echo "**Last updated:** $NOW — auto-checkpoint (stop.sh)"
+    echo "**Last updated:** $NOW_FULL — auto-checkpoint (stop.sh)"
     echo "**Branch:** $_BRANCH"
     echo "**Last commit:** $_COMMIT"
     if [[ -n "$_ACTIVE_TASK" ]]; then

--- a/templates/project/.rig/memory/CONTEXT_SNAPSHOT.md
+++ b/templates/project/.rig/memory/CONTEXT_SNAPSHOT.md
@@ -27,7 +27,7 @@ At session end (or before an anticipated context reset), overwrite this file wit
 ## Template
 
 ```markdown
-**Last updated:** [YYYY-MM-DD] — [session description, e.g. "after merging PR #12"]
+**Last updated:** [YYYY-MM-DD HH:MM] — [session description, e.g. "after merging PR #12"]
 **Session name:** [set by /session-name, or blank if unnamed]
 
 ---


### PR DESCRIPTION
## Summary

Three P0 fixes from the improvement triage session, each with upstream/downstream audit and full bats test verification.

- **#225** `fix(commands)`: `/doc-list` was hardcoding `$REPO/docs/INDEX.md` — stealth installs keep docs at `$RIG_DIR/docs/`. Added DOCS_DIR resolution block (same `.rigpath` check pattern) to select the correct path per install mode.

- **#226** `fix(hooks)`: `stop.sh` was writing date-only (`YYYY-MM-DD`) to `**Last updated:**`. Multiple tabs open on the same day produced indistinguishable session boundaries. Both write paths (sed-update and auto-checkpoint) now use `$NOW_FULL` (`YYYY-MM-DD HH:MM`). Description extraction regex made backward-compatible with old date-only format.

- **#227** `feat(templates)`: Added multiple-choice format constraint to the clarifying-question rule in `templates/global/CLAUDE.md`: present 2–4 numbered options with "Other (describe below)" as the last choice.

## Files changed

| File | Change | Issue |
|---|---|---|
| `templates/project/.claude/commands/doc-list.md` | DOCS_DIR resolution block; `$REPO/docs` → `$DOCS_DIR` | #225 |
| `templates/project/.claude/hooks/stop.sh` | `$NOW` → `$NOW_FULL` (2 sites); backward-compat extraction regex | #226 |
| `templates/project/.rig/memory/CONTEXT_SNAPSHOT.md` | Template placeholder: `[YYYY-MM-DD]` → `[YYYY-MM-DD HH:MM]` | #226 |
| `templates/global/CLAUDE.md` | Multi-choice format appended to clarifying-question rule | #227 |

## Test plan

- [x] 113/113 bats tests pass on `fix/p0-improvements`
- [x] `bash -n stop.sh` syntax check passes
- [x] No bats tests reference doc-list.md content (command file, not installer)
- [x] stop.sh bats tests (lines 807–853) only check `.wrap-needed` existence — not CONTEXT_SNAPSHOT content — so the backward-compat regex change is safe
- [x] `~/.claude/CLAUDE.md` updated in-session for immediate effect (not tracked in this repo)

Closes #225, #226, #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)