### PR TITLE
feat(upgrade): surface CHANGELOG breaking changes before applying an upgrade [#258]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -420,6 +420,47 @@ backup_file() {
   cp "$src" "$dest"
 }
 
+# ── BREAKING CHANGE CHECK ─────────────────────────────────────────────────────
+# Print any "### Changed — BREAKING" bullets from CHANGELOG sections that are
+# newer than $current_version, then prompt the user to confirm before continuing.
+# Silent (returns 0) when: version is unknown, changelog missing, or no breaking
+# changes exist in the upgrade range.
+_show_breaking_changes() {
+  local current_version="$1"
+  local changelog="$2"
+
+  [[ "$current_version" == "unknown" ]] && return 0
+  [[ -f "$changelog" ]] || return 0
+
+  local breaking_lines
+  breaking_lines=$(awk -v ver="$current_version" '
+    BEGIN { stop=0; in_breaking=0 }
+    /^## \[/ {
+      if (index($0, "[" ver "]") > 0) { stop=1 }
+      in_breaking=0
+    }
+    stop { next }
+    /^### .*BREAKING/ { in_breaking=1; next }
+    /^### / { in_breaking=0 }
+    in_breaking && /^- / { print }
+  ' "$changelog")
+
+  [[ -n "$breaking_lines" ]] || return 0
+
+  echo ""
+  warn "Breaking changes since v${current_version} — review before upgrading:"
+  echo ""
+  while IFS= read -r line; do
+    echo "  $line"
+  done <<< "$breaking_lines"
+  echo ""
+  if ! confirm "Continue upgrade with the above breaking changes?" "y"; then
+    info "Upgrade cancelled. No files were modified."
+    exit 0
+  fi
+  echo ""
+}
+
 # ── SMART MERGE: .claude/settings.json ───────────────────────────────────────
 # Merges The Rig's hooks into an existing settings.json without duplicating
 # any hook that already has the same command string.
@@ -1023,6 +1064,20 @@ if [[ "$DO_PROJECT" == true ]]; then
     MANIFEST_FILE="$EXTERNAL_RIG_DIR/memory/.rig-manifest"
   else
     MANIFEST_FILE="$TARGET/.rig/memory/.rig-manifest"
+  fi
+
+  # ── BREAKING CHANGE GATE (upgrade only) ───────────────────────────────────
+  # Read the project's installed Rig version and surface any breaking changes
+  # between it and the incoming installer version before touching any files.
+  # Tests can override _RIG_TEST_CHANGELOG to point to a controlled fixture.
+  if [[ "$COLLISION_STRATEGY" == "upgrade" ]]; then
+    if [[ "$RIG_TRACKING" == "external" || "$RIG_TRACKING" == "stealth" ]]; then
+      _installed_version=$(cat "$EXTERNAL_RIG_DIR/VERSION" 2>/dev/null || echo "unknown")
+    else
+      _installed_version=$(cat "$TARGET/.rig/VERSION" 2>/dev/null || echo "unknown")
+    fi
+    _changelog_path="${_RIG_TEST_CHANGELOG:-$SCRIPT_DIR/CHANGELOG.md}"
+    _show_breaking_changes "$_installed_version" "$_changelog_path"
   fi
 
   echo ""

--- a/templates/project/.claude/commands/rig-upgrade.md
+++ b/templates/project/.claude/commands/rig-upgrade.md
@@ -186,12 +186,43 @@ If `$INSTALLER_SRC` is NOT `$REPO`:
 
 ```bash
 git -C "$INSTALLER_SRC" pull origin main 2>&1
-cat "$INSTALLER_SRC/VERSION"  # confirm new version after pull
+INSTALLER_VERSION=$(cat "$INSTALLER_SRC/VERSION" 2>/dev/null || echo "unknown")
+echo "Installer now at: $INSTALLER_VERSION"
 ```
 
 If `$INSTALLER_SRC` IS `$REPO`: skip — dev repo is already on the correct state.
 
-### 1b — Detect tracking mode and key paths
+### 1b — Breaking-change gate
+
+Read `$INSTALLER_SRC/CHANGELOG.md` and extract all `### Changed — BREAKING` bullets
+from sections newer than `$CURRENT_VERSION` (i.e., above the `## [$CURRENT_VERSION]`
+header in the file). Sections are in descending order; stop collecting at
+`## [$CURRENT_VERSION]`.
+
+```bash
+CHANGELOG="$INSTALLER_SRC/CHANGELOG.md"
+```
+
+If `$CHANGELOG` does not exist or `$CURRENT_VERSION` is `"unknown"`: skip silently and
+continue to 1c.
+
+Otherwise, collect the breaking-change bullets. If **no breaking changes** exist in
+the range: say briefly —
+> "No breaking changes since v$CURRENT_VERSION. Proceeding."
+
+If **breaking changes exist**: display them in full, then say —
+> "⚠️ Breaking changes since v$CURRENT_VERSION:
+>
+> [list of bullets, verbatim from CHANGELOG]
+>
+> Review the above before proceeding. Type **go** to continue the upgrade, or
+> **cancel** to abort. No files will be modified until you confirm."
+
+Wait for the user's response. If they say **cancel** (or anything other than
+**go** / **yes** / **proceed** / **continue**): say "Upgrade cancelled. No files
+were modified." and stop. Do not proceed to 1c.
+
+### 1c — Detect tracking mode and key paths
 
 ```bash
 # Tracking mode
@@ -213,7 +244,7 @@ BASE_BRANCH=$(grep "^base-branch:" "$REPO/CLAUDE.md" 2>/dev/null | awk '{print $
 BASE_BRANCH="${BASE_BRANCH:-main}"
 ```
 
-### 1c — Survey changed files
+### 1d — Survey changed files
 
 For each key Rig-owned file, compare the installed version to the template.
 Where the template uses `[BASE_BRANCH]`, substitute `$BASE_BRANCH` before diffing.
@@ -277,7 +308,7 @@ _diff_tpl ".rig/VERSION" "$TEMPLATES/.rig/VERSION" "$RIG_DIR/VERSION"
 _diff_tpl ".gitleaks.toml" "$TEMPLATES/.gitleaks.toml" "$REPO/.gitleaks.toml"
 ```
 
-### 1d — Check for user-modified Rig-owned files
+### 1e — Check for user-modified Rig-owned files
 
 Read the manifest to find files where the installed hash differs from the manifest hash.
 These are files the user has edited since install — the installer will skip them.
@@ -297,7 +328,7 @@ if [[ -f "$MANIFEST" ]]; then
 fi
 ```
 
-### 1e — Present the plan and wait
+### 1f — Present the plan and wait
 
 Display a summary table before touching anything:
 
@@ -322,7 +353,7 @@ Then say:
 
 **Wait for confirmation before Phase 2.**
 
-### 1f — Initialise result accumulators
+### 1g — Initialise result accumulators
 
 Declare these arrays before Phase 2 begins. Every sub-phase appends to them;
 Phase 5 reads them to produce an accurate summary.

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1736,3 +1736,174 @@ print(m.group(1) + (m.group(2) if m.group(2) else '/'))
   result=$(_worktree_redirect_path "/repo/.claude/hooks/pre-tool.sh")
   [ -z "$result" ]
 }
+
+# ── Breaking change detection: _show_breaking_changes (#258) ─────────────────
+# Mirrors the awk logic in _show_breaking_changes() to unit-test detection
+# without running the full installer.
+
+_extract_breaking_changes() {
+  local current_version="$1"
+  local changelog="$2"
+
+  [[ "$current_version" == "unknown" ]] && return 1
+  [[ -f "$changelog" ]] || return 1
+
+  local breaking_lines
+  breaking_lines=$(awk -v ver="$current_version" '
+    BEGIN { stop=0; in_breaking=0 }
+    /^## \[/ {
+      if (index($0, "[" ver "]") > 0) { stop=1 }
+      in_breaking=0
+    }
+    stop { next }
+    /^### .*BREAKING/ { in_breaking=1; next }
+    /^### / { in_breaking=0 }
+    in_breaking && /^- / { print }
+  ' "$changelog")
+
+  [[ -n "$breaking_lines" ]] || return 1
+  echo "$breaking_lines"
+}
+
+_make_changelog() {
+  # Write a minimal CHANGELOG.md to $1 for testing.
+  cat > "$1" <<'CLEOF'
+# Changelog
+
+## [Unreleased]
+
+### Changed — BREAKING
+- Breaking thing in unreleased
+
+### Added
+- Non-breaking thing
+
+## [2.0.0] — 2026-01-01
+
+### Changed — BREAKING
+- Old breaking thing in 2.0.0
+
+### Added
+- Some feature in 2.0.0
+
+## [1.5.0] — 2025-06-01
+
+### Added
+- Some feature in 1.5.0
+CLEOF
+}
+
+@test "breaking change detection: surfaces bullets from [Unreleased] when installed is older" {
+  local changelog="$TEMP_DIR/CHANGELOG.md"
+  _make_changelog "$changelog"
+
+  run _extract_breaking_changes "1.5.0" "$changelog"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Breaking thing in unreleased"* ]]
+  [[ "$output" == *"Old breaking thing in 2.0.0"* ]]
+}
+
+@test "breaking change detection: surfaces only changes newer than installed version" {
+  local changelog="$TEMP_DIR/CHANGELOG.md"
+  _make_changelog "$changelog"
+
+  # Installed at 2.0.0: only [Unreleased] should be in range
+  run _extract_breaking_changes "2.0.0" "$changelog"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Breaking thing in unreleased"* ]]
+  [[ "$output" != *"Old breaking thing in 2.0.0"* ]]
+}
+
+@test "breaking change detection: silent when no breaking changes in range" {
+  local changelog="$TEMP_DIR/CHANGELOG.md"
+  # Changelog with no BREAKING section above 1.5.0
+  cat > "$changelog" <<'CLEOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Just an addition
+
+## [1.5.0] — 2025-06-01
+
+### Changed — BREAKING
+- Old breaking thing
+CLEOF
+
+  run _extract_breaking_changes "1.5.0" "$changelog"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "breaking change detection: silent when installed version is unknown" {
+  local changelog="$TEMP_DIR/CHANGELOG.md"
+  _make_changelog "$changelog"
+
+  run _extract_breaking_changes "unknown" "$changelog"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "breaking change detection: silent when CHANGELOG is missing" {
+  run _extract_breaking_changes "1.5.0" "$TEMP_DIR/no-such-file.md"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "breaking change detection: upgrade prints warning when breaking changes exist" {
+  # Use a controlled fixture changelog so this test doesn't depend on real CHANGELOG content.
+  local fixture="$TEMP_DIR/fixture-changelog.md"
+  cat > "$fixture" <<'CLEOF'
+# Changelog
+
+## [Unreleased]
+
+### Changed — BREAKING
+- Stealth is now the default tracking mode
+
+## [1.0.0] — 2025-01-01
+
+### Added
+- Initial release
+CLEOF
+
+  # First install to establish the project; set installed version below the range.
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+  echo "0.9.0" > "$TEST_PROJECT/.rig/VERSION"
+
+  # Upgrade: confirm() auto-accepts in non-interactive mode (default "y").
+  # _RIG_TEST_CHANGELOG points the gate at our fixture instead of the real CHANGELOG.
+  _RIG_TEST_CHANGELOG="$fixture" run_installer --strategy upgrade
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Breaking changes since v0.9.0"* ]]
+  [[ "$output" == *"Stealth is now the default tracking mode"* ]]
+}
+
+@test "breaking change detection: upgrade is silent when no breaking changes in range" {
+  # Fixture has breaking changes only in [1.0.0], not in [Unreleased].
+  local fixture="$TEMP_DIR/fixture-no-breaking.md"
+  cat > "$fixture" <<'CLEOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Some non-breaking addition
+
+## [1.0.0] — 2025-01-01
+
+### Changed — BREAKING
+- Old breaking change (already installed)
+CLEOF
+
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+  # Installed version is 1.0.0 — nothing above it has breaking changes in this fixture.
+  echo "1.0.0" > "$TEST_PROJECT/.rig/VERSION"
+
+  _RIG_TEST_CHANGELOG="$fixture" run_installer --strategy upgrade
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Breaking changes since"* ]]
+}


### PR DESCRIPTION
## Summary

Neither `install.sh --strategy upgrade` nor the agent-led `/rig-upgrade` command previously read `CHANGELOG.md` before copying files. A user upgrading from v1.17.0 would hit the stealth-default breaking change (#233) silently. This PR adds a breaking-change gate to both paths.

- **`install.sh`**: new `_show_breaking_changes(version, changelog)` function, called during `--strategy upgrade` after the installed `.rig/VERSION` is read, before any files are touched. Uses `awk` to extract `### Changed -- BREAKING` bullets from all CHANGELOG sections newer than the installed version. Silent when no breaking changes exist in range, or when the installed version is unknown. `confirm()` gates on a default-yes prompt (auto-accepts in CI/non-interactive). `_RIG_TEST_CHANGELOG` env var overrides the changelog path for test isolation (same pattern as `_RIG_DRIFT_DIR`).
- **`rig-upgrade.md`**: new **Phase 1b -- Breaking-change gate** added between the pull (1a) and tracking-mode detection (now 1c). After `git pull` brings the installer to latest, reads `$INSTALLER_SRC/CHANGELOG.md`, extracts breaking-change bullets between `$CURRENT_VERSION` and the (post-pull) `$INSTALLER_VERSION`, and requires explicit user confirmation before Phase 2 (file writes). Existing steps 1b-1f renumbered 1c-1g.

## Test plan

- [x] 7 new bats tests (141 -> 148 total passing)
  - 5 unit tests for the `awk` extraction logic using controlled fixtures
  - 2 integration tests using `_RIG_TEST_CHANGELOG` fixture injection: warning appears when breaking changes exist; silent when none
- [x] `bash -n install.sh` -- syntax clean
- [x] Full `bats tests/` suite: 148/148 passing

Closes #258

Generated with [Claude Code](https://claude.com/claude-code)
