### PR TITLE
fix(commands): clarify /doc-list must not display features/README.md [#286]

### DIFF
--- a/templates/project/.claude/commands/doc-list.md
+++ b/templates/project/.claude/commands/doc-list.md
@@ -44,4 +44,6 @@ without loading large files unnecessarily.
 
 - Reads `$DOCS_DIR/INDEX.md` only — does not scan or read the doc files themselves
 - The index is maintained manually; update it when a doc is added or its scope changes
-- Feature doc index is separate: `$DOCS_DIR/features/README.md` (managed by `/doc-feature`)
+- **Do not display `$DOCS_DIR/features/README.md` here.** Feature docs are a separate
+  system managed by `/doc-feature` and `/feature-context` — `/doc-list` shows the
+  general docs index only.


### PR DESCRIPTION
## Summary

- The Notes section previously said "Feature doc index is separate: `$DOCS_DIR/features/README.md`" — Claude interpreted this as "also show this", producing a second feature-docs table below the main index table.
- Reworded as an explicit prohibition so the agent instruction is unambiguous.

## Test plan

- [x] Run `/doc-list` on a project with both `docs/INDEX.md` and `docs/features/README.md` — only one table should appear
- [x] No bats changes needed (command-only)

Closes #286

Generated with [Claude Code](https://claude.com/claude-code)