### PR TITLE
feat(install,hooks): seed permission baseline + one-time nudge for /fewer-permission-prompts [#294]

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ cd ~/code/my-project
 
 ---
 
+### Reducing permission prompts
+
+Claude Code asks for confirmation on many tool calls. The Rig seeds a baseline
+allowlist for common read-only git operations in `.claude/settings.json` automatically.
+
+To expand it based on your actual session activity, run:
+
+```
+/fewer-permission-prompts
+```
+
+This scans recent tool use, identifies safe patterns, and adds them to your
+`.claude/settings.json`. Run it once after a few sessions to cut the friction
+significantly — it adds patterns, never removes them.
+
+---
+
 ### Upgrading
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -516,6 +516,15 @@ for event, incoming_hooks in incoming.get("hooks", {}).items():
                 existing_commands.add(cmd)  # rig-debug-ok
                 break  # each entry is a unit; add it once
 
+# Merge permissions.allow (dedup by pattern string)
+incoming_allow = incoming.get("permissions", {}).get("allow", [])
+if incoming_allow:
+    existing_allow = existing.get("permissions", {}).get("allow", [])
+    existing_allow_set = set(existing_allow)
+    new_patterns = [p for p in incoming_allow if p not in existing_allow_set]
+    if new_patterns:
+        existing.setdefault("permissions", {}).setdefault("allow", []).extend(new_patterns)
+
 with open(output_path, "w") as f:
     json.dump(existing, f, indent=2)
     f.write("\n")

--- a/templates/project/.claude/hooks/prompt-submit.sh
+++ b/templates/project/.claude/hooks/prompt-submit.sh
@@ -6,10 +6,13 @@
 # a warning into context if either is set — so the agent sees the flag
 # whether it was set at session start or mid-session (e.g. after a commit).
 #
-# Must be fast: UserPromptSubmit has a 30-second timeout.
-# When no flags are set, exits immediately with no output.
+# Also fires a one-time nudge when the project's permission allowlist is
+# sparse, suggesting /fewer-permission-prompts to reduce session friction.
 #
-# Output: JSON {"additionalContext": "..."} when a flag is present.
+# Must be fast: UserPromptSubmit has a 30-second timeout.
+# When no flags are set and the nudge has already been offered, exits immediately.
+#
+# Output: JSON {"additionalContext": "..."} when there is something to surface.
 # Claude Code receives this as context alongside the user's message.
 
 REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -23,13 +26,14 @@ fi
 
 WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
 POST_MERGE_PENDING="$RIG_DIR/memory/.post-merge-pending"
+NUDGE_FLAG="$RIG_DIR/memory/.permission-nudge-offered"
 
-# Fast path: no flags set — exit with no output
-if [[ ! -f "$WRAP_NEEDED" && ! -f "$POST_MERGE_PENDING" ]]; then
+# Fast path: no flags AND nudge already evaluated — exit immediately
+if [[ ! -f "$WRAP_NEEDED" && ! -f "$POST_MERGE_PENDING" && -f "$NUDGE_FLAG" ]]; then
   exit 0
 fi
 
-# Build warning text
+# Build warning text for housekeeping flags
 WARNINGS=""
 if [[ -f "$WRAP_NEEDED" ]]; then
   WARNINGS+="⚠️ The last session ended without running /wrap. CONTEXT_SNAPSHOT.md may be stale and PROGRESS.md has unexpanded entries. Run /wrap now to capture session state before starting new work — or say 'skip wrap' to proceed anyway."
@@ -38,6 +42,29 @@ if [[ -f "$POST_MERGE_PENDING" ]]; then
   [[ -n "$WARNINGS" ]] && WARNINGS+=$'\n\n'
   WARNINGS+="⚠️ A merge landed since /post-merge was last run. Memory may not reflect the merged state. Run /post-merge now — or say 'skip post-merge' to proceed anyway."
 fi
+
+# Permission nudge — once per project when allowlist is sparse
+if [[ ! -f "$NUDGE_FLAG" ]] && command -v python3 >/dev/null 2>&1; then
+  SETTINGS="$REPO/.claude/settings.json"
+  if [[ -f "$SETTINGS" ]]; then
+    allowed_count=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$SETTINGS'))
+    print(len(d.get('permissions', {}).get('allow', [])))
+except Exception:
+    print(99)
+" 2>/dev/null || echo 99)
+    touch "$NUDGE_FLAG"
+    if [[ "$allowed_count" -lt 5 ]]; then
+      [[ -n "$WARNINGS" ]] && WARNINGS+=$'\n\n'
+      WARNINGS+="Tip: run /fewer-permission-prompts to build a permission allowlist from your session history — reduces repetitive prompts without affecting oversight of write operations."
+    fi
+  fi
+fi
+
+# Exit cleanly if nothing to report
+[[ -z "$WARNINGS" ]] && exit 0
 
 # Output JSON additionalContext
 if command -v python3 >/dev/null 2>&1; then

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -1,4 +1,13 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git branch*)",
+      "Bash(git diff*)",
+      "Bash(git rev-parse*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -385,6 +385,68 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
   [ "$count_after_second" -eq "$count_after_first" ]
 }
 
+@test "fresh install: settings.json includes baseline permissions.allow entries" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+  local allow_count
+  allow_count=$(python3 -c "
+import json
+with open('$TEST_PROJECT/.claude/settings.json') as f:
+    s = json.load(f)
+print(len(s.get('permissions', {}).get('allow', [])))
+")
+  # Baseline has 5 read-only git patterns
+  [ "$allow_count" -ge 5 ]
+  grep -q '"Bash(git status\*)"' "$TEST_PROJECT/.claude/settings.json"
+  grep -q '"Bash(git log\*)"' "$TEST_PROJECT/.claude/settings.json"
+  grep -q '"Bash(git rev-parse\*)"' "$TEST_PROJECT/.claude/settings.json"
+}
+
+@test "merge strategy: does not duplicate permissions.allow on re-install" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+  local count_after_first
+  count_after_first=$(python3 -c "
+import json
+with open('$TEST_PROJECT/.claude/settings.json') as f:
+    s = json.load(f)
+print(len(s.get('permissions', {}).get('allow', [])))
+")
+  run_installer --strategy merge
+  [ "$status" -eq 0 ]
+  local count_after_second
+  count_after_second=$(python3 -c "
+import json
+with open('$TEST_PROJECT/.claude/settings.json') as f:
+    s = json.load(f)
+print(len(s.get('permissions', {}).get('allow', [])))
+")
+  # Allow list count must not grow — no duplicates added
+  [ "$count_after_second" -eq "$count_after_first" ]
+}
+
+@test "upgrade strategy: does not duplicate permissions.allow on upgrade" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+  local count_after_first
+  count_after_first=$(python3 -c "
+import json
+with open('$TEST_PROJECT/.claude/settings.json') as f:
+    s = json.load(f)
+print(len(s.get('permissions', {}).get('allow', [])))
+")
+  run_installer --strategy upgrade
+  [ "$status" -eq 0 ]
+  local count_after_second
+  count_after_second=$(python3 -c "
+import json
+with open('$TEST_PROJECT/.claude/settings.json') as f:
+    s = json.load(f)
+print(len(s.get('permissions', {}).get('allow', [])))
+")
+  [ "$count_after_second" -eq "$count_after_first" ]
+}
+
 # ── CLI flag validation ───────────────────────────────────────────────────────
 
 @test "--strategy with invalid value warns and falls back to interactive" {
@@ -440,6 +502,15 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
 @test "syntax: prompt-submit.sh has valid bash syntax" {
   run bash -n "$REPO_ROOT/templates/project/.claude/hooks/prompt-submit.sh"
   [ "$status" -eq 0 ]
+}
+
+@test "prompt-submit.sh: contains permission nudge logic" {
+  local f="$REPO_ROOT/templates/project/.claude/hooks/prompt-submit.sh"
+  grep -q "NUDGE_FLAG" "$f"
+  grep -q "fewer-permission-prompts" "$f"
+  grep -q "permission-nudge-offered" "$f"
+  # Fast path must check nudge flag so it exits before building WARNINGS
+  grep -q 'NUDGE_FLAG' "$f"
 }
 
 @test "syntax: permission-request.sh has valid bash syntax" {


### PR DESCRIPTION
## Summary

Seeds a `permissions.allow` baseline into the Rig's default `settings.json` and adds a one-time session nudge that fires when the allowlist is sparse — reducing the permission prompt friction that surfaces early in every new project.

## Changes

- `templates/project/.claude/settings.json` — adds `permissions.allow` with 5 read-only git patterns (`git status*`, `git log*`, `git branch*`, `git diff*`, `git rev-parse*`)
- `install.sh` (`merge_settings_json`) — extends the Python merge logic to also merge `permissions.allow` entries (dedup by pattern string, same strategy as hooks)
- `templates/project/.claude/hooks/prompt-submit.sh` — adds one-time nudge: checks allowlist count on first prompt, writes `.permission-nudge-offered` flag, suggests `/fewer-permission-prompts` if count < 5; fast-path now also exits when nudge flag is set
- `README.md` — adds "Reducing permission prompts" section to Quickstart
- `tests/test_install.bats` — 3 new assertions: fresh install has baseline entries, merge doesn't duplicate, upgrade doesn't duplicate; 1 structural assertion for nudge logic in prompt-submit.sh

## Closes
Closes #294

## Test plan

- 175 bats tests pass (`bats tests/`)
- `bash -n install.sh` clean
- `bash -n templates/project/.claude/hooks/prompt-submit.sh` clean
- Fresh install: `settings.json` contains `Bash(git status*)` in `permissions.allow`
- Re-install (merge): allow count does not grow
- Upgrade: allow count does not grow

## Notes

Threshold of `< 5` means: nudge fires when the project has fewer entries than the baseline (pre-294 installs with 0 patterns). Projects that receive the baseline via upgrade will have exactly 5, so the condition is false — the nudge only fires once and the flag is set.
