### PR TITLE
fix(session-naming): harden name preservation across all session boundaries [#272] [#273]

### DIFF
--- a/templates/project/.claude/commands/session-name.md
+++ b/templates/project/.claude/commands/session-name.md
@@ -130,7 +130,11 @@ Do **not** run anything automatically. Present it for the user to confirm, copy,
 ### 5 — After confirmation
 
 When the user confirms the name (or runs `/session-name` with a name argument),
-update the `**Session name:**` field in `.rig/memory/CONTEXT_SNAPSHOT.md` to match.
+write the name into `.rig/memory/CONTEXT_SNAPSHOT.md`:
+
+- **If `**Session name:**` field already exists:** update it in-place.
+- **If absent:** insert it as the second line of the file (after `**Last updated:**`),
+  or append it to the header block before the first `---` divider.
 
 ---
 

--- a/templates/project/.claude/hooks/pre-compact.sh
+++ b/templates/project/.claude/hooks/pre-compact.sh
@@ -53,8 +53,9 @@ if [[ -f "$SNAPSHOT" ]]; then
     | sed 's/\*\*Session name:\*\* *//' || echo "none")
   # Extract the header section (everything before the first --- divider) for
   # post-compaction orientation; agent can read project state without needing
-  # the full snapshot file.
-  CONTEXT_HEADER=$(awk '/^---/{exit} {print}' "$SNAPSHOT" 2>/dev/null || true)
+  # the full snapshot file. Capped at 25 lines to guard against malformed
+  # files with no --- divider producing an oversized checkpoint.
+  CONTEXT_HEADER=$(awk '/^---/{exit} {print}' "$SNAPSHOT" 2>/dev/null | head -25 || true)
 fi
 
 # ── Write checkpoint ───────────────────────────────────────────────────────────

--- a/templates/project/.claude/hooks/session-end.sh
+++ b/templates/project/.claude/hooks/session-end.sh
@@ -57,13 +57,18 @@ write_wrap_needed() {
 
 write_minimal_checkpoint() {
   [[ ! -d "$RIG_DIR/memory" ]] && return
-  local branch commit active_task
+  local branch commit active_task session_name=""
   branch=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   commit=$(git -C "$REPO" log -1 --format="%h %s" 2>/dev/null || echo "none")
   active_task=""
   if [[ -d "$RIG_DIR/tasks/active" ]]; then
     active_task=$(ls "$RIG_DIR/tasks/active"/*.md 2>/dev/null \
       | head -1 | xargs basename 2>/dev/null || true)
+  fi
+  # Preserve the session name from the existing snapshot before overwriting it.
+  if [[ -f "$SNAPSHOT" ]]; then
+    session_name=$(grep -m1 "^\*\*Session name:\*\*" "$SNAPSHOT" 2>/dev/null \
+      | sed 's/\*\*Session name:\*\* *//' || true)
   fi
 
   {
@@ -76,6 +81,7 @@ write_minimal_checkpoint() {
     echo "**Branch:** $branch"
     echo "**Last commit:** $commit"
     [[ -n "$active_task" ]] && echo "**Active task:** $active_task"
+    [[ -n "$session_name" ]] && echo "**Session name:** $session_name"
     echo ""
     echo "---"
     echo ""

--- a/templates/project/.claude/hooks/stop.sh
+++ b/templates/project/.claude/hooks/stop.sh
@@ -39,14 +39,18 @@ NOW_FULL=$(date "+%Y-%m-%d %H:%M")
 # This keeps the freshness signal accurate for the next session without
 # requiring /wrap to have run in this session.
 if [[ -f "$SNAPSHOT" ]] && grep -q "^\*\*Last updated:\*\*" "$SNAPSHOT" 2>/dev/null; then
-  # Extract the description (everything after "YYYY-MM-DD[ HH:MM] — ")
-  # Regex handles both old date-only and new datetime formats for backward compat.
+  # Extract the description (everything after "YYYY-MM-DD[ HH:MM] — ").
+  # Handles both old date-only and new datetime formats for backward compat.
   DESCRIPTION=$(grep "^\*\*Last updated:\*\*" "$SNAPSHOT" \
     | sed 's/\*\*Last updated:\*\*[^—]*— //')
 
+  # Use awk instead of sed so that | characters in session names (e.g.
+  # "fix auth #91 | feat dashboard #92") do not corrupt the replacement.
   TMP=$(mktemp)
-  sed "s|^\*\*Last updated:\*\*.*|\*\*Last updated:\*\* $NOW_FULL — $DESCRIPTION|" \
-    "$SNAPSHOT" > "$TMP" && mv "$TMP" "$SNAPSHOT"
+  awk -v now="$NOW_FULL" -v desc="$DESCRIPTION" -v em="—" '
+    /^\*\*Last updated:\*\*/ { print "**Last updated:** " now " " em " " desc; next }
+    { print }
+  ' "$SNAPSHOT" > "$TMP" && mv "$TMP" "$SNAPSHOT"
 
   echo "[$(date +%H:%M:%S)] STOP: updated Last updated: → $NOW_FULL in CONTEXT_SNAPSHOT" \
     >> "$SESSION_LOG"


### PR DESCRIPTION
## Summary

Closes #272, #273. Found during a second audit pass of the full session boundary stack.

**Four fixes in one commit:**

**Bug: `stop.sh` pipe-in-session-name data corruption (#272)**
The `Last updated:` rewrite used `sed` with `|` as delimiter. Session names contain `|` (Tier 1 format: `fix auth #91 | feat dashboard #92`). Any session with a multi-PR name silently mangled the `Last updated:` line on every agent turn. Switched to `awk -v em="—"` which treats `|` as a literal character.

**Bug: `session-end.sh` minimal checkpoint destroys session name (#273)**
`write_minimal_checkpoint` completely overwrites `CONTEXT_SNAPSHOT.md` with a template that has no `**Session name:**` field. Any name set via `/session-name`, `/wrap`, or `/post-merge` was permanently gone if the session ended without running `/wrap`. Now extracts the existing name before overwriting and re-includes it.

**Safety: `pre-compact.sh` CONTEXT_HEADER line cap**
`awk '/^---/{exit}'` on a malformed snapshot with no `---` divider reads the entire file into the compact checkpoint. Added `| head -25` to cap it.

**Docs: `session-name.md` Step 5 ambiguity**
Step 5 said "update the Session name field" but didn't say what to do if the field is absent. Now explicitly says "update if present, add if absent."

## Test plan

- [x] 161 bats tests passing
- [x] `bash -n` clean on all three hooks
- [x] Manual: awk handles `|` in session name correctly (tested inline)
- [ ] End a session with a named session without running /wrap — verify next session start shows the name
- [ ] Run a session where the session name contains `|`, check CONTEXT_SNAPSHOT.md **Last updated:** isn't mangled after the next agent turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)