### PR TITLE
fix+feat: session boundary hardening + installer opt-in flags [#266-270]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,6 +172,8 @@ _FLAG_BASE_BRANCH=""  # set via --base-branch <n>   (skips interactive prompt)
 _FLAG_TRACKING=""     # set via --tracking <mode>   (skips tracking prompt; orthogonal to --target)
 SKIP_GIT_HOOKS=false       # set via --skip-git-hooks    (stealth: skip .git/hooks/ writes)
 INSTALL_FEATURE_DOCS=false # set via --feature-docs      (gates doc-feature/feature-context/etc.)
+INSTALL_SUBAGENTS=false    # set via --subagents          (gates subagent-start.sh + SubagentStart hook)
+INSTALL_CONTRIBUTE=false   # set via --contribute         (gates rig-gaps.md + rig-propose.md)
 
 for arg in "$@"; do
   case "$arg" in
@@ -179,6 +181,8 @@ for arg in "$@"; do
     --project-only)     DO_GLOBAL=false ;;
     --skip-git-hooks)   SKIP_GIT_HOOKS=true ;;
     --feature-docs)     INSTALL_FEATURE_DOCS=true ;;
+    --subagents)        INSTALL_SUBAGENTS=true ;;
+    --contribute)       INSTALL_CONTRIBUTE=true ;;
     --rig-dir|--strategy|--target|--project-name|--base-branch|--tracking)
       # two-arg flags; value captured in the loop below
       ;;
@@ -228,6 +232,13 @@ for arg in "$@"; do
       echo "                        /refresh-feature-doc, and docs/features/README.md."
       echo "                        Skipped by default — add for projects that maintain"
       echo "                        end-to-end feature traces."
+      echo "  --subagents           Install multi-agent hook (opt-in)."
+      echo "                        Installs subagent-start.sh and wires the SubagentStart"
+      echo "                        event in settings.json. Skipped by default — add for"
+      echo "                        projects that use Claude Code multi-agent workflows."
+      echo "  --contribute          Install Rig contributor commands (opt-in)."
+      echo "                        Installs /rig-gaps and /rig-propose. Useful for"
+      echo "                        developers who maintain The Rig or a fork."
       echo "  --skip-git-hooks      Stealth mode only: skip writing hooks to .git/hooks/."
       echo "                        Use when the project already manages git hooks via Husky"
       echo "                        or another tool and you want to avoid the conflict."
@@ -1175,6 +1186,9 @@ if [[ "$DO_PROJECT" == true ]]; then
       .claude/commands/feature-context.md|\
       .claude/commands/refresh-feature-doc.md|\
       docs/features/*)                     [[ "$INSTALL_FEATURE_DOCS" == true ]]   ;;
+      .claude/hooks/subagent-start.sh)     [[ "$INSTALL_SUBAGENTS" == true ]]      ;;
+      .claude/commands/rig-gaps.md|\
+      .claude/commands/rig-propose.md)     [[ "$INSTALL_CONTRIBUTE" == true ]]     ;;
       .claude/commands/*|\
       .claude/agents/*)                    [[ "$INSTALL_COMMANDS" == true ]]       ;;
       .husky/*|.gitleaks.toml)             [[ "$INSTALL_GIT_HOOKS" == true ]]      ;;
@@ -1193,6 +1207,23 @@ if [[ "$DO_PROJECT" == true ]]; then
       "$TARGET/.claude/commands/refresh-feature-doc.md"; do
       if [[ -f "$_fd_check" ]]; then
         INSTALL_FEATURE_DOCS=true
+        break
+      fi
+    done
+  fi
+
+  # ── UPGRADE AUTO-DETECT: enable subagents if already installed ─────────────
+  if [[ "$INSTALL_SUBAGENTS" != true && -f "$TARGET/.claude/hooks/subagent-start.sh" ]]; then
+    INSTALL_SUBAGENTS=true
+  fi
+
+  # ── UPGRADE AUTO-DETECT: enable contribute if already installed ─────────────
+  if [[ "$INSTALL_CONTRIBUTE" != true ]]; then
+    for _cc_check in \
+      "$TARGET/.claude/commands/rig-gaps.md" \
+      "$TARGET/.claude/commands/rig-propose.md"; do
+      if [[ -f "$_cc_check" ]]; then
+        INSTALL_CONTRIBUTE=true
         break
       fi
     done
@@ -1246,6 +1277,29 @@ if [[ "$DO_PROJECT" == true ]]; then
   if [[ -f "$TARGET_CLAUDE" ]]; then
     sed_inplace "s/\\[Project Name\\]/${PROJECT_NAME}/g" "$TARGET_CLAUDE"
     success "Substituted [Project Name] in CLAUDE.md"
+  fi
+
+  # ── INJECT SubagentStart hook when --subagents is active ─────────────────
+  # The settings.json template omits SubagentStart by default (it's opt-in).
+  # When INSTALL_SUBAGENTS=true (via --subagents or auto-detect), inject the
+  # SubagentStart entry with [REPO_ROOT] placeholder; it is substituted below.
+  if [[ "$INSTALL_SUBAGENTS" == true && -f "$TARGET/.claude/settings.json" ]]; then
+    if command -v python3 >/dev/null 2>&1; then
+      python3 - "$TARGET/.claude/settings.json" <<'PYEOF' 2>/dev/null || true
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    s = json.load(f)
+hooks = s.setdefault('hooks', {})
+if 'SubagentStart' not in hooks:
+    hooks['SubagentStart'] = [{'hooks': [{'type': 'command',
+        'command': 'bash [REPO_ROOT]/.claude/hooks/subagent-start.sh'}]}]
+    with open(path, 'w') as f:
+        json.dump(s, f, indent=2)
+        f.write('\n')
+PYEOF
+      success "Wired SubagentStart hook in .claude/settings.json"
+    fi
   fi
 
   # Substitute [REPO_ROOT] in settings.json with the absolute project path.

--- a/install.sh
+++ b/install.sh
@@ -1180,13 +1180,13 @@ if [[ "$DO_PROJECT" == true ]]; then
       .rig/tasks/*)                        [[ "$INSTALL_TASKS" == true ]]          ;;
       .rig/processes/*)                    [[ "$INSTALL_PROCESSES" == true ]]      ;;
       .rig/rules/*)                        [[ "$INSTALL_RULES" == true ]]          ;;
+      .claude/hooks/subagent-start.sh)     [[ "$INSTALL_SUBAGENTS" == true ]]      ;;
       .claude/hooks/*|.claude/settings*)   [[ "$INSTALL_CLAUDE_HOOKS" == true ]]   ;;
       .claude/commands/doc-feature.md|\
       .claude/commands/doc-list.md|\
       .claude/commands/feature-context.md|\
       .claude/commands/refresh-feature-doc.md|\
       docs/features/*)                     [[ "$INSTALL_FEATURE_DOCS" == true ]]   ;;
-      .claude/hooks/subagent-start.sh)     [[ "$INSTALL_SUBAGENTS" == true ]]      ;;
       .claude/commands/rig-gaps.md|\
       .claude/commands/rig-propose.md)     [[ "$INSTALL_CONTRIBUTE" == true ]]     ;;
       .claude/commands/*|\

--- a/templates/project/.claude/commands/rig-help.md
+++ b/templates/project/.claude/commands/rig-help.md
@@ -63,9 +63,23 @@ No arguments. Output the table below directly — do not read individual command
 | Command | What it does | Key flags |
 |---|---|---|
 | `/rig-upgrade` | Upgrade The Rig to the latest version. | `--version` (print versions only, no upgrade), `--scope=project\|global\|both` |
-| `/rig-propose` | Propose a change to Rig governance files (hooks, processes, rules, CLAUDE.md). Writes a diff for human review — never applies it directly. | — |
-| `/rig-gaps` | _(Rig contributors)_ Log and submit workflow friction observed during a task. | `--push` (append to local Rig repo), `--submit` (create GitHub issue) |
+| `/rig-propose` | _(opt-in: `--contribute`)_ Propose a change to Rig governance files (hooks, processes, rules, CLAUDE.md). Writes a diff for human review — never applies it directly. | — |
+| `/rig-gaps` | _(opt-in: `--contribute`)_ Log and submit workflow friction observed during a task. | `--push` (append to local Rig repo), `--submit` (create GitHub issue) |
 | `/rig-help` | This command. | — |
+
+---
+
+## Installer opt-in flags
+
+Some features are not installed by default. Pass these flags to `install.sh` (or `/rig-upgrade`) to enable them:
+
+| Flag | What it installs |
+|---|---|
+| `--feature-docs` | `/doc-feature`, `/doc-list`, `/feature-context`, `/refresh-feature-doc`, and `docs/features/` — for projects that maintain end-to-end feature traces |
+| `--subagents` | `subagent-start.sh` hook + `SubagentStart` event wiring in `settings.json` — for projects using multi-agent Claude Code workflows |
+| `--contribute` | `/rig-gaps` and `/rig-propose` — for developers who maintain The Rig or a fork |
+
+These flags are preserved across upgrades: once a feature is installed, it is auto-detected and retained on future upgrade runs without re-passing the flag.
 
 ---
 

--- a/templates/project/.claude/commands/rig-upgrade.md
+++ b/templates/project/.claude/commands/rig-upgrade.md
@@ -173,6 +173,51 @@ INSTALLER_VERSION=$(cat "$INSTALLER_SRC/VERSION" 2>/dev/null || echo "unknown")
 Report what version will be installed:
 > "Upgrading: **$CURRENT_VERSION → $INSTALLER_VERSION**"
 
+### 0e — CLAUDE.md path sanity check
+
+Detect whether `CLAUDE.md` contains paths that belong to a different tracking mode.
+This can happen when an upgrade was run with the wrong tracking flag, writing stealth
+absolute paths into a repo-tracked project's `CLAUDE.md`.
+
+```bash
+CLAUDE_MD="$REPO/CLAUDE.md"
+if [[ -f "$CLAUDE_MD" ]]; then
+  # Check for stealth-style absolute paths (e.g. /Users/name/.rig/projects/)
+  STEALTH_PATHS=$(grep -E '/\.rig/projects/' "$CLAUDE_MD" 2>/dev/null || true)
+
+  if [[ -n "$STEALTH_PATHS" && "$TRACKING" == "repo" ]]; then
+    echo "⚠️  Path mismatch in CLAUDE.md:"
+    echo "   CLAUDE.md contains absolute stealth paths but this is a repo-tracked install."
+    echo "   These paths point to a directory that likely does not exist:"
+    echo "$STEALTH_PATHS" | head -5
+    echo ""
+    echo "   This causes the agent to fail silently when Bash is unavailable."
+    echo "   Options:"
+    echo "   [f] Fix — rewrite context-loading and @import paths to use relative .rig/ paths"
+    echo "   [s] Skip — leave CLAUDE.md unchanged (mismatch persists)"
+  fi
+fi
+```
+
+If user chooses **[f]**: make the following substitutions in `$CLAUDE_MD`:
+
+1. Replace the numbered context-loading list (lines starting with `1.`, `2.`, etc. that
+   reference an absolute `.rig/projects/*/memory/` path) with relative equivalents:
+   - `/Users/*/memory/CONTEXT_SNAPSHOT.md` → `.rig/memory/CONTEXT_SNAPSHOT.md`
+   - `/Users/*/memory/PROGRESS.md` → `.rig/memory/PROGRESS.md`
+   - `/Users/*/memory/ERRORS.md` → `.rig/memory/ERRORS.md`
+   - `/Users/*/memory/DECISIONS.md` → `.rig/memory/DECISIONS.md`
+   - `/Users/*/tasks/active/` → `.rig/tasks/active/`
+2. Replace `@/Users/*/rules/*.md` imports with `@.rig/rules/*.md`
+3. Replace the "External .rig/ note" block with the hook-enforced context note from the
+   current template.
+
+Then confirm: "CLAUDE.md paths corrected to relative `.rig/` references."
+
+If user chooses **[s]**: note the skip and continue.
+
+If CLAUDE.md does not exist, or tracking is not `repo`, or no stealth paths found: skip silently.
+
 ---
 
 ## Phase 1 — Pull + Survey (read-only)
@@ -267,24 +312,29 @@ _diff_tpl() {
 
 Survey these files (adjust paths based on `$TRACKING`):
 
-**Claude hooks** (always at `$REPO/.claude/hooks/`):
+**Claude hooks** — iterate the template directory so new hooks are never missed:
 ```bash
-for f in pre-tool.sh post-tool.sh stop.sh; do
-  _diff_tpl ".claude/hooks/$f" "$TEMPLATES/.claude/hooks/$f" "$REPO/.claude/hooks/$f"
+echo "=== Surveying Claude hooks ==="
+for tpl in "$TEMPLATES/.claude/hooks/"*.sh; do
+  [[ -f "$tpl" ]] || continue
+  f=$(basename "$tpl")
+  _diff_tpl ".claude/hooks/$f" "$tpl" "$REPO/.claude/hooks/$f"
 done
 ```
 
-**Claude commands** (always at `$REPO/.claude/commands/`):
+**Claude commands** — iterate the template directory:
 ```bash
-for f in debug.md doc-feature.md kickoff.md new-feature.md post-merge.md propose.md \
-          recon.md refresh-feature-doc.md rig-gaps.md run.md session-name.md ship.md \
-          task.md upgrade.md wrap.md; do
-  _diff_tpl ".claude/commands/$f" "$TEMPLATES/.claude/commands/$f" "$REPO/.claude/commands/$f"
+echo "=== Surveying Claude commands ==="
+for tpl in "$TEMPLATES/.claude/commands/"*.md; do
+  [[ -f "$tpl" ]] || continue
+  f=$(basename "$tpl")
+  _diff_tpl ".claude/commands/$f" "$tpl" "$REPO/.claude/commands/$f"
 done
 ```
 
 **Git hooks** (location depends on tracking mode):
 ```bash
+echo "=== Surveying git hooks (${TRACKING} mode) ==="
 for f in pre-commit commit-msg post-commit post-merge filter-commit-message-inplace.sh; do
   if [[ "$TRACKING" == "stealth" ]]; then
     _diff_tpl ".husky/$f" "$TEMPLATES/.husky/$f" "$REPO/.git/hooks/$f"
@@ -296,9 +346,11 @@ done
 
 **Process files** (location: `$RIG_DIR/processes/`):
 ```bash
-for f in SHIP_WORKFLOW.md NEW_TASK_WORKFLOW.md POST_MERGE_WORKFLOW.md \
-          DEBUG_WORKFLOW.md UPGRADE_WORKFLOW.md; do
-  _diff_tpl ".rig/processes/$f" "$TEMPLATES/.rig/processes/$f" "$RIG_DIR/processes/$f"
+echo "=== Surveying process files ==="
+for tpl in "$TEMPLATES/.rig/processes/"*.md; do
+  [[ -f "$tpl" ]] || continue
+  f=$(basename "$tpl")
+  _diff_tpl ".rig/processes/$f" "$tpl" "$RIG_DIR/processes/$f"
 done
 ```
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -373,13 +373,18 @@ rm -f "$RIG_DIR/memory/.wrap-needed" 2>/dev/null || true
 
 # Release the concurrent session lock
 rm -f "$RIG_DIR/memory/.wrap-in-progress" 2>/dev/null || true
+
+# Clear any stale compact checkpoint — the full snapshot supersedes it
+rm -f "$RIG_DIR/memory/.compact-checkpoint.md" 2>/dev/null || true
 ```
 
-Log: "`.wrap-needed` cleared. Concurrent session lock released."
+Log: "`.wrap-needed` cleared. Concurrent session lock released. Compact checkpoint cleared."
 
 `.wrap-needed` signals to `stop.sh` that `/wrap` has run and no flag should be
 written until the next commit creates new unexpanded stubs.
 `.wrap-in-progress` signals to concurrent sessions that this wrap is complete.
+`.compact-checkpoint.md` is cleared so the next session reads the authoritative
+`CONTEXT_SNAPSHOT.md` rather than a stale post-compaction checkpoint.
 
 ---
 

--- a/templates/project/.claude/hooks/pre-compact.sh
+++ b/templates/project/.claude/hooks/pre-compact.sh
@@ -45,6 +45,18 @@ if [[ -f "$PROGRESS_FILE" ]]; then
   LAST_PROGRESS=$(grep -m1 "^## " "$PROGRESS_FILE" 2>/dev/null | sed 's/^## //' || echo "none")
 fi
 
+SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
+SESSION_NAME="none"
+CONTEXT_HEADER=""
+if [[ -f "$SNAPSHOT" ]]; then
+  SESSION_NAME=$(grep -m1 "^\*\*Session name:\*\*" "$SNAPSHOT" 2>/dev/null \
+    | sed 's/\*\*Session name:\*\* *//' || echo "none")
+  # Extract the header section (everything before the first --- divider) for
+  # post-compaction orientation; agent can read project state without needing
+  # the full snapshot file.
+  CONTEXT_HEADER=$(awk '/^---/{exit} {print}' "$SNAPSHOT" 2>/dev/null || true)
+fi
+
 # ── Write checkpoint ───────────────────────────────────────────────────────────
 
 cat > "$CHECKPOINT" <<CPEOF
@@ -54,12 +66,17 @@ cat > "$CHECKPOINT" <<CPEOF
 **Last commit:** ${LAST_COMMIT}
 **Active task:** ${ACTIVE_TASK}
 **Last progress entry:** ${LAST_PROGRESS}
+**Session name:** ${SESSION_NAME}
+
+---
+
+${CONTEXT_HEADER}
 CPEOF
 
 # ── Output compactionSummary ───────────────────────────────────────────────────
 
 if command -v python3 >/dev/null 2>&1; then
-  SUMMARY="Branch: ${BRANCH} | Last commit: ${LAST_COMMIT} | Active task: ${ACTIVE_TASK} | Last progress: ${LAST_PROGRESS}"
+  SUMMARY="Branch: ${BRANCH} | Last commit: ${LAST_COMMIT} | Active task: ${ACTIVE_TASK} | Last progress: ${LAST_PROGRESS} | Session: ${SESSION_NAME}"
   printf '%s' "$SUMMARY" | python3 -c "
 import json, sys
 summary = sys.stdin.read()

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -62,16 +62,6 @@
         ]
       }
     ],
-    "SubagentStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash [REPO_ROOT]/.claude/hooks/subagent-start.sh"
-          }
-        ]
-      }
-    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -590,6 +590,119 @@ assert 'additionalContext' in d['hookSpecificOutput']
   rm -rf "$tmpdir"
 }
 
+@test "subagents: subagent-start.sh excluded from default install" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/hooks/subagent-start.sh" ]
+  rm -rf "$tmpdir"
+}
+
+@test "subagents: subagent-start.sh included with --subagents flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo --subagents 2>/dev/null
+  [ -f "$tmpdir/.claude/hooks/subagent-start.sh" ]
+  rm -rf "$tmpdir"
+}
+
+@test "subagents: SubagentStart wired in settings.json with --subagents flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo --subagents 2>/dev/null
+  grep -q '"SubagentStart"' "$tmpdir/.claude/settings.json"
+  rm -rf "$tmpdir"
+}
+
+@test "subagents: SubagentStart absent from settings.json without flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo 2>/dev/null
+  ! grep -q '"SubagentStart"' "$tmpdir/.claude/settings.json"
+  rm -rf "$tmpdir"
+}
+
+@test "subagents: upgrade preserves existing subagent-start.sh without flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo --subagents 2>/dev/null
+  [ -f "$tmpdir/.claude/hooks/subagent-start.sh" ] || skip "initial install failed"
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy upgrade \
+    --tracking repo 2>/dev/null
+  [ -f "$tmpdir/.claude/hooks/subagent-start.sh" ]
+  rm -rf "$tmpdir"
+}
+
+@test "subagents: upgrade on project without subagents does not add hook" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/hooks/subagent-start.sh" ] || skip "initial install unexpectedly included subagent-start"
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy upgrade \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/hooks/subagent-start.sh" ]
+  rm -rf "$tmpdir"
+}
+
+@test "contribute: rig-gaps.md excluded from default install" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/commands/rig-gaps.md" ]
+  rm -rf "$tmpdir"
+}
+
+@test "contribute: rig-gaps.md and rig-propose.md included with --contribute flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo --contribute 2>/dev/null
+  [ -f "$tmpdir/.claude/commands/rig-gaps.md" ]
+  [ -f "$tmpdir/.claude/commands/rig-propose.md" ]
+  rm -rf "$tmpdir"
+}
+
+@test "contribute: upgrade preserves existing rig-gaps.md without flag" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo --contribute 2>/dev/null
+  [ -f "$tmpdir/.claude/commands/rig-gaps.md" ] || skip "initial install failed"
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy upgrade \
+    --tracking repo 2>/dev/null
+  [ -f "$tmpdir/.claude/commands/rig-gaps.md" ]
+  rm -rf "$tmpdir"
+}
+
+@test "contribute: upgrade on project without contribute does not add rig-gaps" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy merge \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/commands/rig-gaps.md" ] || skip "initial install unexpectedly included contribute commands"
+  bash "$REPO_ROOT/install.sh" --project-only --target "$tmpdir" --strategy upgrade \
+    --tracking repo 2>/dev/null
+  [ ! -f "$tmpdir/.claude/commands/rig-gaps.md" ]
+  rm -rf "$tmpdir"
+}
+
 @test "syntax: pre-commit hook has valid bash syntax" {
   run bash -n "$REPO_ROOT/templates/project/.husky/pre-commit"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #266, #267, #268, #269, #270.

Three commits across two areas:

**Session boundary + upgrade command hardening (#266–269)**
- `pre-compact.sh`: compact checkpoint now includes session name and CONTEXT_SNAPSHOT header — session naming no longer lost after compaction
- `wrap.md`: flag cleanup step deletes `.compact-checkpoint.md` so the next session reads the fresh snapshot rather than a stale checkpoint
- `rig-upgrade.md` Phase 1d: survey now iterates template directories dynamically — new hooks/commands auto-detected as MISSING without manual list updates
- `rig-upgrade.md` Phase 0e: new sanity check detects when CLAUDE.md contains absolute stealth paths for a repo-tracked install, warns, and offers to fix

**Installer opt-in flags (#270)**
- `--subagents`: installs `subagent-start.sh` + wires `SubagentStart` in `settings.json`. Off by default.
- `--contribute`: installs `rig-gaps.md` + `rig-propose.md`. Off by default.
- Both flags are auto-detected on upgrade (files exist → flag enabled → files preserved)
- `settings.json` template removes `SubagentStart` (injected only when --subagents active)
- `rig-help.md` documents all three opt-in flags in a new table

## Test plan

- [x] 161 bats tests passing (151 baseline + 10 new for --subagents and --contribute)
- [x] `bash -n install.sh` clean
- [x] `bash -n templates/project/.claude/hooks/pre-compact.sh` clean
- [ ] Run `/rig-upgrade` on a project with a compact checkpoint to verify session name preserved
- [ ] Run fresh install without flags and confirm subagent-start.sh absent from .claude/hooks
- [ ] Run fresh install with --subagents and confirm SubagentStart in settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)