### PR TITLE
feat(hooks): add SessionStart, UserPromptSubmit, PermissionRequest hooks

### DIFF
--- a/templates/global/CLAUDE.md
+++ b/templates/global/CLAUDE.md
@@ -27,6 +27,10 @@ At the start of any session, silently read in this order:
 
 **After reading context, check for pending housekeeping flags before starting any work:**
 
+> The `SessionStart` hook injects flag warnings automatically at session start.
+> The `UserPromptSubmit` hook re-checks on every prompt. These instructions are
+> a fallback for sessions where the hooks are absent or fail.
+
 - If `.rig/memory/.wrap-needed` exists: say exactly —
   > "⚠️ The last session ended without running `/wrap`. CONTEXT_SNAPSHOT.md may be
   > stale and PROGRESS.md has unexpanded entries. Run `/wrap` now to capture session

--- a/templates/project/.claude/hooks/permission-request.sh
+++ b/templates/project/.claude/hooks/permission-request.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# permission-request.sh
+#
+# Runs when Claude Code requests permission to use a tool (PermissionRequest event).
+# Auto-approves known-safe read-only patterns so the user isn't prompted
+# repeatedly for the same operations within and across sessions.
+#
+# Approved patterns:
+#   Read       — any file (read-only, no side effects)
+#   Bash       — git log/status/diff/branch (read-only git queries)
+#   Bash       — bats (test runner, local only)
+#   Bash       — bash -n (syntax check, no execution)
+#   Bash       — grep, find (read-only searches)
+#
+# For approved patterns: outputs JSON decision with behavior: allow.
+# For all other patterns: exits 0 with no output (normal permission handling).
+#
+# Input JSON: {"tool_name": "...", "tool_input": {...}, ...}
+# Output JSON: {"hookSpecificOutput": {"hookEventName": "PermissionRequest",
+#               "decision": {"behavior": "allow"}}}
+
+INPUT=$(cat)
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+DECISION=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys, re
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+tool_name = data.get('tool_name', '')
+tool_input = data.get('tool_input', {})
+
+def allow():
+    out = {
+        'hookSpecificOutput': {
+            'hookEventName': 'PermissionRequest',
+            'decision': {
+                'behavior': 'allow'
+            }
+        }
+    }
+    print(json.dumps(out))
+    sys.exit(0)
+
+# Read — always safe
+if tool_name == 'Read':
+    allow()
+
+# Bash — check command against safe patterns
+if tool_name == 'Bash':
+    cmd = tool_input.get('command', '').lstrip()
+    safe_patterns = [
+        r'^git (log|status|diff|branch|show|describe|tag|remote|stash list)',
+        r'^bats\b',
+        r'^bash\s+-n\b',
+        r'^grep\b',
+        r'^find\b',
+    ]
+    for pattern in safe_patterns:
+        if re.match(pattern, cmd):
+            allow()
+
+# Not an approved pattern — fall through to normal permission handling
+sys.exit(0)
+" 2>/dev/null || true)
+
+if [[ -n "$DECISION" ]]; then
+  echo "$DECISION"
+fi
+
+exit 0

--- a/templates/project/.claude/hooks/prompt-submit.sh
+++ b/templates/project/.claude/hooks/prompt-submit.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# prompt-submit.sh
+#
+# Runs on every user prompt (UserPromptSubmit event).
+# Checks for .wrap-needed and .post-merge-pending flag files and injects
+# a warning into context if either is set — so the agent sees the flag
+# whether it was set at session start or mid-session (e.g. after a commit).
+#
+# Must be fast: UserPromptSubmit has a 30-second timeout.
+# When no flags are set, exits immediately with no output.
+#
+# Output: JSON {"additionalContext": "..."} when a flag is present.
+# Claude Code receives this as context alongside the user's message.
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+[[ -z "$REPO" ]] && exit 0
+
+if [[ -f "$REPO/.rigpath" ]]; then
+  RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+else
+  RIG_DIR="$REPO/.rig"
+fi
+
+WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
+POST_MERGE_PENDING="$RIG_DIR/memory/.post-merge-pending"
+
+# Fast path: no flags set — exit with no output
+if [[ ! -f "$WRAP_NEEDED" && ! -f "$POST_MERGE_PENDING" ]]; then
+  exit 0
+fi
+
+# Build warning text
+WARNINGS=""
+if [[ -f "$WRAP_NEEDED" ]]; then
+  WARNINGS+="⚠️ The last session ended without running /wrap. CONTEXT_SNAPSHOT.md may be stale and PROGRESS.md has unexpanded entries. Run /wrap now to capture session state before starting new work — or say 'skip wrap' to proceed anyway."
+fi
+if [[ -f "$POST_MERGE_PENDING" ]]; then
+  [[ -n "$WARNINGS" ]] && WARNINGS+=$'\n\n'
+  WARNINGS+="⚠️ A merge landed since /post-merge was last run. Memory may not reflect the merged state. Run /post-merge now — or say 'skip post-merge' to proceed anyway."
+fi
+
+# Output JSON additionalContext
+if command -v python3 >/dev/null 2>&1; then
+  printf '%s' "$WARNINGS" | python3 -c "
+import json, sys
+warnings = sys.stdin.read()
+print(json.dumps({'additionalContext': warnings}))
+" 2>/dev/null || true
+fi
+
+exit 0

--- a/templates/project/.claude/hooks/session-start.sh
+++ b/templates/project/.claude/hooks/session-start.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# session-start.sh
+#
+# Runs at Claude Code session start (SessionStart event).
+# Injects context before the first turn so the agent is oriented without
+# relying on instruction-dependent file reading — hook-enforced orientation.
+#
+# Source values and behaviour:
+#   startup / resume  — inject CONTEXT_SNAPSHOT.md + housekeeping flag warnings
+#   compact           — inject .compact-checkpoint.md (PreCompact output);
+#                       falls back to CONTEXT_SNAPSHOT.md if checkpoint absent
+#   clear             — inject minimal orientation (project name + run /status)
+#
+# Output: JSON with hookSpecificOutput.additionalContext
+# Falls through silently (exit 0, no output) on any error or missing files.
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+[[ -z "$REPO" ]] && exit 0
+
+if [[ -f "$REPO/.rigpath" ]]; then
+  RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+else
+  RIG_DIR="$REPO/.rig"
+fi
+
+INPUT=$(cat)
+
+# Parse source from stdin JSON
+SOURCE=""
+if command -v python3 >/dev/null 2>&1; then
+  SOURCE=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('source', ''))
+except Exception:
+    pass
+" 2>/dev/null || true)
+fi
+
+SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
+COMPACT_CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint.md"
+WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
+POST_MERGE_PENDING="$RIG_DIR/memory/.post-merge-pending"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+flag_warnings() {
+  local w=""
+  if [[ -f "$WRAP_NEEDED" ]]; then
+    w+="⚠️ The last session ended without running /wrap. CONTEXT_SNAPSHOT.md may be stale and PROGRESS.md has unexpanded entries. Run /wrap now to capture session state before starting new work — or say 'skip wrap' to proceed anyway."
+  fi
+  if [[ -f "$POST_MERGE_PENDING" ]]; then
+    [[ -n "$w" ]] && w+=$'\n\n'
+    w+="⚠️ A merge landed since /post-merge was last run. Memory may not reflect the merged state. Run /post-merge now — or say 'skip post-merge' to proceed anyway."
+  fi
+  printf '%s' "$w"
+}
+
+emit_context() {
+  local ctx="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$ctx" | python3 -c "
+import json, sys
+ctx = sys.stdin.read()
+out = {
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': ctx
+    }
+}
+print(json.dumps(out))
+" 2>/dev/null || true
+  fi
+}
+
+# ── Dispatch by source ────────────────────────────────────────────────────────
+
+case "$SOURCE" in
+  startup|resume)
+    [[ ! -f "$SNAPSHOT" ]] && exit 0
+    CONTEXT=$(cat "$SNAPSHOT")
+    WARNINGS=$(flag_warnings)
+    if [[ -n "$WARNINGS" ]]; then
+      emit_context "${WARNINGS}"$'\n\n---\n\n'"${CONTEXT}"
+    else
+      emit_context "$CONTEXT"
+    fi
+    ;;
+
+  compact)
+    if [[ -f "$COMPACT_CHECKPOINT" ]]; then
+      CONTEXT=$(cat "$COMPACT_CHECKPOINT")
+    elif [[ -f "$SNAPSHOT" ]]; then
+      CONTEXT=$(cat "$SNAPSHOT")
+    else
+      exit 0
+    fi
+    WARNINGS=$(flag_warnings)
+    if [[ -n "$WARNINGS" ]]; then
+      emit_context "${WARNINGS}"$'\n\n---\n\n'"${CONTEXT}"
+    else
+      emit_context "$CONTEXT"
+    fi
+    ;;
+
+  clear)
+    PROJECT_NAME=$(basename "$REPO")
+    emit_context "Project: ${PROJECT_NAME}. Session cleared — run /status for current state."
+    ;;
+
+  *)
+    # Unknown source or unparseable input — fail silently
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -31,6 +31,36 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash [REPO_ROOT]/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash [REPO_ROOT]/.claude/hooks/prompt-submit.sh"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash [REPO_ROOT]/.claude/hooks/permission-request.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -201,6 +201,10 @@ docker compose up
 
 ## Context files — load at session start
 
+> **Hook-enforced:** The `SessionStart` hook automatically injects `CONTEXT_SNAPSHOT.md`
+> and any pending flag warnings before the first turn. The instructions below are a
+> fallback for sessions where the hook is absent or fails.
+
 When starting a new session, read in this order:
 
 1. `.rig/memory/CONTEXT_SNAPSHOT.md` — **if this exists, it is sufficient for orientation.
@@ -210,6 +214,22 @@ When starting a new session, read in this order:
 3. `.rig/memory/ERRORS.md` — known pitfalls
 4. `.rig/memory/DECISIONS.md` — architectural and process decisions (skim only)
 5. `.rig/tasks/active/` — current in-flight task(s)
+
+**After reading context, check for pending housekeeping flags:**
+
+> The `UserPromptSubmit` hook injects these warnings automatically on every prompt.
+> Check manually only if the hook is absent or the session started without one.
+
+- If `.rig/memory/.wrap-needed` exists: say exactly —
+  > "⚠️ The last session ended without running `/wrap`. CONTEXT_SNAPSHOT.md may be
+  > stale and PROGRESS.md has unexpanded entries. Run `/wrap` now to capture session
+  > state before we start new work — or say 'skip wrap' to proceed anyway."
+  Wait for the user's response before continuing.
+
+- If `.rig/memory/.post-merge-pending` exists: say exactly —
+  > "⚠️ A merge landed since `/post-merge` was last run. Memory may not reflect the
+  > merged state. Run `/post-merge` now — or say 'skip post-merge' to proceed anyway."
+  Wait for the user's response before continuing.
 
 > **External .rig/ note:** if `.rigpath` exists at the project root, all `.rig/`
 > paths above resolve to the external directory it points to. The installer

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -419,6 +419,21 @@ print(total)
   [ "$status" -eq 0 ]
 }
 
+@test "syntax: session-start.sh has valid bash syntax" {
+  run bash -n "$REPO_ROOT/templates/project/.claude/hooks/session-start.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "syntax: prompt-submit.sh has valid bash syntax" {
+  run bash -n "$REPO_ROOT/templates/project/.claude/hooks/prompt-submit.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "syntax: permission-request.sh has valid bash syntax" {
+  run bash -n "$REPO_ROOT/templates/project/.claude/hooks/permission-request.sh"
+  [ "$status" -eq 0 ]
+}
+
 @test "syntax: pre-commit hook has valid bash syntax" {
   run bash -n "$REPO_ROOT/templates/project/.husky/pre-commit"
   [ "$status" -eq 0 ]

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -337,39 +337,50 @@ is_rig_owned_stub() {
   # First install populates settings.json with the Rig hooks.
   run_installer --strategy skip
   [ "$status" -eq 0 ]
+  local count_after_first
+  count_after_first=$(python3 -c "
+import json
+with open('$TEST_PROJECT/.claude/settings.json') as f:
+    s = json.load(f)
+print(sum(len(v) for v in s.get('hooks', {}).values()))
+")
   # Second install via merge should not add duplicate entries.
   run_installer --strategy merge
   [ "$status" -eq 0 ]
-  local hook_count
-  hook_count=$(python3 -c "
-import json, sys
+  local count_after_second
+  count_after_second=$(python3 -c "
+import json
 with open('$TEST_PROJECT/.claude/settings.json') as f:
     s = json.load(f)
-events = s.get('hooks', {})
-total = sum(len(v) for v in events.values())
-print(total)
+print(sum(len(v) for v in s.get('hooks', {}).values()))
 ")
-  # Should have exactly one entry per hook event (PreToolUse, PostToolUse, Stop = 3 total)
-  [ "$hook_count" -eq 3 ]
+  # Count must not grow — no duplicates added
+  [ "$count_after_second" -eq "$count_after_first" ]
 }
 
 @test "upgrade strategy: does not duplicate hooks when settings.json already has Rig hooks" {
   # First install populates settings.json with the Rig hooks.
   run_installer --strategy skip
   [ "$status" -eq 0 ]
+  local count_after_first
+  count_after_first=$(python3 -c "
+import json
+with open('$TEST_PROJECT/.claude/settings.json') as f:
+    s = json.load(f)
+print(sum(len(v) for v in s.get('hooks', {}).values()))
+")
   # Upgrade should not add duplicate entries.
   run_installer --strategy upgrade
   [ "$status" -eq 0 ]
-  local hook_count
-  hook_count=$(python3 -c "
-import json, sys
+  local count_after_second
+  count_after_second=$(python3 -c "
+import json
 with open('$TEST_PROJECT/.claude/settings.json') as f:
     s = json.load(f)
-events = s.get('hooks', {})
-total = sum(len(v) for v in events.values())
-print(total)
+print(sum(len(v) for v in s.get('hooks', {}).values()))
 ")
-  [ "$hook_count" -eq 3 ]
+  # Count must not grow — no duplicates added
+  [ "$count_after_second" -eq "$count_after_first" ]
 }
 
 # ── CLI flag validation ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#238** — `session-start.sh`: injects `CONTEXT_SNAPSHOT.md` and flag warnings before the first turn; handles startup/resume/compact/clear sources; falls back silently when files absent
- **#241** — `prompt-submit.sh`: checks `.wrap-needed` and `.post-merge-pending` on every prompt; fast-path exits with no output when no flags set
- **#239** — `permission-request.sh`: auto-approves Read(*) and safe Bash patterns (git read queries, bats, bash -n, grep, find)
- `settings.json` wired with all three new hook events (SessionStart, UserPromptSubmit, PermissionRequest)
- Both CLAUDE.md templates updated: flag-check instructions now marked as hook-enforced fallback only

## Test plan

- [x] `bats tests/` — 128/128 passing (3 new syntax tests)
- [x] `bash -n` syntax check on all three new hook files
- [ ] Manual: start a session in a project with these hooks — verify CONTEXT_SNAPSHOT.md is injected
- [ ] Manual: create `.wrap-needed` sentinel — verify warning appears on next prompt
- [ ] Manual: trigger a Read tool call — verify no permission prompt fires

Closes #238, #241, #239