### PR TITLE
fix(hooks): scope compact checkpoint to PPID — prevent concurrent compaction clobbering [#277]

### DIFF
--- a/templates/project/.claude/hooks/post-compact.sh
+++ b/templates/project/.claude/hooks/post-compact.sh
@@ -18,10 +18,14 @@ else
   RIG_DIR="$REPO/.rig"
 fi
 
-CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint.md"
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
 
-if [[ -f "$CHECKPOINT" ]]; then
+CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint-${PPID}.md"
+if [[ ! -f "$CHECKPOINT" ]]; then
+  CHECKPOINT=$(ls -t "$RIG_DIR/memory"/.compact-checkpoint-*.md 2>/dev/null | head -1 || true)
+fi
+
+if [[ -n "$CHECKPOINT" ]] && [[ -f "$CHECKPOINT" ]]; then
   CONTEXT=$(cat "$CHECKPOINT")
 elif [[ -f "$SNAPSHOT" ]]; then
   CONTEXT=$(cat "$SNAPSHOT")

--- a/templates/project/.claude/hooks/pre-compact.sh
+++ b/templates/project/.claude/hooks/pre-compact.sh
@@ -23,7 +23,7 @@ fi
 
 [[ ! -d "$RIG_DIR/memory" ]] && exit 0
 
-CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint.md"
+CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint-${PPID}.md"
 
 # ── Gather context ─────────────────────────────────────────────────────────────
 

--- a/templates/project/.claude/hooks/session-end.sh
+++ b/templates/project/.claude/hooks/session-end.sh
@@ -131,6 +131,8 @@ case "$SOURCE" in
       write_minimal_checkpoint
     fi
 
+    rm -f "$RIG_DIR/memory/.compact-checkpoint-${PPID}.md" 2>/dev/null || true
+
     echo "[$(date +%H:%M:%S)] SESSION_END: source=${SOURCE} — session terminated" \
       >> "$SESSION_LOG" 2>/dev/null || true
     ;;

--- a/templates/project/.claude/hooks/session-start.sh
+++ b/templates/project/.claude/hooks/session-start.sh
@@ -38,7 +38,6 @@ except Exception:
 fi
 
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
-COMPACT_CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint.md"
 WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
 POST_MERGE_PENDING="$RIG_DIR/memory/.post-merge-pending"
 
@@ -88,7 +87,11 @@ case "$SOURCE" in
     ;;
 
   compact)
-    if [[ -f "$COMPACT_CHECKPOINT" ]]; then
+    COMPACT_CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint-${PPID}.md"
+    if [[ ! -f "$COMPACT_CHECKPOINT" ]]; then
+      COMPACT_CHECKPOINT=$(ls -t "$RIG_DIR/memory"/.compact-checkpoint-*.md 2>/dev/null | head -1 || true)
+    fi
+    if [[ -n "$COMPACT_CHECKPOINT" ]] && [[ -f "$COMPACT_CHECKPOINT" ]]; then
       CONTEXT=$(cat "$COMPACT_CHECKPOINT")
     elif [[ -f "$SNAPSHOT" ]]; then
       CONTEXT=$(cat "$SNAPSHOT")

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -45,3 +45,9 @@ ERRORS_archive.md
 # to cover /post-merge too). Kept here for projects that still have this file on
 # disk from older sessions.
 .wrap-in-progress
+
+# .compact-checkpoint-<PPID>.md files are PPID-scoped per-session compact checkpoints.
+# Written by pre-compact.sh, read by post-compact.sh and session-start.sh (source=compact),
+# and deleted by session-end.sh on session close. Gitignored — ephemeral, never committed.
+.compact-checkpoint.md
+.compact-checkpoint-*.md

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -470,9 +470,11 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
   (cd "$tmpdir" && RIG_DIR="$tmpdir/.rig" \
     bash "$REPO_ROOT/templates/project/.claude/hooks/pre-compact.sh" >/dev/null)
 
-  [ -f "$tmpdir/.rig/memory/.compact-checkpoint.md" ]
-  grep -q "Branch:" "$tmpdir/.rig/memory/.compact-checkpoint.md"
-  grep -q "Last commit:" "$tmpdir/.rig/memory/.compact-checkpoint.md"
+  local cp_file
+  cp_file=$(ls -t "$tmpdir/.rig/memory"/.compact-checkpoint-*.md 2>/dev/null | head -1 || true)
+  [ -n "$cp_file" ]
+  grep -q "Branch:" "$cp_file"
+  grep -q "Last commit:" "$cp_file"
   rm -rf "$tmpdir"
 }
 
@@ -482,7 +484,7 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
   git -C "$tmpdir" init -q
   mkdir -p "$tmpdir/.rig/memory"
   printf '## Compact checkpoint\n\n**Branch:** test-branch\n' \
-    > "$tmpdir/.rig/memory/.compact-checkpoint.md"
+    > "$tmpdir/.rig/memory/.compact-checkpoint-12345.md"
 
   local output
   # cd into tmpdir so git rev-parse --show-toplevel returns tmpdir, not Rig repo root
@@ -512,6 +514,95 @@ assert 'additionalContext' in d['hookSpecificOutput']
     bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh") 2>/dev/null)
 
   [ -z "$output" ]
+  rm -rf "$tmpdir"
+}
+
+@test "pre-compact: concurrent sessions write separate checkpoints, no clobbering" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" config user.email "test@test.com"
+  git -C "$tmpdir" config user.name "Test"
+  git -C "$tmpdir" commit --allow-empty -m "initial" -q
+  mkdir -p "$tmpdir/.rig/memory" "$tmpdir/.rig/tasks/active"
+
+  # Pre-create a checkpoint simulating an existing concurrent session
+  printf '## Compact checkpoint\n\n**Branch:** feat/other-session\n' \
+    > "$tmpdir/.rig/memory/.compact-checkpoint-11111.md"
+
+  # Current session runs pre-compact — must not overwrite the other session's file
+  (cd "$tmpdir" && RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/pre-compact.sh" >/dev/null)
+
+  # Other session's checkpoint must be intact
+  [ -f "$tmpdir/.rig/memory/.compact-checkpoint-11111.md" ]
+  grep -q "feat/other-session" "$tmpdir/.rig/memory/.compact-checkpoint-11111.md"
+  # A second checkpoint file (from this session) must also exist
+  local count
+  count=$(ls "$tmpdir/.rig/memory"/.compact-checkpoint-*.md 2>/dev/null | wc -l | tr -d ' ')
+  [ "$count" -ge 2 ]
+  rm -rf "$tmpdir"
+}
+
+@test "post-compact: reads own PPID-scoped checkpoint when multiple checkpoints exist" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" config user.email "test@test.com"
+  git -C "$tmpdir" config user.name "Test"
+  git -C "$tmpdir" commit --allow-empty -m "initial" -q
+  mkdir -p "$tmpdir/.rig/memory" "$tmpdir/.rig/tasks/active"
+
+  # Create a stale checkpoint from a different session (old PID)
+  printf '## Compact checkpoint\n\n**Branch:** feat/wrong-session\n' \
+    > "$tmpdir/.rig/memory/.compact-checkpoint-99.md"
+
+  # Run pre-compact then post-compact in the same subshell (shared PPID)
+  # — post-compact must return the checkpoint written by pre-compact (this session),
+  # not the stale one from PID 99
+  local output
+  output=$((cd "$tmpdir" && RIG_DIR="$tmpdir/.rig" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/pre-compact.sh" >/dev/null && \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/post-compact.sh") 2>/dev/null)
+
+  echo "$output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert 'wrong-session' not in ctx, 'Got stale checkpoint from wrong session: ' + ctx
+assert 'Branch:' in ctx, 'Expected branch info in checkpoint: ' + ctx
+" 2>/dev/null
+  [ "$?" -eq 0 ]
+  rm -rf "$tmpdir"
+}
+
+@test "session-start: compact source uses most-recent checkpoint when no PPID-scoped file exists" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init -q
+  mkdir -p "$tmpdir/.rig/memory"
+
+  # Create an older checkpoint and a newer one — session-start must pick the newest
+  printf '## Compact checkpoint\n\n**Branch:** feat/old-session\n' \
+    > "$tmpdir/.rig/memory/.compact-checkpoint-111.md"
+  # Ensure newer mtime on the second file
+  sleep 0.05
+  printf '## Compact checkpoint\n\n**Branch:** feat/latest-session\n' \
+    > "$tmpdir/.rig/memory/.compact-checkpoint-222.md"
+
+  local output
+  output=$((cd "$tmpdir" && RIG_DIR="$tmpdir/.rig" \
+    printf '{"source":"compact"}' | \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/session-start.sh") 2>/dev/null)
+
+  echo "$output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert 'latest-session' in ctx, 'Expected latest-session but got: ' + ctx
+assert 'old-session' not in ctx, 'Got stale checkpoint instead of latest: ' + ctx
+" 2>/dev/null
+  [ "$?" -eq 0 ]
   rm -rf "$tmpdir"
 }
 


### PR DESCRIPTION
## Summary

- **Root cause:** pre-compact.sh wrote all sessions context to a single shared .compact-checkpoint.md. When two sessions compacted simultaneously, the second write overwrote the first — causing the agent in Session A to resume thinking it was working on Session B's branch/task.
- **Fix:** pre-compact.sh now writes to .compact-checkpoint-${PPID}.md. post-compact.sh and session-start.sh (source=compact) first try the PPID-scoped file, then fall back to ls -t .compact-checkpoint-*.md | head -1 for the post-compaction new-session case.
- **Cleanup:** session-end.sh deletes its own PPID-scoped checkpoint on session close. Added .compact-checkpoint.md and .compact-checkpoint-*.md to memory .gitignore.
- **Side-effect fix (Scenario E):** Session B post-compact.sh now reads its own scoped checkpoint rather than CONTEXT_SNAPSHOT.md, immune to a concurrent session-end.sh overwrite mid-compaction.
- **Tests:** 168/168 bats passing (was 165 — 3 new tests: no-clobbering, PPID-scoped read, most-recent fallback).

## Test plan

- [x] bats tests/ — 168/168 passing
- [x] bash -n syntax check on all modified hooks
- [x] No debug output, no dead code in diff

Closes #277

Generated with [Claude Code](https://claude.com/claude-code)