### PR TITLE
docs(release-prep): sync README, how-it-works, and CHANGELOG with Sprints 1-6 [#256]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **`session-start.sh` hook** (`templates/project/.claude/hooks/session-start.sh`, `SessionStart`): injects `CONTEXT_SNAPSHOT.md` content and any pending housekeeping flag warnings (`.wrap-needed`, `.post-merge-pending`) into the conversation as `additionalContext` at the very start of each session — before the first user turn. Eliminates the need for the agent to manually read these files. Closes #238.
+- **`prompt-submit.sh` hook** (`templates/project/.claude/hooks/prompt-submit.sh`, `UserPromptSubmit`): re-checks `.wrap-needed` and `.post-merge-pending` flags on every user prompt and re-injects warnings when they are present. Ensures warnings persist across multi-turn sessions. Closes #241.
+- **`permission-request.sh` hook** (`templates/project/.claude/hooks/permission-request.sh`, `PermissionRequest`): auto-approves safe, read-only tool patterns (Read, Bash read-only commands, non-destructive Grep/Find) so they never prompt. Reduces permission-prompt noise for routine operations. Closes #239.
+- **`pre-compact.sh` hook** (`templates/project/.claude/hooks/pre-compact.sh`, `PreCompact`): writes a `.compact-checkpoint.md` file before context compaction, capturing current branch, last commit, active task, and session progress markers. Outputs a `compactionSummary` JSON field so Claude receives orientation context immediately after compaction. Closes #232.
+- **`post-compact.sh` hook** (`templates/project/.claude/hooks/post-compact.sh`, `PostCompact`): reads `.compact-checkpoint.md` back and injects its content as `additionalContext` after compaction completes, restoring the working context that would otherwise be lost. Closes #232.
+- **`session-end.sh` hook** (`templates/project/.claude/hooks/session-end.sh`, `SessionEnd`): handles true session termination (distinct from `Stop`, which fires after every agent turn). Dispatches by source signal: on logout/clear, writes `.wrap-needed` and a minimal auto-checkpoint; on resume, clears the `.wrap-needed` flag. Owns the wrap-needed logic that was previously in `stop.sh`. Closes #240.
+- **`subagent-start.sh` hook** (`templates/project/.claude/hooks/subagent-start.sh`, `SubagentStart`): injects project name, current branch, active task slug, and key conventions into spawned subagents so they share the same working context as the parent session. Closes #244.
+- **`/ship` Step 4.5 — code-reviewer offer** (`templates/project/.claude/commands/ship.md`): after the checklist gate, `/ship` optionally invokes the `code-reviewer` agent for a lightweight pre-commit correctness scan. Accepts yes/no/skip; non-blocking. Closes #228, #230.
+- **`/ship` Step 4.8 — docs/memory freshness gate** (`templates/project/.claude/commands/ship.md`): before commit, checks whether any feature docs or memory files that overlap with the PR's touched files are stale. Surfaces stale docs and waits for user decision (update now / skip). Closes #230.
+- **`--feature-docs` installer flag** (`install.sh`): gates `/doc-feature`, `/doc-list`, `/feature-context`, `/refresh-feature-doc`, and `docs/features/` installation behind an explicit opt-in flag. Default installs are leaner; projects that want feature-knowledge tooling pass `--feature-docs` to include it. Closes #250.
+- **`code-reviewer.md` agent template** (`templates/project/.claude/agents/code-reviewer.md`): reusable sub-agent for lightweight pre-commit code review. Invoked optionally by `/ship` Step 4.5; can also be triggered directly. Checks for correctness issues, logic errors, and missed edge cases in staged changes. Closes #228.
+
 ### Changed — BREAKING
 - **Default install tracking mode changed to stealth** (`install.sh`): the interactive
   prompt now defaults to option 4 (stealth) instead of option 1 (in-repo). All Rig
@@ -16,6 +29,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to the project repo. Users who prefer in-repo tracking must choose option 1 explicitly
   or pass `--tracking repo`. This affects all fresh installs where no `--tracking` flag
   is provided. Closes #233.
+
+### Changed
+- **`stop.sh` simplified** (`templates/project/.claude/hooks/stop.sh`): stripped to date-update + session-end marker only. The `.wrap-needed` sentinel logic moved to `session-end.sh`, which fires on true termination events rather than after every agent turn. The `Stop` hook still fires after every response — it now only updates the `Last updated:` timestamp and appends a `<!-- session-end -->` boundary marker to `PROGRESS.md`. Closes #240.
+- **`housekeeping: direct-push` type guard** (`templates/project/.claude/hooks/pre-tool.sh`): `direct-push` now blocks commit types that indicate code changes (`feat`, `fix`, `refactor`, `test`, `perf`, `devops`, `style`) even when `direct-push` is set. Only `chore` and `docs` commit types can go directly to the base branch. `feat`, `fix`, and all other code-change types must go through a PR regardless of the housekeeping setting. Closes #221.
+- **Worktree redirect in `pre-tool.sh`** (`templates/project/.claude/hooks/pre-tool.sh`): `PreToolUse` now intercepts `Write`, `Edit`, and `NotebookEdit` calls targeting `.claude/worktrees/` paths and transparently redirects them to the main-repo equivalent path via `updatedToolInput`. Hard rule #12 (never edit inside a worktree) is now mechanically enforced rather than relying on the agent. Closes #242.
+- **`/pre-release-review` scope clarified** (`templates/project/.claude/commands/pre-release-review.md`, `rig-help.md`): opening paragraph now explicitly states the command is for projects with a formal release cycle (versioned libraries, shipped products, public APIs). Not needed for scripts, CLIs, or internal tools. Marked `(release-cycle projects)` in `/rig-help`. Closes #246.
+- **`/kickoff` marked as one-shot** (`templates/project/.claude/commands/kickoff.md`, `rig-help.md`): header now states "Run once, at project creation." End-of-flow (Step 5) includes a suggestion to delete `.claude/commands/kickoff.md` after use. Marked `(new projects only)` in `/rig-help`. Closes #247.
+- **`/rig-gaps` scoped to Rig contributors** (`templates/project/.claude/commands/rig-gaps.md`, `rig-help.md`): header now states the command is for users who contribute to or develop The Rig. Submit-step framing simplified: "Review logged gaps and decide which to act on. If you're contributing to The Rig, bring these to a Rig dev session." Marked `(Rig contributors)` in `/rig-help`. Closes #249.
+- **`## Personal context` section inlined into global `CLAUDE.md`** (`templates/global/CLAUDE.md`): personal context prompts (name, role, expertise, preferences, goals) now live directly in `CLAUDE.md` as a `## Personal context` section. Closes #248.
+- **`DOCS_DIR` resolution standard for stealth/external projects** (`templates/project/.claude/commands/`): stealth projects (`.rigpath` exists) resolve `DOCS_DIR` to `$RIG_DIR/docs`; in-repo projects use `$REPO/docs`. Applied consistently across `/doc-feature`, `/refresh-feature-doc`, `/feature-context`. Closes #250.
+
+### Removed
+- **`/new-feature` command** (`templates/project/.claude/commands/`): deprecated redirect to `/task`. Removed from template install. Closes #245.
+- **`/rig-install` command** (`templates/project/.claude/commands/`): guided install wizard. Removed from template install — `/rig-upgrade` covers all upgrade scenarios; new installs use `install.sh` directly. Closes #245.
+- **`PROFILE.md.example`** (`templates/global/`): personal context file removed from the global template. Content is now inlined in `templates/global/CLAUDE.md` as `## Personal context`. Closes #248.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The Rig has two layers that load in sequence at every session start:
 │  GLOBAL LAYER  (~/.claude/)                                     │
 │  Installed once. Applies to every project on the machine.       │
 │                                                                 │
-│  CLAUDE.md          ← identity, hard rules, working style       │
+│  CLAUDE.md          ← identity, hard rules, working style,      │
+│                       personal context (fill in once)           │
 │  skills/            ← reusable skill scripts (5 included)       │
-│  ~/.your-ai-contexts/PROFILE.md  ← personal/professional context│
 └────────────────────────────┬────────────────────────────────────┘
                              │ loaded first at every session
                              ▼
@@ -58,8 +58,7 @@ The Rig has two layers that load in sequence at every session start:
 
 | Component | Location | What it does |
 |---|---|---|
-| Global identity | `templates/global/CLAUDE.md` | Hard rules, working style, memory discipline — loads at every session |
-| Personal profile | `templates/global/PROFILE.md.example` | Your professional context — the agent reads it so you never re-explain yourself |
+| Global identity | `templates/global/CLAUDE.md` | Hard rules, working style, memory discipline, and a `## Personal context` section to fill in once — loads at every session |
 | Skills (5) | `templates/global/skills/` | Reusable prompt scripts for debug, review, refactor, tests, explain |
 | Project brain | `templates/project/CLAUDE.md` | Project-specific identity, stack, conventions, off-limits paths |
 | Processes (5) | `templates/project/.rig/processes/` | Step-by-step workflows: new-task, ship, debug, post-merge, upgrade |
@@ -89,8 +88,8 @@ git clone git@github.com:laudtetteh/the-rig.git ~/tools/the-rig
 cd ~/tools/the-rig
 ./install.sh --global-only
 
-# Fill in your personal profile
-$EDITOR ~/.your-ai-contexts/PROFILE.md
+# Fill in your personal context (name, role, expertise, working style)
+$EDITOR ~/.claude/CLAUDE.md   # look for the ## Personal context section
 ```
 
 This installs the global layer (`~/.claude/CLAUDE.md` + skills) once. Every project
@@ -160,8 +159,8 @@ git clone https://github.com/laudtetteh/the-rig.git ~/tools/the-rig
 cd ~/tools/the-rig
 ./install.sh --global-only
 
-# 3. Fill in your personal profile (machine-local — not committed)
-$EDITOR ~/.your-ai-contexts/PROFILE.md
+# 3. Fill in your personal context (machine-local — ## Personal context section)
+$EDITOR ~/.claude/CLAUDE.md
 
 # 4. Clone your project
 git clone <your-project-url> ~/code/my-project
@@ -188,19 +187,19 @@ See `docs/troubleshooting.md` for common issues after a re-clone.
 
 ## How it works at session start
 
-When you open Claude Code in a project using The Rig, the agent automatically reads (in order):
+When you open Claude Code in a project using The Rig, hooks fire automatically:
 
-1. `~/.claude/CLAUDE.md` — who it is and how to behave
-2. `~/.your-ai-contexts/PROFILE.md` — who you are
-3. `./CLAUDE.md` — what this project is
-4. `./.rig/memory/CONTEXT_SNAPSHOT.md` — full current state (written at session end by `/wrap`); **if present, this is sufficient — the agent stops here**
-5. `./.rig/memory/PROGRESS.md` — build history; only loaded if snapshot is absent or stale
+1. **`session-start.sh`** injects `CONTEXT_SNAPSHOT.md` and any pending flag warnings as hook context — before the first user turn
+2. The agent reads `~/.claude/CLAUDE.md` — who it is, how to behave, and your personal context
+3. The agent reads `./CLAUDE.md` — what this project is
+4. The agent reads `./.rig/memory/CONTEXT_SNAPSHOT.md` — **if present, this is sufficient; the agent stops here**
+5. `./.rig/memory/PROGRESS.md` — only loaded if snapshot is absent or stale
 6. `./.rig/memory/ERRORS.md` — what to avoid
 7. `./.rig/tasks/active/` — what's currently in flight
 
-No re-briefing. No repeating context. Every session picks up exactly where the last one left off.
+On every user prompt, `prompt-submit.sh` re-checks for pending flag warnings and re-injects them if still present. No re-briefing. No repeating context. Every session picks up exactly where the last one left off.
 
-**At session end**, `stop.sh` fires automatically (Claude Code's Stop event): it updates the `Last updated:` timestamp in `CONTEXT_SNAPSHOT.md` and appends a `<!-- session-end -->` boundary marker to `PROGRESS.md`. Run `/wrap` before closing Claude Code for a full snapshot — `stop.sh` is a lightweight safety net, not a replacement.
+**At session end**, `session-end.sh` fires (Claude Code's `SessionEnd` event) and writes `.wrap-needed` + a minimal auto-checkpoint. The `stop.sh` hook fires after every agent turn (the `Stop` event) to keep `CONTEXT_SNAPSHOT.md`'s timestamp current. Run `/wrap` before closing Claude Code for a full snapshot — the hooks are a safety net, not a replacement.
 
 ---
 
@@ -208,8 +207,7 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 **Start a project**
 ```
-/rig-install  →  guided install wizard: asks scope/path/tracking, shows the exact install command, verifies result
-/kickoff      →  reads PROJECT_BRIEF.md, scaffolds CLAUDE.md + task backlog + GitHub issues
+/kickoff      →  reads PROJECT_BRIEF.md, scaffolds CLAUDE.md + task backlog + GitHub issues (run once at project creation)
 ```
 
 **Daily work**
@@ -267,13 +265,27 @@ No re-briefing. No repeating context. Every session picks up exactly where the l
 
 ## What the hooks enforce
 
+### Claude Code hooks
+
+| Hook | Event | What it does |
+|---|---|---|
+| `session-start.sh` | `SessionStart` | Injects `CONTEXT_SNAPSHOT.md` and pending flag warnings before the first user turn |
+| `prompt-submit.sh` | `UserPromptSubmit` | Re-checks `.wrap-needed`/`.post-merge-pending` on every prompt; re-injects warnings when present |
+| `permission-request.sh` | `PermissionRequest` | Auto-approves safe read-only tool patterns to reduce permission-prompt noise |
+| `pre-tool.sh` | `PreToolUse` (every tool call) | Blocks writes to protected paths; gates `git commit` on user go-ahead sentinel; blocks direct commits to `main`/`master` unless `housekeeping: direct-push`; redirects worktree writes to main-repo path |
+| `post-tool.sh` | `PostToolUse` (every tool call) | Auto-stubs `PROGRESS.md` after every commit; clears commit sentinel |
+| `pre-compact.sh` | `PreCompact` | Writes compact checkpoint + `compactionSummary` before context compaction |
+| `post-compact.sh` | `PostCompact` | Injects checkpoint content as `additionalContext` after compaction |
+| `subagent-start.sh` | `SubagentStart` | Injects project name, branch, active task, and key conventions into spawned subagents |
+| `session-end.sh` | `SessionEnd` | Handles true session termination: writes `.wrap-needed` + minimal auto-checkpoint on logout/clear; clears flag on resume |
+| `stop.sh` | `Stop` (every agent turn) | Updates `Last updated:` in `CONTEXT_SNAPSHOT.md`; appends session-end boundary to `PROGRESS.md` |
+
+### Git hooks
+
 | Hook | Trigger | What it prevents |
 |---|---|---|
-| `pre-tool.sh` | Before every Claude Code tool call | Writes to protected paths; blocks `git commit` until user gives explicit go-ahead; blocks commits directly to `main`/`master` unless `housekeeping: direct-push` is set |
-| `post-tool.sh` | After every Claude Code tool call | PROGRESS.md being skipped after a commit; clears commit sentinel after use |
-| `stop.sh` | When the agent finishes its final response | CONTEXT_SNAPSHOT going stale — updates `Last updated:` and appends a session-end boundary to PROGRESS.md without requiring `/wrap` |
 | `pre-commit` | Before every git commit | Secrets reaching the repository |
-| `commit-msg` | On every git commit | (1) Strips auto-injected tool footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.) from commit messages; (2) validates Conventional Commits subject-line format; (3) requires a tracker-specific issue reference (`[#N]` for GitHub, `[TEAM-123]` for Linear, etc.) when `issue-tracking:` is set in `CLAUDE.md` |
+| `commit-msg` | On every git commit | (1) Strips auto-injected tool footers (`Co-Authored-By: Claude`, `Made-with-Claude`, etc.); (2) validates Conventional Commits subject-line format; (3) requires a tracker-specific issue reference (`[#N]` for GitHub, `[TEAM-123]` for Linear, etc.) when `issue-tracking:` is set in `CLAUDE.md` |
 | `post-commit` | After every git commit | Re-applies footer stripping in case the git client re-injected footers after `commit-msg` ran |
 
 ---

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -57,19 +57,16 @@ Three locations work together. The installer repo produces the other two:
 │       memory discipline, │  │  .rig/rules/     ← standards      │
 │       planning, git,     │  │  .rig/memory/    ← PROGRESS +     │
 │       code quality,      │  │                    ERRORS +        │
-│       skill trigger table│  │                    SNAPSHOT        │
-│                          │  │  .rig/tasks/     ← backlog/active/│
-│  ~/.claude/skills/       │  │                    done            │
-│    ├─ debug.md           │  │  .claude/        ← hooks +        │
-│    ├─ code-review.md     │  │                    commands        │
-│    ├─ refactor.md        │  │  .husky/         ← git hooks      │
-│    ├─ write-tests.md     │  │  .github/        ← PR + issue     │
-│    └─ explain.md         │  │                    templates       │
-│                          │  └───────────────────────────────────┘
-│  ~/.your-ai-contexts/    │
-│    PROFILE.md            │
-│    └─ Personal context   │
-│       (path configurable)│
+│       personal context,  │  │                    SNAPSHOT        │
+│       skill trigger table│  │  .rig/tasks/     ← backlog/active/│
+│                          │  │                    done            │
+│  ~/.claude/skills/       │  │  .claude/        ← hooks (10) +   │
+│    ├─ debug.md           │  │                    commands        │
+│    ├─ code-review.md     │  │  .husky/         ← git hooks      │
+│    ├─ refactor.md        │  │  .github/        ← PR + issue     │
+│    ├─ write-tests.md     │  │                    templates       │
+│    └─ explain.md         │  └───────────────────────────────────┘
+│                          │
 └──────────────────────────┘
 ```
 
@@ -86,12 +83,14 @@ only runs when you install or upgrade.
 Session starts
      │
      ▼
-Claude Code auto-loads ~/.claude/CLAUDE.md
-     │  Hard rules, working style, memory discipline
+session-start.sh fires (SessionStart hook)
+     │  Reads CONTEXT_SNAPSHOT.md + checks .wrap-needed / .post-merge-pending
+     │  Injects snapshot content and any warnings as additionalContext
+     │  (before the first user turn — no manual file read required)
      │
      ▼
-CLAUDE.md instructs: read PROFILE.md
-     │  Personal/professional context
+Claude Code auto-loads ~/.claude/CLAUDE.md
+     │  Hard rules, working style, memory discipline, personal context
      │
      ▼
 CLAUDE.md instructs: read ./CLAUDE.md
@@ -99,12 +98,13 @@ CLAUDE.md instructs: read ./CLAUDE.md
      │
      ▼
 CLAUDE.md instructs: check .rig/memory/CONTEXT_SNAPSHOT.md
-     │  If it exists → sufficient for orientation. Load it and stop.
+     │  Already injected by hook above — agent confirms or loads from disk if absent
+     │  If it exists → sufficient for orientation. Stop here.
      │  If absent or stale → load .rig/memory/PROGRESS.md (last 20 entries only)
      │
      ▼
 CLAUDE.md instructs: read ./.rig/memory/ERRORS.md
-     │  Known pitfalls to avoid
+     │  Known pitfalls to avoid (only if snapshot absent/stale)
      │
      ▼
 CLAUDE.md instructs: skim ./.rig/memory/DECISIONS.md
@@ -117,10 +117,36 @@ CLAUDE.md instructs: read ./.rig/tasks/active/
      ▼
 Agent is oriented. Hooks are live. Ready to work.
      │
-     │  During the session (repeats every turn):
-     │  ├─ pre-tool.sh  runs before every tool call
-     │  ├─ post-tool.sh runs after every tool call
-     │  └─ stop.sh      runs after the agent's final message each turn
+     │  On every user prompt:
+     │  └─ prompt-submit.sh (UserPromptSubmit)
+     │       Re-checks .wrap-needed / .post-merge-pending; re-injects warnings
+     │
+     │  On every permission request:
+     │  └─ permission-request.sh (PermissionRequest)
+     │       Auto-approves safe read-only patterns
+     │
+     │  Before every tool call:
+     │  └─ pre-tool.sh (PreToolUse)
+     │       Protected-path check, commit gate, main-branch guard, worktree redirect
+     │
+     │  After every tool call:
+     │  └─ post-tool.sh (PostToolUse)
+     │       PROGRESS.md auto-stub on commit; sentinel cleanup
+     │
+     │  Before context compaction:
+     │  └─ pre-compact.sh (PreCompact)
+     │       Writes .compact-checkpoint.md; outputs compactionSummary JSON
+     │
+     │  After context compaction:
+     │  └─ post-compact.sh (PostCompact)
+     │       Injects checkpoint as additionalContext; restores working context
+     │
+     │  When a subagent spawns:
+     │  └─ subagent-start.sh (SubagentStart)
+     │       Injects project name, branch, active task, key conventions
+     │
+     │  After the agent's final message each turn:
+     │  └─ stop.sh (Stop)
      │       Updates "Last updated:" date in CONTEXT_SNAPSHOT.md
      │       Appends <!-- session-end YYYY-MM-DD HH:MM --> to PROGRESS.md
      │       (lightweight; idempotent — safe to run after every response)
@@ -133,6 +159,14 @@ Agent is oriented. Hooks are live. Ready to work.
      │  Trims ERRORS.md if > 30 entries
      │  Suggests session name (derives name from session-end markers)
      └─ Surfaces next priority
+     │
+     ▼
+Session ends
+     │
+     └─ session-end.sh (SessionEnd)
+          On logout/clear: writes .wrap-needed + minimal auto-checkpoint
+          On resume: clears .wrap-needed flag
+          (session-end.sh owns the wrap-needed lifecycle; stop.sh is lightweight only)
 ```
 
 ---
@@ -241,16 +275,42 @@ Step 8: Surface next priority — ask "What's next?"
 
 ### Claude Code hooks (`.claude/`)
 
-Wired via `.claude/settings.json`. Run on every tool call (`"matcher": ".*"`).
+Wired via `.claude/settings.json`. Ten hooks covering the full session lifecycle.
 
 ```
+Session starts
+     │
+     └─► session-start.sh (SessionStart)
+           Resolves RIG_DIR (.rigpath if present, else $REPO/.rig)
+           Reads CONTEXT_SNAPSHOT.md — injects as additionalContext
+           Checks .wrap-needed — injects warning if present
+           Checks .post-merge-pending — injects warning if present
+           (fires before the first user turn — no manual file read required)
+
+User submits a prompt
+     │
+     └─► prompt-submit.sh (UserPromptSubmit)
+           Re-checks .wrap-needed / .post-merge-pending on every prompt
+           Re-injects warnings when flags are present
+           (ensures flags surface even mid-session without repeating session-start)
+
+Agent requests a permission
+     │
+     └─► permission-request.sh (PermissionRequest)
+           Auto-approves safe read-only patterns:
+             Read, Bash (ls/cat/grep/find/git log/git diff/etc.), WebFetch, WebSearch
+           Returns {"behavior": "allow"} for matched patterns — no prompt shown
+           Falls through (no response) for write/destructive operations
+
 Every tool call
      │
      ├─► pre-tool.sh (PreToolUse)
      │     Resolves RIG_DIR (.rigpath if present, else $REPO/.rig)
      │     Logs call to /tmp/the-rig-session.log
+     │     Worktree redirect: Write/Edit/NotebookEdit targeting .claude/worktrees/
+     │       → rewrites path to main-repo equivalent via updatedToolInput
      │     Checks RIG_PROTECTED: blocks writes to governance files
-     │     (RIG_DIR/processes/, RIG_DIR/rules/, .husky/, CLAUDE.md, .claude/hooks/)
+     │       (RIG_DIR/processes/, RIG_DIR/rules/, .husky/, CLAUDE.md, .claude/hooks/)
      │     Checks BLOCKED_PATHS: blocks project-specific protected paths
      │     Gates git commit on $RIG_DIR/memory/.rig-commit-ok sentinel:
      │       Blocked → agent shows commit message, asks for trigger phrase
@@ -258,7 +318,8 @@ Every tool call
      │       Agent creates sentinel → commit succeeds → post-tool.sh deletes it
      │     Guards git commit on main/master:
      │       Blocked unless CLAUDE.md sets housekeeping: direct-push
-     │       Prevents accidental direct commits to protected branches
+     │       Even with direct-push: blocks feat/fix/refactor/test/perf/devops/style types
+     │       Only chore/docs may go directly to main
      │     Exit 1 (block) if any check fails
      │
      └─► post-tool.sh (PostToolUse)
@@ -271,7 +332,29 @@ Every tool call
                Append dated stub to RIG_DIR/memory/PROGRESS.md (idempotent)
                Delete $RIG_DIR/memory/.rig-commit-ok sentinel (one-shot auth)
 
-Agent finishes response
+Before context compaction
+     │
+     └─► pre-compact.sh (PreCompact)
+           Resolves RIG_DIR
+           Writes .compact-checkpoint.md: branch, last commit, active task, progress markers
+           Outputs compactionSummary JSON field for Claude to receive immediately after compact
+           (prevents disorientation when the context window is replaced)
+
+After context compaction
+     │
+     └─► post-compact.sh (PostCompact)
+           Reads .compact-checkpoint.md
+           Injects its content as additionalContext
+           (restores working context that would otherwise require manual re-orientation)
+
+When a subagent spawns
+     │
+     └─► subagent-start.sh (SubagentStart)
+           Resolves RIG_DIR
+           Injects: project name, current branch, active task slug, key conventions
+           (subagents share the same working context as the parent session)
+
+Agent finishes response each turn
      │
      └─► stop.sh (Stop event)
            Resolves RIG_DIR (.rigpath if present, else $REPO/.rig)
@@ -280,10 +363,17 @@ Agent finishes response
            If PROGRESS.md exists:
              Append <!-- session-end YYYY-MM-DD HH:MM --> boundary marker
              (idempotent: skips if last non-blank line is already a marker)
-           If .wrap-needed flag exists (session ended without /wrap):
-             Write a minimal auto-checkpoint to CONTEXT_SNAPSHOT.md
-             (current branch + last commit; prevents the next session from loading
-             the full PROGRESS.md history when a snapshot is absent or stale)
+           (lightweight; .wrap-needed logic moved to session-end.sh)
+
+Session ends (logout / clear / quit)
+     │
+     └─► session-end.sh (SessionEnd)
+           Resolves RIG_DIR
+           On logout/clear: writes .wrap-needed sentinel
+                            writes a minimal auto-checkpoint to CONTEXT_SNAPSHOT.md
+                            (current branch + last commit; prevents cold-start next session)
+           On resume:       clears .wrap-needed flag
+           (session-end.sh owns the wrap-needed lifecycle; stop.sh is for per-turn cleanup only)
 ```
 
 **Critical implementation note:** Tool names in Claude Code are `PascalCase`
@@ -421,13 +511,12 @@ proportion to the complexity of the work — not because of Rig overhead.
 
 ## The command set
 
-Twenty-two slash commands covering the full development lifecycle:
+Twenty slash commands covering the full development lifecycle:
 
 ### Project bootstrap
 | Command | Triggers | Key behaviour |
 |---|---|---|
-| `/rig-install` | Guided wizard | Asks three questions (scope, path, tracking mode), shows the exact install command, and verifies the result. For upgrades of existing installs, use `/rig-upgrade`. |
-| `/kickoff` | `NEW_TASK_WORKFLOW` | Reads `PROJECT_BRIEF.md`, confirms understanding, scaffolds `CLAUDE.md` + task backlog + GitHub issues in one pass |
+| `/kickoff` | `NEW_TASK_WORKFLOW` | Reads `PROJECT_BRIEF.md`, confirms understanding, scaffolds `CLAUDE.md` + task backlog + GitHub issues in one pass. Run once at project creation — the command file can be deleted after use. |
 
 ### Daily work
 | Command | Triggers | Key behaviour |
@@ -469,9 +558,8 @@ Twenty-two slash commands covering the full development lifecycle:
 | `/rig-propose` | Governance gate | Writes change proposal to `/tmp/`, shows before/after diff, waits for approval before touching any governance file |
 | `/session-name` | Session naming | Derives a session name from current PROGRESS entries and presents it as a suggestion — callable at any time, not just at wrap |
 | `/wrap` | Session-end sequence | Writes CONTEXT_SNAPSHOT, captures in-flight task state, updates PROGRESS, trims PROGRESS/ERRORS, suggests session name, surfaces next priority. Concurrent session guard prevents race conditions on PROGRESS.md. |
-| `/rig-gaps` | Self-improvement | Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats report for submission. `--push` appends directly to the local Rig repo (requires `rig-gaps-push-target:` in `CLAUDE.md`); `--submit` creates public GitHub issues in `laudtetteh/the-rig` (opt-in; requires `.rig-contribute-enabled` sentinel + `gh` auth) |
+| `/rig-gaps` | Self-improvement | _(Rig contributors)_ Compiles unsubmitted `RIG_GAPS.md` entries + cross-checks `ERRORS.md`; formats report for review and optional submission. `--push` appends directly to the local Rig repo (requires `rig-gaps-push-target:` in `CLAUDE.md`); `--submit` creates public GitHub issues in `laudtetteh/the-rig` (opt-in; requires `.rig-contribute-enabled` sentinel + `gh` auth) |
 | `/rig-upgrade` | Upgrade workflow | Pulls latest Rig source and re-runs `install.sh` with `--strategy upgrade`. `--version` prints the project version, global installer version, and the latest tagged release from GitHub (via `gh`), warning if any are out of sync. `--scope=project\|global\|both` limits which layers are upgraded. |
-| `/new-feature` | *(deprecated)* | Redirects to `/task`. Kept for backward compatibility only. |
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only update to bring README, `docs/how-it-works.md`, and `CHANGELOG.md [Unreleased]` in sync with everything that landed in Sprints 1-6 (PRs #251-#255) since v1.17.0.

- **CHANGELOG**: Added all Sprint 1-6 entries under `[Unreleased]` -- 7 new hooks, `/ship` gate steps, `--feature-docs` flag, `code-reviewer` agent, `housekeeping` type guard, worktree redirect, command scoping clarifications, and the stealth-default breaking change.
- **README**: Removed `PROFILE.md.example` references (replaced by `## Personal context` section inline in `CLAUDE.md`); removed `/rig-install` (deleted in #245); updated session-start description to reflect hooks; expanded hooks table from 3 rows to 10 Claude Code hooks + 3 git hooks.
- **docs/how-it-works.md**: Removed `PROFILE.md` from global layer diagram and session lifecycle; removed `/rig-install` and `/new-feature` from command table; updated command count 22 to 20; expanded hook system section from 3 hooks to full 10-hook coverage with annotated diagrams.

No installer changes -- `install.sh` uses `find` over the templates directory, so new hooks are picked up automatically.

## Test plan

- [x] 141/141 bats tests passing
- [x] `bash -n install.sh` -- syntax clean
- [x] No stale `PROFILE.md`, `your-ai-contexts`, `/rig-install`, or `/new-feature` references remain in README or how-it-works.md
- [x] All 7 new hooks documented in both session lifecycle and hook system section
- [x] Command count (20) matches actual template file count (20)

Closes #256

Generated with [Claude Code](https://claude.com/claude-code)
