### PR TITLE
fix(commands,hooks): shared snapshot write guard + session-end protection [#279] [#280]

### DIFF
--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -52,6 +52,29 @@ which PR merged if it's not clear from context.
 >
 > Substitute `$RIG_DIR` for `.rig/` in every step below.
 
+## Concurrent session guard — run before anything else
+
+Check for a `.snapshot-write-in-progress` sentinel before touching CONTEXT_SNAPSHOT.
+Both `/wrap` and `/post-merge` write the snapshot; if either is running in another
+session, block rather than silently overwrite:
+
+```bash
+SNAP_LOCK="$RIG_DIR/memory/.snapshot-write-in-progress"
+if [[ -f "$SNAP_LOCK" ]]; then
+  echo "⚠️  A snapshot write is already in progress (/wrap or /post-merge in another session)."
+  echo "   Lock file: $SNAP_LOCK"
+  echo "   If no other session is active, delete it and retry:"
+  echo "   rm '$SNAP_LOCK'"
+  exit 1
+fi
+touch "$SNAP_LOCK"
+```
+
+The lock is released in the Flag cleanup step at the very end. If `/post-merge`
+fails mid-run, the sentinel persists — delete it manually before retrying.
+
+---
+
 ## Git state check — run first, before anything else
 
 Before touching any files, verify the repo is in a known-good state:
@@ -158,15 +181,20 @@ If no meaningful work shipped (pure exploration, no merges), skip this step sile
 
 ## Flag cleanup
 
-After step 8 ("What's next?"), delete the `.post-merge-pending` flag file if it exists:
+After step 8 ("What's next?"), run all cleanups:
 
 ```bash
-rm -f "$(git rev-parse --show-toplevel)/.rig/memory/.post-merge-pending" 2>/dev/null || true
+# Release the concurrent session lock
+rm -f "$RIG_DIR/memory/.snapshot-write-in-progress" 2>/dev/null || true
+
+# Clear the post-merge-pending flag
+rm -f "$RIG_DIR/memory/.post-merge-pending" 2>/dev/null || true
 ```
 
-(Resolve via `.rigpath` if present.) This flag is written by `.husky/post-merge` after
-every merge and is detected at the next session start. Cleaning it up here confirms
-that `/post-merge` ran successfully.
+The `.post-merge-pending` flag is written by `.husky/post-merge` after every merge
+and detected at the next session start. Clearing it here confirms `/post-merge` ran
+successfully. The `.snapshot-write-in-progress` lock is cleared to unblock any
+concurrent `/wrap` or `/post-merge` waiting to run.
 
 ---
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -41,19 +41,19 @@ Performs the session-end housekeeping that prevents state loss between sessions:
 
 ## Concurrent session guard — run before anything else
 
-Check for a `.wrap-in-progress` sentinel that would indicate another session is
-already running `/wrap`:
+Check for a `.snapshot-write-in-progress` sentinel that would indicate another session is
+already running `/wrap` or `/post-merge`:
 
 ```bash
-WRAP_LOCK="$RIG_DIR/memory/.wrap-in-progress"
-if [[ -f "$WRAP_LOCK" ]]; then
-  echo "⚠️  Another /wrap is already running (or a previous run crashed)."
-  echo "   Lock file: $WRAP_LOCK"
+SNAP_LOCK="$RIG_DIR/memory/.snapshot-write-in-progress"
+if [[ -f "$SNAP_LOCK" ]]; then
+  echo "⚠️  A snapshot write is already in progress (/wrap or /post-merge in another session)."
+  echo "   Lock file: $SNAP_LOCK"
   echo "   If no other session is active, delete it and retry:"
-  echo "   rm '$WRAP_LOCK'"
+  echo "   rm '$SNAP_LOCK'"
   exit 1
 fi
-touch "$WRAP_LOCK"
+touch "$SNAP_LOCK"
 ```
 
 Create the sentinel immediately. Delete it at the very end of `/wrap` (step 11,
@@ -372,7 +372,7 @@ After suggesting a session name and before asking "What's next?", run both clean
 rm -f "$RIG_DIR/memory/.wrap-needed" 2>/dev/null || true
 
 # Release the concurrent session lock
-rm -f "$RIG_DIR/memory/.wrap-in-progress" 2>/dev/null || true
+rm -f "$RIG_DIR/memory/.snapshot-write-in-progress" 2>/dev/null || true
 
 # Clear any stale compact checkpoint — the full snapshot supersedes it
 rm -f "$RIG_DIR/memory/.compact-checkpoint.md" 2>/dev/null || true
@@ -382,7 +382,7 @@ Log: "`.wrap-needed` cleared. Concurrent session lock released. Compact checkpoi
 
 `.wrap-needed` signals to `stop.sh` that `/wrap` has run and no flag should be
 written until the next commit creates new unexpanded stubs.
-`.wrap-in-progress` signals to concurrent sessions that this wrap is complete.
+`.snapshot-write-in-progress` signals to concurrent sessions that this snapshot write is complete.
 `.compact-checkpoint.md` is cleared so the next session reads the authoritative
 `CONTEXT_SNAPSHOT.md` rather than a stale post-compaction checkpoint.
 

--- a/templates/project/.claude/hooks/session-end.sh
+++ b/templates/project/.claude/hooks/session-end.sh
@@ -43,6 +43,7 @@ fi
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
 PROGRESS="$RIG_DIR/memory/PROGRESS.md"
 WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
+SNAP_LOCK="$RIG_DIR/memory/.snapshot-write-in-progress"
 SESSION_LOG="${RIG_SESSION_LOG:-/tmp/the-rig-session-$(basename "$REPO").log}"
 NOW_FULL=$(date "+%Y-%m-%d %H:%M" 2>/dev/null || true)
 
@@ -57,6 +58,13 @@ write_wrap_needed() {
 
 write_minimal_checkpoint() {
   [[ ! -d "$RIG_DIR/memory" ]] && return
+  # If /wrap or /post-merge was running when the session closed, don't clobber
+  # their in-progress snapshot. The stale lock will surface at next session start.
+  if [[ -f "$SNAP_LOCK" ]]; then
+    echo "[$(date +%H:%M:%S)] SESSION_END: snapshot write in progress — skipping write_minimal_checkpoint" \
+      >> "$SESSION_LOG" 2>/dev/null || true
+    return
+  fi
   local branch commit active_task session_name=""
   branch=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   commit=$(git -C "$REPO" log -1 --format="%h %s" 2>/dev/null || echo "none")

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -34,3 +34,14 @@ ERRORS_archive.md
 # signalling that /post-merge should be run before starting new work.
 # Deleted by /post-merge when it completes successfully. Never committed.
 .post-merge-pending
+
+# .snapshot-write-in-progress is a mutual-exclusion lock held by /wrap and
+# /post-merge while writing CONTEXT_SNAPSHOT.md. Prevents concurrent writes from
+# silently overwriting each other. session-end.sh checks this before calling
+# write_minimal_checkpoint. Never committed.
+.snapshot-write-in-progress
+
+# .wrap-in-progress is the legacy name for .snapshot-write-in-progress (renamed
+# to cover /post-merge too). Kept here for projects that still have this file on
+# disk from older sessions.
+.wrap-in-progress

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1204,6 +1204,55 @@ _is_rig_protected() {
   [ ! -f "$wrap_needed" ]
 }
 
+# ── TASK_255: session-end.sh skips write_minimal_checkpoint if snap lock held ─
+
+@test "session-end.sh: skips write_minimal_checkpoint when snapshot write lock exists" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local rig_dir="$TEST_PROJECT/.rig"
+  local session_end_hook="$TEST_PROJECT/.claude/hooks/session-end.sh"
+  local session_log="$TEMP_DIR/the-rig-session-test.log"
+  local snap_lock="$rig_dir/memory/.snapshot-write-in-progress"
+
+  # Write a recognisable snapshot so we can detect if it was overwritten
+  printf '**Last updated:** 2026-01-01 — original snapshot\n' \
+    > "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+
+  # Simulate /wrap holding the lock
+  touch "$snap_lock"
+
+  echo '{"source": "logout"}' \
+    | ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$session_end_hook" )
+
+  # Snapshot must be unchanged — write_minimal_checkpoint was skipped
+  grep -q "original snapshot" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+}
+
+@test "session-end.sh: write_minimal_checkpoint runs normally when no lock exists" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local rig_dir="$TEST_PROJECT/.rig"
+  local session_end_hook="$TEST_PROJECT/.claude/hooks/session-end.sh"
+  local session_log="$TEMP_DIR/the-rig-session-test.log"
+  local snap_lock="$rig_dir/memory/.snapshot-write-in-progress"
+
+  printf '**Last updated:** 2026-01-01 — original snapshot\n' \
+    > "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+  # Ensure unexpanded stubs exist so the write-needed path is triggered
+  printf '[10:00:00] PROGRESS stub: abc1234 feat(x): commit [#1]\n' >> "$session_log"
+  printf '[10:01:00] PROGRESS stub: def5678 feat(x): commit [#2]\n' >> "$session_log"
+
+  rm -f "$snap_lock"
+
+  echo '{"source": "logout"}' \
+    | ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$session_end_hook" )
+
+  # Snapshot must have been replaced with the minimal checkpoint content
+  grep -q "session-end checkpoint" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+}
+
 # ── Session log path is per-project ──────────────────────────────────────────
 # Hooks must write to /tmp/the-rig-session-<project>.log, not a global path.
 # This prevents cross-project commit count contamination in session-end.sh.


### PR DESCRIPTION
## Summary

- Renames `.wrap-in-progress` to `.snapshot-write-in-progress` — extends the existing /wrap lock to also cover /post-merge
- `/post-merge` now acquires the lock before writing CONTEXT_SNAPSHOT and releases it in flag cleanup — concurrent /wrap + /post-merge runs are blocked rather than silently overwriting
- `session-end.sh` checks the lock in `write_minimal_checkpoint` — if /wrap or /post-merge is mid-run when the session closes, the minimal checkpoint is skipped rather than clobbering the in-progress snapshot
- `memory/.gitignore` adds both sentinel names (neither was gitignored before); legacy `.wrap-in-progress` kept for projects with old files on disk

Closes #279, Closes #280

## Test plan

- [x] 165 bats tests pass (was 163 — 2 new tests)
- [x] new: session-end skips write_minimal_checkpoint when snapshot write lock exists
- [x] new: write_minimal_checkpoint runs normally when no lock exists
- [x] session-end.sh syntax check passes
- [ ] Manual: start /wrap, close session mid-run, confirm snapshot not clobbered

Generated with Claude Code