### PR TITLE
fix(commands): auto-expire stale snapshot write lock after 30 minutes [#289]

### DIFF
--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -61,17 +61,21 @@ session, block rather than silently overwrite:
 ```bash
 SNAP_LOCK="$RIG_DIR/memory/.snapshot-write-in-progress"
 if [[ -f "$SNAP_LOCK" ]]; then
-  echo "⚠️  A snapshot write is already in progress (/wrap or /post-merge in another session)."
-  echo "   Lock file: $SNAP_LOCK"
-  echo "   If no other session is active, delete it and retry:"
-  echo "   rm '$SNAP_LOCK'"
-  exit 1
+  LOCK_AGE=$(( $(date +%s) - $(stat -c %Y "$SNAP_LOCK" 2>/dev/null || stat -f %m "$SNAP_LOCK" 2>/dev/null || echo 0) ))
+  if [[ "$LOCK_AGE" -gt 1800 ]]; then
+    echo "⚠️  Stale lock detected (age: ${LOCK_AGE}s). Auto-removing and proceeding."
+    rm -f "$SNAP_LOCK"
+  else
+    echo "⚠️  A snapshot write is already in progress (/wrap or /post-merge in another session, lock age: ${LOCK_AGE}s)."
+    echo "   If the other session is no longer active: rm '$SNAP_LOCK'"
+    exit 1
+  fi
 fi
 touch "$SNAP_LOCK"
 ```
 
-The lock is released in the Flag cleanup step at the very end. If `/post-merge`
-fails mid-run, the sentinel persists — delete it manually before retrying.
+The lock is released in the Flag cleanup step at the very end. Locks older than
+30 minutes are automatically expired — they are from crashed sessions.
 
 ---
 

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -47,19 +47,23 @@ already running `/wrap` or `/post-merge`:
 ```bash
 SNAP_LOCK="$RIG_DIR/memory/.snapshot-write-in-progress"
 if [[ -f "$SNAP_LOCK" ]]; then
-  echo "⚠️  A snapshot write is already in progress (/wrap or /post-merge in another session)."
-  echo "   Lock file: $SNAP_LOCK"
-  echo "   If no other session is active, delete it and retry:"
-  echo "   rm '$SNAP_LOCK'"
-  exit 1
+  LOCK_AGE=$(( $(date +%s) - $(stat -c %Y "$SNAP_LOCK" 2>/dev/null || stat -f %m "$SNAP_LOCK" 2>/dev/null || echo 0) ))
+  if [[ "$LOCK_AGE" -gt 1800 ]]; then
+    echo "⚠️  Stale lock detected (age: ${LOCK_AGE}s). Auto-removing and proceeding."
+    rm -f "$SNAP_LOCK"
+  else
+    echo "⚠️  A snapshot write is already in progress (/wrap or /post-merge in another session, lock age: ${LOCK_AGE}s)."
+    echo "   If the other session is no longer active: rm '$SNAP_LOCK'"
+    exit 1
+  fi
 fi
 touch "$SNAP_LOCK"
 ```
 
 Create the sentinel immediately. Delete it at the very end of `/wrap` (step 11,
-after flag cleanup). If `/wrap` fails mid-run, the sentinel will persist — the
-user must delete it manually. This is intentional: a stale lock is safer than
-silent corruption.
+after flag cleanup). Locks older than 30 minutes are automatically expired on the
+next run — they are from crashed sessions. Locks under 30 minutes block and require
+the other session to finish (or the lock deleted manually if that session is gone).
 
 The sentinel file is gitignored alongside other `.rig/memory/` runtime files.
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1906,11 +1906,17 @@ _status_backlog_count() {
 # We test the acquire/release cycle in isolation.
 
 _wrap_acquire_lock() {
-  # Mirrors the concurrent session guard in /wrap.
-  # Returns 0 (lock acquired + sentinel created) or 1 (already locked).
+  # Mirrors the concurrent session guard in /wrap and /post-merge.
+  # Returns 0 (lock acquired + sentinel created) or 1 (active lock present).
   local wrap_lock="$1"
   if [[ -f "$wrap_lock" ]]; then
-    return 1  # another session is wrapping, or prior run crashed
+    local lock_age
+    lock_age=$(( $(date +%s) - $(stat -c %Y "$wrap_lock" 2>/dev/null || stat -f %m "$wrap_lock" 2>/dev/null || echo 0) ))
+    if [[ "$lock_age" -gt 1800 ]]; then
+      rm -f "$wrap_lock"  # stale — auto-expire
+    else
+      return 1  # active lock, block
+    fi
   fi
   touch "$wrap_lock"
   return 0
@@ -1925,10 +1931,28 @@ _wrap_release_lock() {
 @test "wrap guard: lock acquisition blocked when sentinel already exists" {
   local rig_dir="$TEMP_DIR/rig"
   mkdir -p "$rig_dir/memory"
-  touch "$rig_dir/memory/.wrap-in-progress"
+  local lock="$rig_dir/memory/.wrap-in-progress"
+  touch "$lock"  # fresh mtime — under 1800s, must block
 
-  run _wrap_acquire_lock "$rig_dir/memory/.wrap-in-progress"
+  run _wrap_acquire_lock "$lock"
   [ "$status" -ne 0 ]
+}
+
+@test "wrap guard: stale lock (>1800s) is auto-removed and acquisition proceeds" {
+  local rig_dir="$TEMP_DIR/rig"
+  mkdir -p "$rig_dir/memory"
+  local lock="$rig_dir/memory/.wrap-in-progress"
+  touch "$lock"
+  # Set mtime to 2025-01-01 00:00 — guaranteed older than 30 minutes
+  touch -t 202501010000 "$lock"
+
+  run _wrap_acquire_lock "$lock"
+  [ "$status" -eq 0 ]
+  [ -f "$lock" ]  # new lock written
+  # Verify the new lock has a recent mtime (within 60s of now)
+  local new_age
+  new_age=$(( $(date +%s) - $(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null || echo 0) ))
+  [ "$new_age" -lt 60 ]
 }
 
 @test "wrap guard: lock acquired and sentinel created when none exists" {


### PR DESCRIPTION
## Summary

- `/wrap` and `/post-merge` concurrent session guards now check the age of `.snapshot-write-in-progress` before blocking.
- Locks **older than 1800s (30 min)** are automatically removed with a warning message and execution continues — they are from crashed sessions.
- Locks **under 30 min** block as before; the error message now includes the lock age so the user knows how long it has been held.
- `session-end.sh` is unchanged — it skips on lock presence regardless of age (expiry is the responsibility of the commands that own the lock lifecycle).
- `stat` portability: uses `-c %Y` (GNU/Linux) with `-f %m` (BSD/macOS) fallback and `echo 0` as a last resort — same pattern used elsewhere in the installer.

## Test plan

- [x] 171/171 bats passing (was 170 — 1 new test: stale lock >1800s auto-removed, fresh lock sentinel written)
- [x] Existing `wrap guard: lock acquisition blocked when sentinel already exists` still passes with fresh-touched lock

Closes #289

Generated with [Claude Code](https://claude.com/claude-code)