### PR TITLE
feat(hooks,installer,commands): Sprint 5 — SessionEnd, code-reviewer, feature-docs opt-in

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,7 @@ is_rig_owned() {
   case "$rel" in
     .claude/hooks/*|\
     .claude/commands/*|\
+    .claude/agents/*|\
     .rig/processes/*|\
     .rig/VERSION|\
     .husky/*|\
@@ -169,13 +170,15 @@ _FLAG_TARGET=""       # set via --target <path>     (skips interactive prompt)
 _FLAG_PROJECT_NAME="" # set via --project-name <n>  (skips interactive prompt)
 _FLAG_BASE_BRANCH=""  # set via --base-branch <n>   (skips interactive prompt)
 _FLAG_TRACKING=""     # set via --tracking <mode>   (skips tracking prompt; orthogonal to --target)
-SKIP_GIT_HOOKS=false  # set via --skip-git-hooks    (stealth: skip .git/hooks/ writes)
+SKIP_GIT_HOOKS=false       # set via --skip-git-hooks    (stealth: skip .git/hooks/ writes)
+INSTALL_FEATURE_DOCS=false # set via --feature-docs      (gates doc-feature/feature-context/etc.)
 
 for arg in "$@"; do
   case "$arg" in
     --global-only)      DO_PROJECT=false ;;
     --project-only)     DO_GLOBAL=false ;;
     --skip-git-hooks)   SKIP_GIT_HOOKS=true ;;
+    --feature-docs)     INSTALL_FEATURE_DOCS=true ;;
     --rig-dir|--strategy|--target|--project-name|--base-branch|--tracking)
       # two-arg flags; value captured in the loop below
       ;;
@@ -220,6 +223,11 @@ for arg in "$@"; do
       echo "  --rig-dir <path>      Install .rig/ to an external path outside the repo."
       echo "                        Writes a .rigpath pointer file at the project root."
       echo "                        Useful for shared repos where teammates don't use The Rig."
+      echo "  --feature-docs        Install feature-documentation commands (opt-in)."
+      echo "                        Includes: /doc-feature, /doc-list, /feature-context,"
+      echo "                        /refresh-feature-doc, and docs/features/README.md."
+      echo "                        Skipped by default — add for projects that maintain"
+      echo "                        end-to-end feature traces."
       echo "  --skip-git-hooks      Stealth mode only: skip writing hooks to .git/hooks/."
       echo "                        Use when the project already manages git hooks via Husky"
       echo "                        or another tool and you want to avoid the conflict."
@@ -1090,12 +1098,33 @@ if [[ "$DO_PROJECT" == true ]]; then
       .rig/processes/*)                    [[ "$INSTALL_PROCESSES" == true ]]      ;;
       .rig/rules/*)                        [[ "$INSTALL_RULES" == true ]]          ;;
       .claude/hooks/*|.claude/settings*)   [[ "$INSTALL_CLAUDE_HOOKS" == true ]]   ;;
-      .claude/commands/*)                  [[ "$INSTALL_COMMANDS" == true ]]       ;;
+      .claude/commands/doc-feature.md|\
+      .claude/commands/doc-list.md|\
+      .claude/commands/feature-context.md|\
+      .claude/commands/refresh-feature-doc.md|\
+      docs/features/*)                     [[ "$INSTALL_FEATURE_DOCS" == true ]]   ;;
+      .claude/commands/*|\
+      .claude/agents/*)                    [[ "$INSTALL_COMMANDS" == true ]]       ;;
       .husky/*|.gitleaks.toml)             [[ "$INSTALL_GIT_HOOKS" == true ]]      ;;
       .github/*)                           [[ "$INSTALL_GITHUB" == true ]]         ;;
       *)                                   return 0 ;;  # install unknown files by default
     esac
   }
+
+  # ── UPGRADE AUTO-DETECT: enable feature-docs if already installed ─────────
+  # If any feature-doc command exists in the target, preserve them on upgrade.
+  if [[ "$INSTALL_FEATURE_DOCS" != true ]]; then
+    for _fd_check in \
+      "$TARGET/.claude/commands/doc-feature.md" \
+      "$TARGET/.claude/commands/doc-list.md" \
+      "$TARGET/.claude/commands/feature-context.md" \
+      "$TARGET/.claude/commands/refresh-feature-doc.md"; do
+      if [[ -f "$_fd_check" ]]; then
+        INSTALL_FEATURE_DOCS=true
+        break
+      fi
+    done
+  fi
 
   # ── COPY PROJECT FILES ────────────────────────────────────────────────────
   while IFS= read -r -d '' src_file; do

--- a/templates/project/.claude/agents/code-reviewer.md
+++ b/templates/project/.claude/agents/code-reviewer.md
@@ -1,0 +1,44 @@
+---
+name: code-reviewer
+description: "Focused code review agent. Use when you want a second opinion on staged changes or a diff before shipping."
+---
+
+You are a focused code reviewer. Your job is to find real problems — not to
+suggest style preferences, hypothetical improvements, or nitpicks.
+
+## What you check (in priority order)
+
+1. **Logic bugs** — incorrect conditions, off-by-one errors, wrong operator, unreachable branches, silent failures
+2. **Security issues** — input not validated, credentials exposed, SQL/command injection, overly broad permissions, unescaped output
+3. **Unhandled paths** — missing error handling at system boundaries, unchecked return values, race conditions, null/empty cases that will crash
+4. **Convention violations** — breaks an explicit rule in `CLAUDE.md`, `.rig/rules/`, or a pattern established in the surrounding code
+
+## What you do NOT check
+
+- Style preferences not backed by an explicit project rule
+- Refactoring opportunities ("this could be cleaner")
+- Hypothetical future requirements
+- Test coverage for pure glue code or config
+
+## How to review
+
+1. Read the diff in full before commenting
+2. For each finding: state the **file:line**, the **problem**, and the **fix** — one sentence each
+3. Group findings by severity: **Blocking** (must fix before merge) vs **Advisory** (worth noting, not blocking)
+4. If you find nothing blocking, say so explicitly: "No blocking issues found."
+5. Keep the total response under 400 words unless the diff is large enough to warrant more
+
+## Output format
+
+```
+## Blocking
+- `path/to/file.sh:42` — [problem] → [fix]
+
+## Advisory
+- `path/to/file.sh:17` — [problem] → [fix]
+
+## Verdict
+[No blocking issues found. / N blocking issues — fix before merging.]
+```
+
+If the diff is clean, the entire output can be: `No blocking issues found.`

--- a/templates/project/.claude/commands/doc-feature.md
+++ b/templates/project/.claude/commands/doc-feature.md
@@ -41,10 +41,11 @@ If no argument is given, ask: **"Which feature should I document?"**
 > REPO=$(git rev-parse --show-toplevel)
 > if [[ -f "$REPO/.rigpath" ]]; then
 >   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+>   DOCS_DIR="$RIG_DIR/docs/features"
 > else
 >   RIG_DIR="$REPO/.rig"
+>   DOCS_DIR="$REPO/docs/features"
 > fi
-> DOCS_DIR="$RIG_DIR/docs/features"
 > ```
 >
 > Substitute `$DOCS_DIR` for `docs/features/` in every step below.

--- a/templates/project/.claude/commands/feature-context.md
+++ b/templates/project/.claude/commands/feature-context.md
@@ -36,10 +36,11 @@ If no argument is given, list available feature docs and ask which to load.
 > REPO=$(git rev-parse --show-toplevel)
 > if [[ -f "$REPO/.rigpath" ]]; then
 >   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+>   DOCS_DIR="$RIG_DIR/docs/features"
 > else
 >   RIG_DIR="$REPO/.rig"
+>   DOCS_DIR="$REPO/docs/features"
 > fi
-> DOCS_DIR="$RIG_DIR/docs/features"
 > ```
 
 ### Step 1 — Find the doc

--- a/templates/project/.claude/commands/refresh-feature-doc.md
+++ b/templates/project/.claude/commands/refresh-feature-doc.md
@@ -38,10 +38,11 @@ If the argument doesn't match any existing doc, list the docs in
 > REPO=$(git rev-parse --show-toplevel)
 > if [[ -f "$REPO/.rigpath" ]]; then
 >   RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+>   DOCS_DIR="$RIG_DIR/docs/features"
 > else
 >   RIG_DIR="$REPO/.rig"
+>   DOCS_DIR="$REPO/docs/features"
 > fi
-> DOCS_DIR="$RIG_DIR/docs/features"
 > ```
 >
 > Substitute `$DOCS_DIR` for `docs/features/` in every step below.

--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -194,6 +194,55 @@ If any item cannot be confirmed, stop and resolve it before continuing.
 
 ---
 
+## Step 4.5 — Code review (optional)
+
+Ask the user:
+> "Run the code-reviewer agent on this diff? [yes / skip]"
+
+If they say yes (or "y"): invoke the `code-reviewer` agent with the staged diff
+(`git diff --cached`). Report all **Blocking** findings and stop the ship flow
+until they are resolved. **Advisory** findings are reported but do not block.
+
+If they say skip: proceed to Step 4.8.
+
+---
+
+## Step 4.8 — Docs and memory freshness gate
+
+**Check 1 — PROGRESS.md stubs (blocking)**
+
+Run:
+```bash
+grep -c "Auto-logged by post-tool hook" "$RIG_DIR/memory/PROGRESS.md" 2>/dev/null || echo 0
+```
+
+If the count is > 0: stop and say:
+> "PROGRESS.md has unexpanded auto-stubs. Run `/wrap` to expand them before shipping."
+Do not continue until the user resolves this.
+
+**Check 2 — Feature doc overlap (advisory, only if feature docs are installed)**
+
+Only run this check if `$DOCS_DIR/features/README.md` exists (where `$DOCS_DIR` is
+`$RIG_DIR/docs` for stealth/external installs, `$REPO/docs` otherwise).
+
+List the files changed in this PR (`git diff --name-only HEAD~1..HEAD 2>/dev/null || git diff --cached --name-only`).
+Cross-reference against `$DOCS_DIR/features/README.md` — if any changed file's path
+contains a slug listed in the feature doc index, report:
+> "Advisory: changed files overlap with documented feature(s): [list]. Run
+> `/refresh-feature-doc <feature>` after merging to keep docs current."
+
+This is advisory only — it does not block the ship flow.
+
+**Check 3 — docs/INDEX.md freshness (advisory, only if INDEX.md exists)**
+
+If `$DOCS_DIR/INDEX.md` exists: check if any files in `$DOCS_DIR/` were added or
+removed by this PR that are not reflected in the index. If so, report:
+> "Advisory: docs/INDEX.md may need updating — new or removed files detected in docs/."
+
+This is advisory only.
+
+---
+
 ## Step 5 — Pause for local testing
 
 **Stop here.** Do not commit yet.

--- a/templates/project/.claude/hooks/session-end.sh
+++ b/templates/project/.claude/hooks/session-end.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# session-end.sh
+#
+# Runs when a Claude Code session terminates (SessionEnd event).
+# Handles true end-of-session cleanup — distinct from stop.sh which fires
+# after every agent turn (Stop event).
+#
+# Source values and behaviour:
+#   logout / prompt_input_exit — user closed the session
+#       Write .wrap-needed if /wrap hasn't run and the session had meaningful
+#       commits. Write minimal checkpoint. Log session end.
+#   clear — context was cleared; session will continue in a new context window
+#       Log "context cleared" to session log. Do NOT set .wrap-needed.
+#   resume — new session is starting; nothing to clean up here
+#   other — unknown source; no action
+#
+# Never blocks (exit 2 shows stderr but does not prevent termination).
+# Fails silently on any error.
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+[[ -z "$REPO" ]] && exit 0
+
+if [[ -f "$REPO/.rigpath" ]]; then
+  RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+else
+  RIG_DIR="$REPO/.rig"
+fi
+
+INPUT=$(cat)
+
+# Parse source from stdin JSON
+SOURCE=""
+if command -v python3 >/dev/null 2>&1; then
+  SOURCE=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('source', ''))
+except Exception:
+    pass
+" 2>/dev/null || true)
+fi
+
+SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
+PROGRESS="$RIG_DIR/memory/PROGRESS.md"
+WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
+SESSION_LOG="${RIG_SESSION_LOG:-/tmp/the-rig-session.log}"
+NOW_FULL=$(date "+%Y-%m-%d %H:%M" 2>/dev/null || true)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+write_wrap_needed() {
+  local reason="$1"
+  touch "$WRAP_NEEDED" 2>/dev/null || true
+  echo "[$(date +%H:%M:%S)] SESSION_END: .wrap-needed written (${reason})" \
+    >> "$SESSION_LOG" 2>/dev/null || true
+}
+
+write_minimal_checkpoint() {
+  [[ ! -d "$RIG_DIR/memory" ]] && return
+  local branch commit active_task
+  branch=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  commit=$(git -C "$REPO" log -1 --format="%h %s" 2>/dev/null || echo "none")
+  active_task=""
+  if [[ -d "$RIG_DIR/tasks/active" ]]; then
+    active_task=$(ls "$RIG_DIR/tasks/active"/*.md 2>/dev/null \
+      | head -1 | xargs basename 2>/dev/null || true)
+  fi
+
+  {
+    echo "# Context Snapshot — session-end checkpoint"
+    echo ""
+    echo "> Minimal checkpoint written at session end by session-end.sh."
+    echo "> Run \`/wrap\` at the start of the next session for a full snapshot."
+    echo ""
+    echo "**Last updated:** $NOW_FULL — session-end checkpoint"
+    echo "**Branch:** $branch"
+    echo "**Last commit:** $commit"
+    [[ -n "$active_task" ]] && echo "**Active task:** $active_task"
+    echo ""
+    echo "---"
+    echo ""
+    echo "## Status"
+    echo ""
+    echo "Session ended without running \`/wrap\`. Run \`/wrap\` to capture full context."
+  } > "$SNAPSHOT" 2>/dev/null || true
+
+  echo "[$(date +%H:%M:%S)] SESSION_END: minimal checkpoint written" \
+    >> "$SESSION_LOG" 2>/dev/null || true
+}
+
+# ── Dispatch by source ────────────────────────────────────────────────────────
+
+case "$SOURCE" in
+  logout|prompt_input_exit)
+    # Determine whether .wrap-needed should be set
+    NEEDS_WRAP=false
+
+    if [[ -f "$PROGRESS" ]] && grep -q "Auto-logged by post-tool hook" "$PROGRESS" 2>/dev/null; then
+      write_wrap_needed "unexpanded stubs in PROGRESS.md"
+      NEEDS_WRAP=true
+    fi
+
+    if [[ "$NEEDS_WRAP" == false ]] && [[ ! -f "$SNAPSHOT" ]] && [[ -f "$PROGRESS" ]]; then
+      write_wrap_needed "no CONTEXT_SNAPSHOT.md"
+      NEEDS_WRAP=true
+    fi
+
+    if [[ "$NEEDS_WRAP" == false ]]; then
+      SESSION_COMMIT_COUNT=$(grep -c "PROGRESS stub:" "$SESSION_LOG" 2>/dev/null || echo 0)
+      if [[ "$SESSION_COMMIT_COUNT" -ge 2 ]]; then
+        write_wrap_needed "${SESSION_COMMIT_COUNT} commits this session"
+        NEEDS_WRAP=true
+      fi
+    fi
+
+    if [[ "$NEEDS_WRAP" == true ]]; then
+      write_minimal_checkpoint
+    fi
+
+    echo "[$(date +%H:%M:%S)] SESSION_END: source=${SOURCE} — session terminated" \
+      >> "$SESSION_LOG" 2>/dev/null || true
+    ;;
+
+  clear)
+    echo "[$(date +%H:%M:%S)] SESSION_END: source=clear — context cleared, session continues" \
+      >> "$SESSION_LOG" 2>/dev/null || true
+    ;;
+
+  resume|*)
+    # No action needed
+    ;;
+esac
+
+exit 0

--- a/templates/project/.claude/hooks/stop.sh
+++ b/templates/project/.claude/hooks/stop.sh
@@ -1,21 +1,16 @@
 #!/bin/bash
 # stop.sh
 #
-# Runs when Claude Code's agent finishes its final response (Stop event).
-# Wired via .claude/settings.json under "Stop".
-#
-# This is a lightweight session-boundary marker — not a full snapshot.
+# Runs after every Claude Code agent turn (Stop event).
+# Lightweight per-turn session-boundary marker only.
 #
 # What it does:
 #   1. Updates the date in the "Last updated:" line in CONTEXT_SNAPSHOT.md
-#      (preserves the description — only the YYYY-MM-DD changes)
-#   2. Appends a session-end comment to PROGRESS.md so the session naming
-#      heuristic in /wrap and /post-merge knows where this session ends
-#   3. Writes .wrap-needed if PROGRESS.md has unexpanded auto-stubs,
-#      signalling that /wrap should be run before the next session starts
+#   2. Appends a session-end comment to PROGRESS.md (used by /wrap for naming)
 #
 # What it does NOT do:
-#   - Write a full CONTEXT_SNAPSHOT (that's /wrap's job)
+#   - Write .wrap-needed — that's session-end.sh's job (fires on true termination)
+#   - Write a full CONTEXT_SNAPSHOT — that's /wrap's job
 #   - Block or fail — exits 0 always
 #
 # Claude Code passes: stdin — stop event data as JSON (not used here)
@@ -34,10 +29,8 @@ fi
 
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
 PROGRESS="$RIG_DIR/memory/PROGRESS.md"
-WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
 # Allow tests to inject a custom session log path via RIG_SESSION_LOG env var.
 SESSION_LOG="${RIG_SESSION_LOG:-/tmp/the-rig-session.log}"
-NOW=$(date +%Y-%m-%d)
 NOW_FULL=$(date "+%Y-%m-%d %H:%M")
 
 # ── Update Last updated: date in CONTEXT_SNAPSHOT ────────────────────────────
@@ -75,76 +68,6 @@ if [[ -f "$PROGRESS" ]]; then
     echo "[$(date +%H:%M:%S)] STOP: session-end marker already present — skipped" \
       >> "$SESSION_LOG"
   fi
-fi
-
-# ── Write .wrap-needed flag if unexpanded auto-stubs exist ────────────────────
-# post-tool.sh auto-stubs PROGRESS.md after every git commit with a line:
-#   "_Auto-logged by post-tool hook. Expand this entry during wrap-up._"
-# /wrap expands those stubs and removes that marker text.
-# If stubs are still present, /wrap hasn't run since the last commit.
-# The next session will read this flag and prompt the user to run /wrap first.
-if [[ -f "$PROGRESS" ]] && grep -q "Auto-logged by post-tool hook" "$PROGRESS"; then
-  touch "$WRAP_NEEDED"
-  echo "[$(date +%H:%M:%S)] STOP: .wrap-needed written (unexpanded stubs found)" \
-    >> "$SESSION_LOG"
-elif [[ ! -f "$SNAPSHOT" ]] && [[ -f "$PROGRESS" ]]; then
-  # No snapshot at all — /wrap has never been run in this project
-  touch "$WRAP_NEEDED"
-  echo "[$(date +%H:%M:%S)] STOP: .wrap-needed written (no CONTEXT_SNAPSHOT.md)" \
-    >> "$SESSION_LOG"
-fi
-
-# ── Write .wrap-needed if 2+ commits landed this session ──────────────────────
-# Even if stubs are expanded, 2+ commits means enough context has accumulated
-# to warrant capturing it. The session log records one "PROGRESS stub:" entry
-# per commit (written by post-tool.sh). If the flag is already set from above,
-# skip — no need to write it twice.
-if [[ ! -f "$WRAP_NEEDED" ]]; then
-  SESSION_COMMIT_COUNT=$(grep -c "PROGRESS stub:" "$SESSION_LOG" 2>/dev/null || echo 0)
-  if [[ "$SESSION_COMMIT_COUNT" -ge 2 ]]; then
-    touch "$WRAP_NEEDED"
-    echo "[$(date +%H:%M:%S)] STOP: .wrap-needed written (${SESSION_COMMIT_COUNT} commits this session — wrap recommended)" \
-      >> "$SESSION_LOG"
-  fi
-fi
-
-# ── Write minimal checkpoint to CONTEXT_SNAPSHOT when .wrap-needed is set ────
-# If /wrap hasn't run and the session had meaningful commits, write a minimal
-# orientation block to CONTEXT_SNAPSHOT.md so the next session isn't flying blind.
-# This is not a full /wrap — it just records branch, last commit, and active task.
-# /wrap overwrites this with a complete snapshot; this is a safety net only.
-if [[ -f "$WRAP_NEEDED" ]]; then
-  _BRANCH=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-  _COMMIT=$(git -C "$REPO" log -1 --format="%h %s" 2>/dev/null || echo "none")
-  _ACTIVE_TASK=""
-  _ACTIVE_DIR="$RIG_DIR/tasks/active"
-  if [[ -d "$_ACTIVE_DIR" ]]; then
-    _ACTIVE_TASK=$(ls "$_ACTIVE_DIR"/*.md 2>/dev/null | head -1 | xargs basename 2>/dev/null || true)
-  fi
-
-  {
-    echo "# Context Snapshot — auto-checkpoint"
-    echo ""
-    echo "> This is a minimal checkpoint written by stop.sh — not a full /wrap snapshot."
-    echo "> Run \`/wrap\` to replace this with a complete context snapshot."
-    echo ""
-    echo "**Last updated:** $NOW_FULL — auto-checkpoint (stop.sh)"
-    echo "**Branch:** $_BRANCH"
-    echo "**Last commit:** $_COMMIT"
-    if [[ -n "$_ACTIVE_TASK" ]]; then
-      echo "**Active task:** $_ACTIVE_TASK"
-    fi
-    echo ""
-    echo "---"
-    echo ""
-    echo "## Status"
-    echo ""
-    echo "Session ended without running \`/wrap\`. Run \`/wrap\` at the start of the"
-    echo "next session to capture full context before starting new work."
-  } > "$SNAPSHOT"
-
-  echo "[$(date +%H:%M:%S)] STOP: minimal checkpoint written to CONTEXT_SNAPSHOT.md" \
-    >> "$SESSION_LOG"
 fi
 
 exit 0

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -62,6 +62,16 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash [REPO_ROOT]/.claude/hooks/session-end.sh"
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "hooks": [

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -513,6 +513,64 @@ assert 'additionalContext' in d['hookSpecificOutput']
   rm -rf "$tmpdir"
 }
 
+@test "syntax: session-end.sh has valid bash syntax" {
+  run bash -n "$REPO_ROOT/templates/project/.claude/hooks/session-end.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "syntax: code-reviewer agent has valid markdown header" {
+  run grep -q "^name: code-reviewer" "$REPO_ROOT/templates/project/.claude/agents/code-reviewer.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "feature-docs: doc-feature.md excluded from default install" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/commands/doc-feature.md" ]
+  rm -rf "$tmpdir"
+}
+
+@test "feature-docs: doc-feature.md included with --feature-docs flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo --feature-docs 2>/dev/null
+  [ -f "$tmpdir/.claude/commands/doc-feature.md" ]
+  rm -rf "$tmpdir"
+}
+
+@test "feature-docs: upgrade preserves existing doc-feature.md without flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  # Fresh install with feature-docs
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo --feature-docs 2>/dev/null
+  [ -f "$tmpdir/.claude/commands/doc-feature.md" ] || skip "initial install failed"
+  # Upgrade without --feature-docs — should preserve
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy upgrade \
+    --tracking repo 2>/dev/null
+  [ -f "$tmpdir/.claude/commands/doc-feature.md" ]
+  rm -rf "$tmpdir"
+}
+
+@test "feature-docs: upgrade on project without feature-docs does not add them" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/commands/doc-feature.md" ] || skip "initial install unexpectedly included feature-docs"
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy upgrade \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/commands/doc-feature.md" ]
+  rm -rf "$tmpdir"
+}
+
 @test "syntax: pre-commit hook has valid bash syntax" {
   run bash -n "$REPO_ROOT/templates/project/.husky/pre-commit"
   [ "$status" -eq 0 ]

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -954,14 +954,16 @@ _is_rig_protected() {
   [ "$installed" = "$expected" ]
 }
 
-# ── Gap 4: stop.sh writes .wrap-needed on 2+ commits ─────────────────────────
+# ── Gap 4: session-end.sh writes .wrap-needed on 2+ commits ──────────────────
+# Note: this logic moved from stop.sh to session-end.sh in Sprint 5.
+# stop.sh now only updates CONTEXT_SNAPSHOT date and appends session-end markers.
 
-@test "stop.sh: writes .wrap-needed when session log has 2+ commits" {
+@test "session-end.sh: writes .wrap-needed when session log has 2+ commits" {
   run_installer --strategy skip
   [ "$status" -eq 0 ]
 
   local rig_dir="$TEST_PROJECT/.rig"
-  local stop_hook="$TEST_PROJECT/.claude/hooks/stop.sh"
+  local session_end_hook="$TEST_PROJECT/.claude/hooks/session-end.sh"
   local session_log="$TEMP_DIR/test-session.log"
   local wrap_needed="$rig_dir/memory/.wrap-needed"
 
@@ -977,18 +979,19 @@ _is_rig_protected() {
 
   rm -f "$wrap_needed"
 
-  # Run stop.sh from inside the test project so git rev-parse resolves correctly
-  ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$stop_hook" )
+  # Run session-end.sh with source=logout; cd into project so git rev-parse resolves correctly
+  echo '{"source": "logout"}' \
+    | ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$session_end_hook" )
 
   [ -f "$wrap_needed" ]
 }
 
-@test "stop.sh: does not write .wrap-needed when session has fewer than 2 commits" {
+@test "session-end.sh: does not write .wrap-needed when session has fewer than 2 commits" {
   run_installer --strategy skip
   [ "$status" -eq 0 ]
 
   local rig_dir="$TEST_PROJECT/.rig"
-  local stop_hook="$TEST_PROJECT/.claude/hooks/stop.sh"
+  local session_end_hook="$TEST_PROJECT/.claude/hooks/session-end.sh"
   local session_log="$TEMP_DIR/test-session.log"
   local wrap_needed="$rig_dir/memory/.wrap-needed"
 
@@ -1000,7 +1003,8 @@ _is_rig_protected() {
 
   rm -f "$wrap_needed"
 
-  ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$stop_hook" )
+  echo '{"source": "logout"}' \
+    | ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$session_end_hook" )
 
   [ ! -f "$wrap_needed" ]
 }


### PR DESCRIPTION
## Summary

- **#240** — `session-end.sh`: fires on true session termination (`logout`/`prompt_input_exit`/`clear`); writes `.wrap-needed` and minimal checkpoint on exit; `stop.sh` slimmed to per-turn work only (datetime update + session-end marker)
- **#228** — `agents/code-reviewer.md`: focused review agent with blocking/advisory output format; `/ship` gains optional Step 4.5 (code-reviewer offer) and Step 4.8 (docs/memory freshness gate)
- **#250** — feature-doc commands (`/doc-feature`, `/doc-list`, `/feature-context`, `/refresh-feature-doc`, `docs/features/README.md`) are now opt-in via `--feature-docs` flag; upgrade auto-detects existing installs and preserves them; DOCS_DIR fix applied to 3 command files (repo-mode now resolves `$REPO/docs/features`, not `$RIG_DIR/docs/features`); `.claude/agents/*` added to `is_rig_owned()` and `should_install_file()`; closes #231
- **#230** — `/ship` Step 4.8: checks PROGRESS.md stubs (blocking), feature doc overlap (advisory), INDEX.md freshness (advisory)

## Test plan

- [x] `bats tests/` — 145/145 passing (7 new tests)
- [x] `bash -n` syntax on session-end.sh and stop.sh
- [x] `bash -n install.sh` syntax clean
- [ ] Manual: `./install.sh --project-only` — verify doc commands absent
- [ ] Manual: `./install.sh --project-only --feature-docs` — verify doc commands present
- [ ] Manual: upgrade on project with existing doc commands — verify preserved
- [ ] Manual: close a session and verify session-end.sh writes .wrap-needed correctly

Closes #240, #228, #250, #230, #231