### PR TITLE
fix(wrap,post-merge): standardize session report + auto-execute housekeeping [#292]

### DIFF
--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -101,6 +101,58 @@ will `git checkout [BASE_BRANCH] && git pull`, but flag it now so the user is aw
 
 ---
 
+## Post-merge report step
+
+**Run this after the git state check, before executing POST_MERGE_WORKFLOW steps.**
+
+### Collection phase
+
+Gather all findings silently — no output yet:
+
+1. **Merged PR** — title, number, branch name (from context or `git log --oneline -1`)
+2. **"This session" summary** — from conversation context: all PRs merged or opened, tasks completed, issues resolved this session. Conversation context is the primary signal; PROGRESS.md markers are cross-reference only.
+3. **Task file** — which active task file maps to the merged PR (for step 3 of POST_MERGE_WORKFLOW)
+4. **ERRORS.md additions** — infer from session context whether any unexpected behaviors, footguns, or pitfalls should be added
+5. **Feature doc overlaps** — files changed in the merged PR vs. documented feature entry points (see Feature doc freshness step below)
+6. **Session name** — derive suggestion; check for existing name in CONTEXT_SNAPSHOT.md
+
+### Report
+
+Print a single structured report before executing POST_MERGE_WORKFLOW:
+
+```
+## Post-merge report — [BASE_BRANCH] — [date]
+
+**Merged:** PR #N — type(scope): description
+
+**This session:**
+- PR #N merged: type(scope): description
+- [other work items this session]
+(omit if this is the only work item)
+
+**ERRORS.md:** [N new entries: short-title-1 | no new entries]
+**Feature docs:** [⚠ overlap — run /refresh-feature-doc X | no overlaps]
+**Task file:** [TASK_N_slug.md → moving to done/ | no active task found]
+
+**Session name:** [suggested: "type desc #N | type desc #N" | already set — appending: "..." | nothing meaningful shipped, skipped]
+```
+
+### Execution
+
+After printing the report, **execute POST_MERGE_WORKFLOW steps 1–8 automatically**:
+
+- Pull latest [BASE_BRANCH] and confirm HEAD
+- Update PROGRESS.md
+- Move task file to done/
+- Write CONTEXT_SNAPSHOT.md
+- Add inferred ERRORS.md entries (if any)
+- Make housekeeping commit
+- Apply session name — only if user says "use that" or equivalent
+
+All steps execute automatically. The session name is the only action requiring explicit user input.
+
+---
+
 ## Feature doc freshness step
 
 After updating PROGRESS.md (step 2), check whether the merged PR touched any files

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -97,20 +97,67 @@ Run this:
 - Before switching to a different task or project
 - Any time you want to ensure a future session can pick up exactly where you left off
 
+---
+
+## Wrap report step
+
+**Run this after the git state check and any uncommitted-changes gate, before writing anything.**
+
+### Collection phase
+
+Gather all findings silently — no output yet:
+
+1. **PROGRESS.md entry count** — note if trim is needed (count > 20) and how many would be archived
+2. **Session-end markers** — count stale markers (all but the most recent)
+3. **"This session" summary** — from conversation context: PRs merged or opened, tasks completed, issues resolved, significant changes made. Conversation context is the primary signal; PROGRESS.md markers are cross-reference only.
+4. **ERRORS.md additions** — infer from session context whether any unexpected behaviors, footguns, or non-obvious pitfalls should be added (see ERRORS.md logging step below)
+5. **Feature doc overlaps** — files changed this session vs. documented feature entry points (see Feature doc freshness step below)
+6. **Active tasks** — read `.rig/tasks/active/`
+7. **Session name** — derive suggestion (see Session naming step below); check for existing name in CONTEXT_SNAPSHOT.md
+
+### Report
+
+Print a single structured report before executing anything:
+
+```
+## Wrap report — [branch] — [date]
+
+**This session:**
+- PR #N merged: type(scope): short description
+- [other work items]
+(omit this section if nothing meaningful shipped this session)
+
+**PROGRESS.md:** [N entries → trimming X to archive (topics: CI setup, stealth mode, ...) | N entries, no trim needed]
+**Session-end markers:** [pruned N stale markers | none to prune]
+**ERRORS.md:** [N new entries: short-title-1, short-title-2 | no new entries]
+**Feature docs:** [⚠ overlap detected — run /refresh-feature-doc X | no overlaps]
+**Active tasks:** [task-slug | none]
+
+**Session name:** [suggested: "type desc #N | type desc #N" | already set — appending: "..." | nothing meaningful shipped, skipped]
+```
+
+### Execution
+
+After printing the report, **execute all automatic actions without further prompts**:
+
+- Trim PROGRESS.md if count > 20
+- Prune stale session-end markers
+- Add inferred ERRORS.md entries (if any)
+- Trim ERRORS.md if count > 30
+- Write CONTEXT_SNAPSHOT.md
+- Touch session-name sentinel and update snapshot name field — only if user says "use that", "yes", or equivalent in response to the suggested name
+
+The session name is the only action requiring explicit user input. Everything else executes immediately after the report is printed.
+
+---
+
 ## Trim step — PROGRESS.md
 
 After updating `.rig/memory/PROGRESS.md`, count the number of `## ` entry headers in the file.
 
 **If the count is 20 or fewer:** nothing to do.
 
-**If the count exceeds 20:** tell the user:
-
-> "`.rig/memory/PROGRESS.md` has [N] entries. I'll move the oldest [N-20] to
-> `.rig/memory/PROGRESS_archive.md` to keep session startup lean. The archive is
-> gitignored — history is preserved locally but won't be loaded at session start.
-> Trim now?"
-
-If the user confirms:
+**If the count exceeds 20:** note in the Wrap report, then execute automatically after the report is printed:
 1. Identify the oldest entries (bottom of the file, since entries are newest-first)
 2. Prepend them to `.rig/memory/PROGRESS_archive.md` (create if absent)
 3. Remove them from `.rig/memory/PROGRESS.md`, leaving the 20 most recent entries
@@ -119,9 +166,8 @@ If the user confirms:
    <!-- archived YYYY-MM-DD: [N] entries moved to PROGRESS_archive.md. Topics: [3–6 word comma-separated summary of what was archived, e.g. "CI setup, manifest tracking, stealth mode, command rename"] -->
    ```
    This lets future sessions know what history exists in the archive without loading it.
-5. Confirm: "`.rig/memory/PROGRESS.md` trimmed to 20 entries. Archive: `.rig/memory/PROGRESS_archive.md`"
 
-Never trim without confirmation. Never delete entries — only move them.
+Never delete entries — only move them.
 
 ---
 
@@ -200,10 +246,9 @@ If there is nothing to log, skip silently — do not mention this step.
 
 ## ERRORS.md logging step
 
-Ask: "Did anything unexpected, buggy, or footgun-worthy happen this session that isn't
-already documented?"
+Based on this session's context — tool output, errors observed, unexpected behaviors, non-obvious footguns encountered — **infer** whether anything happened that is not already documented in ERRORS.md. Do not ask the user; derive from what was observed during the session.
 
-If yes, **before creating a new entry**:
+If there are entries to add, **before creating any new entry**:
 
 1. Search the active `.rig/memory/ERRORS.md` for a similar entry (keyword match is enough).
 2. If `ERRORS_archive.md` exists, do a quick search there too:
@@ -227,14 +272,7 @@ After checking `.rig/memory/ERRORS.md`, count the number of `## ` entry headers 
 
 **If the count is 30 or fewer:** nothing to do.
 
-**If the count exceeds 30:** tell the user:
-
-> "`.rig/memory/ERRORS.md` has [N] entries. I'll move the oldest [N-30] to
-> `.rig/memory/ERRORS_archive.md` to keep session startup lean. The archive is
-> gitignored — pitfall history is preserved locally but won't load at session start.
-> Trim now?"
-
-If the user confirms:
+**If the count exceeds 30:** note in the Wrap report, then execute automatically after the report is printed:
 1. Identify the oldest entries (bottom of the file, since entries are newest-first)
 2. Prepend them to `.rig/memory/ERRORS_archive.md` (create if absent)
 3. Remove them from `.rig/memory/ERRORS.md`, leaving the 30 most recent entries
@@ -244,9 +282,8 @@ If the user confirms:
    ```
    This lets the agent grep for a category keyword without loading the archive, and
    signals to the ERRORS.md logging step that the archive should be checked.
-5. Confirm: "`.rig/memory/ERRORS.md` trimmed to 30 entries. Archive: `.rig/memory/ERRORS_archive.md`"
 
-Never trim without confirmation. Never delete entries — only move them.
+Never delete entries — only move them.
 
 ---
 

--- a/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
+++ b/templates/project/.rig/processes/POST_MERGE_WORKFLOW.md
@@ -81,15 +81,20 @@ This file is **gitignored** — it lives on disk only, read at session start.
 
 ---
 
-## Step 5 — Check ERRORS.md and RIG_GAPS.md
+## Step 5 — Update ERRORS.md and RIG_GAPS.md
 
-If anything unexpected happened during the task or the merge process, log it in
-`.rig/memory/ERRORS.md` now. Do not defer — the detail is freshest immediately
-after the work.
+Based on this session's context — tool output, errors hit, unexpected behaviors, non-obvious
+pitfalls — **infer** whether anything should be added to these files. Do not ask the user;
+derive from what was observed.
 
-If anything about The Rig's workflow felt wrong, was missing, or slowed you down
-during this task, log it in `.rig/memory/RIG_GAPS.md`. Use `/rig-gaps` to compile
-and submit those entries to The Rig dev session.
+**ERRORS.md:** For any inferred entry, check the archive first to avoid duplicates
+(see ERRORS.md logging step in `/wrap` for the dedup protocol). Add new entries at the top.
+
+**RIG_GAPS.md:** If anything about The Rig's workflow felt wrong, was missing, or slowed
+work down during this task, log it now while the detail is fresh. Use `/rig-gaps` to
+compile and submit these entries to The Rig dev session.
+
+Include any additions in the Post-merge report (see report step in `/post-merge`).
 
 ---
 

--- a/tests/test_command_lint.bats
+++ b/tests/test_command_lint.bats
@@ -73,3 +73,42 @@ _fail_with_list() {
   done
   [ "${#failures[@]}" -eq 0 ] || _fail_with_list "H2 missing space after ##" "${failures[@]}"
 }
+
+# ── wrap / post-merge behavior spec ───────────────────────────────────────────
+
+@test "wrap.md: contains Wrap report step section" {
+  grep -q "## Wrap report step" "$COMMAND_DIR/wrap.md"
+}
+
+@test "wrap.md: Wrap report step defines collection phase and report format" {
+  grep -q "Collection phase" "$COMMAND_DIR/wrap.md"
+  grep -q "This session" "$COMMAND_DIR/wrap.md"
+  grep -q "Wrap report —" "$COMMAND_DIR/wrap.md"
+}
+
+@test "wrap.md: PROGRESS.md trim executes automatically — no confirmation gate" {
+  # Must NOT contain the old 'Trim now?' prompt
+  ! grep -q "Trim now?" "$COMMAND_DIR/wrap.md"
+}
+
+@test "wrap.md: ERRORS.md logging infers from context — no 'ask' prompt" {
+  # Must NOT ask the user whether anything unexpected happened
+  ! grep -q "Did anything unexpected" "$COMMAND_DIR/wrap.md"
+}
+
+@test "wrap.md: trim steps reference Wrap report — not standalone confirmations" {
+  grep -q "note in the Wrap report" "$COMMAND_DIR/wrap.md"
+}
+
+@test "post-merge.md: contains Post-merge report step section" {
+  grep -q "## Post-merge report step" "$COMMAND_DIR/post-merge.md"
+}
+
+@test "post-merge.md: Post-merge report step defines collection and report format" {
+  grep -q "Collection phase" "$COMMAND_DIR/post-merge.md"
+  grep -q "Post-merge report —" "$COMMAND_DIR/post-merge.md"
+}
+
+@test "post-merge.md: executes POST_MERGE_WORKFLOW automatically after report" {
+  grep -q "execute POST_MERGE_WORKFLOW steps" "$COMMAND_DIR/post-merge.md"
+}


### PR DESCRIPTION
## Summary

- Adds an explicit **Wrap report step** to `/wrap`: all findings are collected silently first, then a single structured report is printed, then all housekeeping executes automatically — no per-step confirmation gates
- Removes the `"Trim now?"` confirmation from PROGRESS.md and ERRORS.md trim operations
- Removes the `"Did anything unexpected happen?"` prompt from ERRORS.md logging — the agent infers from session context instead of asking
- The only remaining gate is uncommitted non-rig changes (genuinely the user's call)
- Adds a matching **Post-merge report step** to `/post-merge` with the same collect/report/execute pattern
- Updates `POST_MERGE_WORKFLOW.md` Step 5 to auto-infer ERRORS.md additions
- 8 new bats assertions enforcing the spec (179 total, was 171)

## Why

`/wrap` was stopping mid-execution to ask confirmation for low-stakes housekeeping (trim PROGRESS.md, add ERRORS.md entries). The output format was also inconsistent — terse when there was nothing to do, verbose when there was — making the command feel unreliable. The new design: collect everything, print once, execute automatically.

## Test plan

- [x] `bats tests/` — 179/179 pass
- [x] New assertions: `wrap.md` contains report step, no "Trim now?", no ask prompt; `post-merge.md` has report step and auto-execute spec
- [x] No debug artifacts, no secrets, syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
