### PR TITLE
feat(wrap,ship): add PR description freshness check [#293]

### DIFF
--- a/templates/project/.claude/commands/ship.md
+++ b/templates/project/.claude/commands/ship.md
@@ -337,12 +337,34 @@ EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number,title,url --jq '
 
 **If a PR already exists:**
 
+Before presenting options, compare the branch commits against the existing PR description
+to surface what may be missing:
+
+```bash
+PR_NUMBER=$(echo "$EXISTING_PR" | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])" 2>/dev/null || echo "")
+PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body 2>/dev/null || echo "")
+BASE=$(grep "^base-branch:" "$REPO/CLAUDE.md" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]')
+BASE="${BASE:-main}"
+COMMITS=$(git log "origin/${BASE}"..HEAD --format="%s" 2>/dev/null)
+```
+
+For each commit subject (skip housekeeping types: `chore(memory)`, `chore(post-merge)`,
+`chore(release)`, `chore(rig)`), check case-insensitively whether it appears in the PR body.
+Collect any that don't match.
+
+Then display:
+
 > "PR #[N] already exists for this branch: [title]
 > [URL]
 >
+> [If stale commits found:]
+> [N] commit(s) not reflected in the description:
+>   - type(scope): commit subject
+>   - ...
+>
 > Options:
-> - **[u] Update** — revise title, body, labels, and linked issues to reflect the new work
-> - **[k] Keep as-is** — the existing PR is accurate, no changes needed"
+> - **[u] Update** — revise title, body, and labels to reflect all work on this branch
+> - **[k] Keep as-is** — the existing PR description is accurate"
 
 If user chooses **[u]**:
 1. Show the current PR title and body (run `gh pr view [N] --json title,body`)

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -213,6 +213,54 @@ session touched files covered by documented features.
 
 ---
 
+## PR description freshness step
+
+After the feature doc freshness check, verify that the open PR for this branch
+reflects all commits that have landed since it was opened.
+
+**How:**
+
+1. Check for an open PR on the current branch:
+   ```bash
+   CURRENT_BRANCH=$(git branch --show-current)
+   PR_JSON=$(gh pr list --head "$CURRENT_BRANCH" --json number,title,body,labels --limit 1 2>/dev/null || echo "[]")
+   PR_NUMBER=$(echo "$PR_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['number'] if d else '')" 2>/dev/null || echo "")
+   ```
+   If `PR_NUMBER` is empty (no open PR or `gh` unavailable): skip silently.
+
+2. Get the PR body:
+   ```bash
+   PR_BODY=$(echo "$PR_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['body'] if d else '')" 2>/dev/null || echo "")
+   ```
+
+3. Get commits on this branch not yet in base:
+   ```bash
+   BASE=$(grep "^base-branch:" "$REPO/CLAUDE.md" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]')
+   BASE="${BASE:-main}"
+   git log "origin/$BASE"..HEAD --format="%s" 2>/dev/null
+   ```
+
+4. For each commit subject, skip housekeeping types: `chore(memory)`, `chore(post-merge)`,
+   `chore(release)`, `chore(rig)`. For the rest, do a case-insensitive substring check
+   against the PR body.
+
+5. **If any non-housekeeping commits are not reflected in the PR body**, surface in the
+   wrap summary:
+   > "PR #[N] description may be stale — [N] commit(s) not in description:
+   >   - type(scope): commit subject
+   >   - ...
+   > Update PR description? [yes / no]"
+
+   If the user says yes: append an `## Additional changes` section to the PR body
+   listing the unrepresented commits. Show the proposed addition before editing:
+   ```bash
+   gh pr edit "$PR_NUMBER" --body-file /tmp/wrap-pr-body.md
+   ```
+
+6. If all commits are reflected, or this is a housekeeping-only session: skip silently.
+
+---
+
 ## Self-improvement check
 
 After the feature doc freshness check, run a brief Rig retrospective:

--- a/tests/test_command_lint.bats
+++ b/tests/test_command_lint.bats
@@ -112,3 +112,25 @@ _fail_with_list() {
 @test "post-merge.md: executes POST_MERGE_WORKFLOW automatically after report" {
   grep -q "execute POST_MERGE_WORKFLOW steps" "$COMMAND_DIR/post-merge.md"
 }
+
+# ── PR description freshness ───────────────────────────────────────────────────
+
+@test "wrap.md: contains PR description freshness step" {
+  grep -q "## PR description freshness step" "$COMMAND_DIR/wrap.md"
+}
+
+@test "wrap.md: PR freshness step skips housekeeping commit types" {
+  grep -q "chore(memory)" "$COMMAND_DIR/wrap.md"
+}
+
+@test "wrap.md: PR freshness step skips silently when no open PR" {
+  grep -q "skip silently" "$COMMAND_DIR/wrap.md"
+}
+
+@test "ship.md: Step 9 compares commits against existing PR description before prompting" {
+  grep -q "compare the branch commits against the existing PR description" "$COMMAND_DIR/ship.md"
+}
+
+@test "ship.md: Step 9 skips housekeeping commit types in freshness check" {
+  grep -qE "chore\(memory\)" "$COMMAND_DIR/ship.md"
+}


### PR DESCRIPTION
## Summary

- **`wrap.md`**: new "PR description freshness step" — after the feature doc check, compares non-housekeeping commits on the branch against the open PR body; surfaces any that are missing and offers to append an `## Additional changes` section via `gh pr edit`
- **`ship.md`**: Step 9 enhanced to proactively diff branch commits against the existing PR description *before* presenting the update/keep prompt, giving the user the information they need to decide
- Both skip housekeeping commit types (`chore(memory)`, `chore(post-merge)`, `chore(release)`, `chore(rig)`) and skip silently when no PR is open or `gh` is unavailable
- 5 new bats assertions

## Note on branch dependency

This PR is based off `main`. The PR freshness step is added as a standalone section. When #302 merges (which adds the Wrap report collection/execute pattern), this step will be absorbed into the collection phase naturally on rebase — no structural conflict.

**Also confirmed:** T9 (validate PR labels before creating) is already implemented in `ship.md` Step 3. No separate ticket work needed there.

## Test plan

- [x] `bats tests/test_command_lint.bats` — 9/9 pass
- [x] No debug artifacts, syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
