### PR TITLE
fix(commands,hooks): session name ownership sentinel + /session-name lock check [#275] [#281]

### DIFF
--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -175,6 +175,15 @@ After the user confirms, **update the `**Session name:**` field in
 `.rig/memory/CONTEXT_SNAPSHOT.md`** to match. This lets subsequent /wrap or
 /post-merge calls detect the existing name and suggest appends correctly.
 
+Then run:
+
+```bash
+touch "/tmp/.rig-session-name-set-${PPID}"
+```
+
+This sentinel tells `session-end.sh` that this session owns the name, preventing
+a concurrent sibling session from inheriting it when it writes its minimal checkpoint.
+
 If no meaningful work shipped (pure exploration, no merges), skip this step silently.
 
 ---

--- a/templates/project/.claude/commands/session-name.md
+++ b/templates/project/.claude/commands/session-name.md
@@ -129,12 +129,42 @@ Do **not** run anything automatically. Present it for the user to confirm, copy,
 
 ### 5 — After confirmation
 
-When the user confirms the name (or runs `/session-name` with a name argument),
-write the name into `.rig/memory/CONTEXT_SNAPSHOT.md`:
+When the user confirms the name (or runs `/session-name` with a name argument):
+
+**5a — Check for a concurrent snapshot write before editing.**
+
+Run this before calling `Edit` on CONTEXT_SNAPSHOT.md:
+
+```bash
+REPO=$(git rev-parse --show-toplevel)
+if [[ -f "$REPO/.rigpath" ]]; then RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath"); else RIG_DIR="$REPO/.rig"; fi
+SNAP_LOCK="$RIG_DIR/memory/.snapshot-write-in-progress"
+if [[ -f "$SNAP_LOCK" ]]; then
+  echo "⚠️ A snapshot write is in progress in another session. Wait for it to finish, then re-run /session-name. Or delete the lock manually: rm '$SNAP_LOCK'"
+  exit 1
+fi
+```
+
+If the lock exists, surface the warning and stop — do not proceed to the `Edit` call.
+
+**5b — Write the name.**
+
+Write the name into `.rig/memory/CONTEXT_SNAPSHOT.md`:
 
 - **If `**Session name:**` field already exists:** update it in-place.
 - **If absent:** insert it as the second line of the file (after `**Last updated:**`),
   or append it to the header block before the first `---` divider.
+
+**5c — Record session ownership.**
+
+After the name is written, run:
+
+```bash
+touch "/tmp/.rig-session-name-set-${PPID}"
+```
+
+This sentinel tells `session-end.sh` that this session owns the name, preventing
+a concurrent sibling session from inheriting it when it writes its minimal checkpoint.
 
 ---
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -358,6 +358,15 @@ After the user confirms, **update the `**Session name:**` field in
 `.rig/memory/CONTEXT_SNAPSHOT.md`** to match. This is how future /wrap calls
 detect an existing name and suggest appends instead of replacements.
 
+Then run:
+
+```bash
+touch "/tmp/.rig-session-name-set-${PPID}"
+```
+
+This sentinel tells `session-end.sh` that this session owns the name, preventing
+a concurrent sibling session from inheriting it when it writes its minimal checkpoint.
+
 If nothing meaningful shipped this session (pure exploration, no PRs, no
 completions), skip this step silently.
 

--- a/templates/project/.claude/hooks/session-end.sh
+++ b/templates/project/.claude/hooks/session-end.sh
@@ -73,8 +73,9 @@ write_minimal_checkpoint() {
     active_task=$(ls "$RIG_DIR/tasks/active"/*.md 2>/dev/null \
       | head -1 | xargs basename 2>/dev/null || true)
   fi
-  # Preserve the session name from the existing snapshot before overwriting it.
-  if [[ -f "$SNAPSHOT" ]]; then
+  # Preserve session name only if this session owns it — prevents inheriting a
+  # name written by a concurrent sibling that ran /session-name or /wrap.
+  if [[ -f "/tmp/.rig-session-name-set-${PPID}" ]] && [[ -f "$SNAPSHOT" ]]; then
     session_name=$(grep -m1 "^\*\*Session name:\*\*" "$SNAPSHOT" 2>/dev/null \
       | sed 's/\*\*Session name:\*\* *//' || true)
   fi
@@ -132,6 +133,7 @@ case "$SOURCE" in
     fi
 
     rm -f "$RIG_DIR/memory/.compact-checkpoint-${PPID}.md" 2>/dev/null || true
+    rm -f "/tmp/.rig-session-name-set-${PPID}" 2>/dev/null || true
 
     echo "[$(date +%H:%M:%S)] SESSION_END: source=${SOURCE} — session terminated" \
       >> "$SESSION_LOG" 2>/dev/null || true

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1344,6 +1344,61 @@ _is_rig_protected() {
   grep -q "session-end checkpoint" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
 }
 
+# ── TASK_252: session name ownership via /tmp sentinel ───────────────────────
+
+@test "session-end.sh: write_minimal_checkpoint omits session name when sentinel absent" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local rig_dir="$TEST_PROJECT/.rig"
+  local session_end_hook="$TEST_PROJECT/.claude/hooks/session-end.sh"
+  local session_log="$TEMP_DIR/the-rig-session-test.log"
+
+  # Snapshot has a name belonging to a sibling session
+  printf '**Last updated:** 2026-01-01\n**Session name:** sibling-session-name\n\n---\n' \
+    > "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+  printf '[10:00:00] PROGRESS stub: abc1234 feat(x): first [#1]\n' >> "$session_log"
+  printf '[10:01:00] PROGRESS stub: def5678 feat(x): second [#1]\n' >> "$session_log"
+  rm -f "$rig_dir/memory/.snapshot-write-in-progress"
+
+  # No sentinel — this session never called /session-name
+  echo '{"source": "logout"}' \
+    | ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$session_end_hook" )
+
+  # Sibling's session name must NOT appear in the checkpoint
+  run grep "sibling-session-name" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "session-end.sh: write_minimal_checkpoint preserves session name when sentinel present" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+
+  local rig_dir="$TEST_PROJECT/.rig"
+  local session_end_hook="$TEST_PROJECT/.claude/hooks/session-end.sh"
+  local session_log="$TEMP_DIR/the-rig-session-test.log"
+
+  # Snapshot has this session's own name
+  printf '**Last updated:** 2026-01-01\n**Session name:** my-own-session\n\n---\n' \
+    > "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+  printf '[10:00:00] PROGRESS stub: abc1234 feat(x): first [#1]\n' >> "$session_log"
+  printf '[10:01:00] PROGRESS stub: def5678 feat(x): second [#1]\n' >> "$session_log"
+  rm -f "$rig_dir/memory/.snapshot-write-in-progress"
+
+  # Run via bash -c so $$ inside = PPID seen by session-end.sh
+  local test_project="$TEST_PROJECT"
+  bash -c "
+    touch \"/tmp/.rig-session-name-set-\$\$\"
+    cd \"$test_project\"
+    echo '{\"source\": \"logout\"}' \
+      | RIG_SESSION_LOG=\"$session_log\" bash \"$session_end_hook\"
+    rm -f \"/tmp/.rig-session-name-set-\$\$\" 2>/dev/null
+  "
+
+  # This session's name must appear in the checkpoint
+  grep -q "my-own-session" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+}
+
 # ── Session log path is per-project ──────────────────────────────────────────
 # Hooks must write to /tmp/the-rig-session-<project>.log, not a global path.
 # This prevents cross-project commit count contamination in session-end.sh.


### PR DESCRIPTION
## Summary

**TASK_252 (#275) — session name ownership:**
- `session-end.sh`'s `write_minimal_checkpoint` now guards session name preservation behind a PPID-scoped sentinel at `/tmp/.rig-session-name-set-${PPID}`. Without the sentinel, closing sessions silently inherited names written by concurrent siblings.
- `/session-name`, `/wrap`, and `/post-merge` each create the sentinel after writing a name to CONTEXT_SNAPSHOT. `session-end.sh` deletes it at close alongside the compact checkpoint cleanup (from #277).
- Sentinel lives in `/tmp/` — ephemeral, OS-cleared on reboot, no accumulation.

**TASK_257 (#281) — /session-name lock check:**
- Step 5 now runs a Bash guard before calling `Edit` on CONTEXT_SNAPSHOT. If `.snapshot-write-in-progress` exists (set by `/wrap` or `/post-merge`), it surfaces a warning and stops rather than racing a concurrent Write with a stale-base Edit.

## Test plan

- [x] 170/170 bats passing (was 168 — 2 new tests: sentinel absent omits name, sentinel present preserves name)
- [x] No bats test for the markdown command lock check (bash guard logic verified by inspection)

Closes #275
Closes #281

Generated with [Claude Code](https://claude.com/claude-code)