### PR TITLE
fix(installer): auto-detect repo/local tracking mode during upgrade [#262]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -966,6 +966,23 @@ if [[ "$DO_PROJECT" == true ]]; then
   RIG_TRACKING="stealth"   # default: zero Rig traces in git
   RIGPATH_FILE=""       # absolute path to .rigpath (set if external or stealth mode)
 
+  # ── Upgrade: auto-detect existing tracking mode ───────────────────────────
+  # When upgrading without --tracking and no .rigpath, infer the prior mode
+  # from git state instead of defaulting to stealth via the interactive prompt.
+  # Prevents silently migrating repo/local installs to stealth on upgrade.
+  if [[ "$COLLISION_STRATEGY" == "upgrade" && -z "$_FLAG_TRACKING" \
+        && -z "$EXTERNAL_RIG_DIR" && ! -f "$TARGET/.rigpath" \
+        && -d "$TARGET/.rig" ]]; then
+    if [[ -n "$(git -C "$TARGET" ls-files -- ".rig/" 2>/dev/null)" ]]; then
+      _FLAG_TRACKING="repo"
+      info "Auto-detected existing tracking mode: repo (.rig/ is git-committed)"
+    elif grep -qF '.rig/' "$TARGET/.git/info/exclude" 2>/dev/null \
+         || grep -qF '.rig/' "$TARGET/.gitignore" 2>/dev/null; then
+      _FLAG_TRACKING="local"
+      info "Auto-detected existing tracking mode: local (.rig/ is git-excluded)"
+    fi
+  fi
+
   if [[ -n "$_FLAG_TRACKING" ]]; then
     # --tracking flag: validate and apply without prompting
     case "$_FLAG_TRACKING" in

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -964,6 +964,57 @@ _is_rig_protected() {
   grep -qF ".rig/" "$TEST_PROJECT/.git/info/exclude"
 }
 
+@test "upgrade auto-detects repo mode when .rig/ is git-committed" {
+  # Simulate a project previously installed in repo mode: .rig/ files committed.
+  run_installer --strategy skip --tracking repo
+  git -C "$TEST_PROJECT" add "$TEST_PROJECT/.rig/VERSION"
+  git -C "$TEST_PROJECT" commit -m "chore: initial rig install" --allow-empty-message 2>/dev/null || true
+
+  # Run upgrade directly (not via run_installer) so auto-detect fires.
+  run bash "$INSTALLER" --project-only \
+    --target "$TEST_PROJECT" \
+    --project-name "TestProject" \
+    --strategy upgrade
+  [ "$status" -eq 0 ]
+  # Must stay in repo mode: no .rigpath, .rig/VERSION still in project dir
+  [ ! -f "$TEST_PROJECT/.rigpath" ]
+  [ -f "$TEST_PROJECT/.rig/VERSION" ]
+  [[ "$output" == *"Auto-detected existing tracking mode: repo"* ]]
+}
+
+@test "upgrade auto-detects local mode when .rig/ is in .git/info/exclude" {
+  # Simulate a project previously installed in local mode.
+  run_installer --strategy skip --tracking local
+  # Confirm .rig/ is in .git/info/exclude (installed by --tracking local)
+  grep -qF ".rig/" "$TEST_PROJECT/.git/info/exclude"
+
+  # Run upgrade directly so auto-detect fires.
+  run bash "$INSTALLER" --project-only \
+    --target "$TEST_PROJECT" \
+    --project-name "TestProject" \
+    --strategy upgrade
+  [ "$status" -eq 0 ]
+  # Must stay in local mode: no .rigpath, .rig/ still in project dir
+  [ ! -f "$TEST_PROJECT/.rigpath" ]
+  [ -f "$TEST_PROJECT/.rig/VERSION" ]
+  [[ "$output" == *"Auto-detected existing tracking mode: local"* ]]
+}
+
+@test "upgrade auto-detects local mode when .rig/ is in .gitignore" {
+  # Simulate a project where .rig/ was manually added to .gitignore (not via installer).
+  run_installer --strategy skip --tracking repo
+  echo ".rig/" >> "$TEST_PROJECT/.gitignore"
+
+  # .rig/ files are NOT in the git index (run_installer --tracking repo commits nothing).
+  run bash "$INSTALLER" --project-only \
+    --target "$TEST_PROJECT" \
+    --project-name "TestProject" \
+    --strategy upgrade
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_PROJECT/.rigpath" ]
+  [[ "$output" == *"Auto-detected existing tracking mode: local"* ]]
+}
+
 @test "fresh install: .rig/VERSION matches installer VERSION" {
   run_installer --strategy skip
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- `--strategy upgrade` without `--tracking` now auto-detects the existing tracking mode from git state instead of falling through to the interactive prompt (which defaults to stealth since v1.18.0)
- Guard conditions: upgrade strategy + no explicit `--tracking` + no `.rigpath` + `.rig/` dir exists
- Detection order: git-committed `.rig/` → repo; `.rig/` in `.git/info/exclude` or `.gitignore` → local
- Fresh installs, stealth installs, and explicit `--tracking` flags are all unaffected

## What broke

During the v1.18.0 machine-wide upgrade, `4Culture` (repo), `okaishie` (repo), and `laudbot` (local) were silently migrated to stealth mode because no `--tracking` flag was passed and the interactive prompt now defaults to stealth. Required manual revert and re-run.

## Test plan

- [x] 3 new bats tests: repo auto-detect, local via `.git/info/exclude`, local via `.gitignore`
- [x] Existing stealth auto-detect test (`upgrade without --tracking auto-detects stealth mode from .rigpath`) still passes
- [x] `bash -n install.sh` — syntax clean
- [x] Full `bats tests/` suite: 151/151 passing

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
