### PR TITLE
feat(hooks): add PreCompact/PostCompact hooks for task context across compaction

### DIFF
--- a/templates/project/.claude/hooks/post-compact.sh
+++ b/templates/project/.claude/hooks/post-compact.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# post-compact.sh
+#
+# Runs after Claude Code finishes compacting the context (PostCompact event).
+# Reads the checkpoint written by pre-compact.sh and re-injects it as
+# additionalContext so the agent can resume mid-task without losing awareness
+# of what branch, commit, and step were active before compaction.
+#
+# Falls back to CONTEXT_SNAPSHOT.md if no checkpoint exists.
+# Falls through silently (exit 0, no output) if neither file is present.
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+[[ -z "$REPO" ]] && exit 0
+
+if [[ -f "$REPO/.rigpath" ]]; then
+  RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+else
+  RIG_DIR="$REPO/.rig"
+fi
+
+CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint.md"
+SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
+
+if [[ -f "$CHECKPOINT" ]]; then
+  CONTEXT=$(cat "$CHECKPOINT")
+elif [[ -f "$SNAPSHOT" ]]; then
+  CONTEXT=$(cat "$SNAPSHOT")
+else
+  exit 0
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  printf '%s' "$CONTEXT" | python3 -c "
+import json, sys
+ctx = sys.stdin.read()
+out = {
+    'hookSpecificOutput': {
+        'hookEventName': 'PostCompact',
+        'additionalContext': ctx
+    }
+}
+print(json.dumps(out))
+" 2>/dev/null || true
+fi
+
+exit 0

--- a/templates/project/.claude/hooks/pre-compact.sh
+++ b/templates/project/.claude/hooks/pre-compact.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# pre-compact.sh
+#
+# Runs before Claude Code compacts the context (PreCompact event).
+# Writes a minimal checkpoint to $RIG_DIR/memory/.compact-checkpoint.md
+# capturing current branch, last commit, active task, and last progress entry.
+# The checkpoint is read back by post-compact.sh (same session) and by
+# session-start.sh when source=compact (new session after compaction).
+#
+# Also outputs a compactionSummary so the checkpoint survives in the
+# compacted summary itself.
+#
+# Falls through silently (exit 0, no output) on any error or missing files.
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+[[ -z "$REPO" ]] && exit 0
+
+if [[ -f "$REPO/.rigpath" ]]; then
+  RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+else
+  RIG_DIR="$REPO/.rig"
+fi
+
+[[ ! -d "$RIG_DIR/memory" ]] && exit 0
+
+CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint.md"
+
+# ── Gather context ─────────────────────────────────────────────────────────────
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M' 2>/dev/null || true)
+BRANCH=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+LAST_COMMIT=$(git -C "$REPO" log -1 --format="%h — %s" 2>/dev/null || echo "none")
+
+ACTIVE_TASK="none"
+if [[ -d "$RIG_DIR/tasks/active" ]]; then
+  TASK_FILE=$(ls "$RIG_DIR/tasks/active"/*.md 2>/dev/null | head -1 || true)
+  if [[ -n "$TASK_FILE" ]]; then
+    ACTIVE_TASK=$(basename "$TASK_FILE" .md)
+  fi
+fi
+
+LAST_PROGRESS="none"
+PROGRESS_FILE="$RIG_DIR/memory/PROGRESS.md"
+if [[ -f "$PROGRESS_FILE" ]]; then
+  LAST_PROGRESS=$(grep -m1 "^## " "$PROGRESS_FILE" 2>/dev/null | sed 's/^## //' || echo "none")
+fi
+
+# ── Write checkpoint ───────────────────────────────────────────────────────────
+
+cat > "$CHECKPOINT" <<CPEOF
+## Compact checkpoint — ${TIMESTAMP}
+
+**Branch:** ${BRANCH}
+**Last commit:** ${LAST_COMMIT}
+**Active task:** ${ACTIVE_TASK}
+**Last progress entry:** ${LAST_PROGRESS}
+CPEOF
+
+# ── Output compactionSummary ───────────────────────────────────────────────────
+
+if command -v python3 >/dev/null 2>&1; then
+  SUMMARY="Branch: ${BRANCH} | Last commit: ${LAST_COMMIT} | Active task: ${ACTIVE_TASK} | Last progress: ${LAST_PROGRESS}"
+  printf '%s' "$SUMMARY" | python3 -c "
+import json, sys
+summary = sys.stdin.read()
+out = {
+    'hookSpecificOutput': {
+        'hookEventName': 'PreCompact',
+        'compactionSummary': summary
+    }
+}
+print(json.dumps(out))
+" 2>/dev/null || true
+fi
+
+exit 0

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -61,6 +61,26 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash [REPO_ROOT]/.claude/hooks/pre-compact.sh"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash [REPO_ROOT]/.claude/hooks/post-compact.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -459,11 +459,14 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
   local tmpdir
   tmpdir=$(mktemp -d)
   git -C "$tmpdir" init -q
+  git -C "$tmpdir" config user.email "test@test.com"
+  git -C "$tmpdir" config user.name "Test"
   git -C "$tmpdir" commit --allow-empty -m "initial" -q
   mkdir -p "$tmpdir/.rig/memory" "$tmpdir/.rig/tasks/active"
 
-  REPO="$tmpdir" RIG_DIR="$tmpdir/.rig" \
-    bash "$REPO_ROOT/templates/project/.claude/hooks/pre-compact.sh" >/dev/null
+  # cd into tmpdir so git rev-parse --show-toplevel returns tmpdir, not Rig repo root
+  (cd "$tmpdir" && RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/pre-compact.sh" >/dev/null)
 
   [ -f "$tmpdir/.rig/memory/.compact-checkpoint.md" ]
   grep -q "Branch:" "$tmpdir/.rig/memory/.compact-checkpoint.md"
@@ -480,8 +483,9 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
     > "$tmpdir/.rig/memory/.compact-checkpoint.md"
 
   local output
-  output=$(REPO="$tmpdir" RIG_DIR="$tmpdir/.rig" \
-    bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh" 2>/dev/null)
+  # cd into tmpdir so git rev-parse --show-toplevel returns tmpdir, not Rig repo root
+  output=$((cd "$tmpdir" && RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh") 2>/dev/null)
 
   echo "$output" | python3 -c "
 import json, sys
@@ -501,8 +505,9 @@ assert 'additionalContext' in d['hookSpecificOutput']
   mkdir -p "$tmpdir/.rig/memory"
 
   local output
-  output=$(REPO="$tmpdir" RIG_DIR="$tmpdir/.rig" \
-    bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh" 2>/dev/null)
+  # cd into tmpdir so git rev-parse --show-toplevel returns tmpdir, not Rig repo root
+  output=$((cd "$tmpdir" && RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh") 2>/dev/null)
 
   [ -z "$output" ]
   rm -rf "$tmpdir"

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -445,6 +445,69 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
   [ "$status" -eq 0 ]
 }
 
+@test "syntax: pre-compact.sh has valid bash syntax" {
+  run bash -n "$REPO_ROOT/templates/project/.claude/hooks/pre-compact.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "syntax: post-compact.sh has valid bash syntax" {
+  run bash -n "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "pre-compact: writes checkpoint file with branch and commit info" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" commit --allow-empty -m "initial" -q
+  mkdir -p "$tmpdir/.rig/memory" "$tmpdir/.rig/tasks/active"
+
+  REPO="$tmpdir" RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/pre-compact.sh" >/dev/null
+
+  [ -f "$tmpdir/.rig/memory/.compact-checkpoint.md" ]
+  grep -q "Branch:" "$tmpdir/.rig/memory/.compact-checkpoint.md"
+  grep -q "Last commit:" "$tmpdir/.rig/memory/.compact-checkpoint.md"
+  rm -rf "$tmpdir"
+}
+
+@test "post-compact: outputs additionalContext JSON when checkpoint exists" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  mkdir -p "$tmpdir/.rig/memory"
+  printf '## Compact checkpoint\n\n**Branch:** test-branch\n' \
+    > "$tmpdir/.rig/memory/.compact-checkpoint.md"
+
+  local output
+  output=$(REPO="$tmpdir" RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh" 2>/dev/null)
+
+  echo "$output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert 'hookSpecificOutput' in d
+assert d['hookSpecificOutput']['hookEventName'] == 'PostCompact'
+assert 'additionalContext' in d['hookSpecificOutput']
+" 2>/dev/null
+  [ "$?" -eq 0 ]
+  rm -rf "$tmpdir"
+}
+
+@test "post-compact: exits silently when neither checkpoint nor snapshot exists" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  mkdir -p "$tmpdir/.rig/memory"
+
+  local output
+  output=$(REPO="$tmpdir" RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh" 2>/dev/null)
+
+  [ -z "$output" ]
+  rm -rf "$tmpdir"
+}
+
 @test "syntax: pre-commit hook has valid bash syntax" {
   run bash -n "$REPO_ROOT/templates/project/.husky/pre-commit"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- **#232** — `pre-compact.sh`: fires before compaction; writes `.compact-checkpoint.md` with branch, last commit, active task, and last progress entry; outputs `compactionSummary` so the checkpoint survives in the compacted summary
- `post-compact.sh`: fires after compaction in the same session; re-injects checkpoint as `additionalContext`; falls back to `CONTEXT_SNAPSHOT.md` if no checkpoint exists
- `settings.json` wired with `PreCompact` and `PostCompact` hook events
- Pairs with `session-start.sh` `compact` handler (#238) which covers the new-session-after-compaction path

## Test plan

- [x] `bats tests/` — 134/134 passing (5 new tests: syntax, checkpoint write, PostCompact JSON output, silent exit with no files)
- [x] `bash -n` syntax check on both new hook files
- [ ] Manual: let context grow until compaction fires — verify `.compact-checkpoint.md` is written and re-injected

Closes #232