### PR TITLE
fix(commands): conversation context as primary signal for session naming

### DIFF
--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -108,12 +108,14 @@ automatically — present it for the user to confirm or tweak.
 
 ### How to determine what belongs to this session
 
-Use the same boundary logic as `/wrap`:
+Use the same logic as `/wrap` and `/session-name`: **conversation context first,
+files as cross-reference.**
 
-1. Look for `<!-- session-end -->` markers in `.rig/memory/PROGRESS.md`. Entries
-   above the most recent marker belong to this session.
-2. If no markers exist, use the `**Last updated:**` date from CONTEXT_SNAPSHOT as
-   the boundary and collect entries added since that date.
+Your direct knowledge of what was done in this session is the primary signal —
+enumerate the PRs, tasks, and work you know about from this conversation. File
+signals (PROGRESS.md markers, CONTEXT_SNAPSHOT.md datetime) are cross-reference
+only, used to catch anything that compacted out of context. If they conflict with
+what you know, trust the conversation.
 
 ### Check for an existing session name
 

--- a/templates/project/.claude/commands/session-name.md
+++ b/templates/project/.claude/commands/session-name.md
@@ -35,14 +35,24 @@ No arguments. Run it whenever you want to name or re-name the current session.
 
 ## Steps
 
-### 1 — Determine the session boundary
+### 1 — Determine what happened this session
 
-Read `.rig/memory/PROGRESS.md`:
+**Your conversation context is the primary signal.** Before reading any files,
+enumerate directly what was done in this session: PRs merged or opened, tasks
+completed, issues created, commands run, significant files changed. You were
+here — this is the most accurate record of the session's work.
 
-- **Primary signal:** look for `<!-- session-end YYYY-MM-DD HH:MM -->` markers.
-  Entries between the top of the file and the most recent marker belong to this session.
-- **Fallback:** if no markers exist, read the `**Last updated:**` date from
-  `CONTEXT_SNAPSHOT.md` and treat entries added since that date as this session.
+File signals are cross-reference only — use them to catch anything that may have
+compacted out of the context window, not to override what you already know:
+
+- **`<!-- session-end YYYY-MM-DD HH:MM -->` markers in PROGRESS.md** — entries
+  above the most recent marker are candidates to cross-check against your context.
+- **`**Last updated:**` datetime in CONTEXT_SNAPSHOT.md** — use as an approximate
+  session-start boundary when correlating PROGRESS.md entries.
+
+**If conversation context and file signals conflict, trust the conversation.**
+Files may be stale, markers may be missing, or another tab may have written to
+the same files. Your direct knowledge of this session is authoritative.
 
 ### 2 — Check for an existing session name
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -286,25 +286,32 @@ the user to confirm or tweak.
 
 ### How to determine "this session's work"
 
-**Do not use today's date** — it breaks for sessions that span midnight or are
-resumed days later. Use this priority order:
+**Your conversation context is the primary signal.** Before reading any files,
+enumerate directly what was done in this session: PRs merged or opened, tasks
+completed, issues created, commands run, significant files changed. You were
+here — this is the most accurate record of what the session name should reflect.
 
-1. **`<!-- session-end -->` markers in PROGRESS.md** (most reliable)
-   The `stop.sh` hook appends `<!-- session-end YYYY-MM-DD HH:MM -->` automatically
-   when the agent finishes each response. Look for the most recent such marker:
-   - Entries **above** the most recent marker belong to this session.
-   - Entries **below** it belong to prior sessions.
+Do not use today's date as a boundary — it breaks for sessions that span midnight
+or are resumed days later.
 
-2. **`Last updated:` field in the previous CONTEXT_SNAPSHOT** (fallback)
-   If no session-end marker exists (e.g. stop.sh wasn't wired yet, or this is the
-   first /wrap on a new install), read the `**Last updated:**` field from the snapshot
-   you noted at session start (before step 1 overwrote it). Collect PROGRESS.md
-   entries added since that date.
+Use file signals as cross-reference only — to catch work that may have compacted
+out of the context window, not to override what you already know:
 
-3. **Infer from PROGRESS.md ordering** (last resort)
-   If neither signal exists, take the entries at the top of PROGRESS.md that are
-   clearly from this session's conversation, and stop when you reach entries from
-   a prior session.
+1. **`<!-- session-end -->` markers in PROGRESS.md** (cross-reference)
+   The `stop.sh` hook appends `<!-- session-end YYYY-MM-DD HH:MM -->` automatically.
+   Entries above the most recent marker are candidates to correlate with your context.
+
+2. **`Last updated:` datetime in the previous CONTEXT_SNAPSHOT** (boundary fallback)
+   If markers are absent or ambiguous, use the snapshot's `**Last updated:**` datetime
+   as an approximate session-start boundary when scanning PROGRESS.md entries.
+
+3. **PROGRESS.md ordering** (last resort for compacted context)
+   If context window is short and you cannot recall specifics, take entries at the
+   top of PROGRESS.md that plausibly match this session and stop at the prior boundary.
+
+**If conversation context and file signals conflict, trust the conversation.**
+Files may be stale, markers may be missing or duplicated across tabs. Your direct
+knowledge of this session is authoritative.
 
 ### Check for an existing session name
 


### PR DESCRIPTION
## Summary

`/session-name`, `/wrap`, and `/post-merge` all inferred session work from file signals first (PROGRESS.md session-end markers, CONTEXT_SNAPSHOT.md datetime). The agent's own conversation context — the most direct and accurate record of what happened — was treated as a last resort.

This inverts the priority in all three commands:

1. **Conversation context (primary)** — enumerate what was done in this session directly from memory
2. **PROGRESS.md session-end markers** — cross-reference for anything that compacted out of context
3. **CONTEXT_SNAPSHOT.md Last updated datetime** — fallback boundary for file corroboration
4. **Explicit conflict rule** — if conversation and files disagree, trust the conversation

File signals break under: multi-tab sessions (markers duplicated across tabs), skipped `/wrap` (PROGRESS.md stale), compaction (context window truncated), or stop.sh not wired. Conversation context has none of these failure modes.

## Files changed

- `templates/project/.claude/commands/session-name.md` — Step 1 rewritten
- `templates/project/.claude/commands/wrap.md` — "How to determine this session's work" rewritten
- `templates/project/.claude/commands/post-merge.md` — "How to determine what belongs to this session" rewritten

## Test plan
- [x] 4/4 command lint tests pass
- [x] No installer changes — no full bats run needed

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
