### PR TITLE
fix(install): --project-only does not block on intent menu in non-interactive mode [#295]

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ cd ~/code/my-project
 # state while always preserving CLAUDE.md, rules, and memory files.
 ```
 
+**Non-interactive / scripted form** (skips all menus — use this from automation or Claude Code):
+
+```bash
+~/tools/the-rig/install.sh \
+  --project-only \
+  --target ~/code/my-project \
+  --tracking stealth \
+  --strategy upgrade
+```
+
+`--project-only` is a scope flag (skip the global layer). It does not imply non-interactive
+mode on its own — provide `--strategy` and `--tracking` to skip all prompts.
+
 ---
 
 ### Setting up on a new machine

--- a/install.sh
+++ b/install.sh
@@ -336,7 +336,7 @@ else
   echo "                      (backs up originals to .rig-backup/)"
   echo "  5) Custom         — full control over layers, strategy, and components"
   echo ""
-  read -r -p "$(echo -e "${BOLD}?${RESET} Choose [1/2/3/4/5] (default: 2): ")" intent_input
+  read -r -p "$(echo -e "${BOLD}?${RESET} Choose [1/2/3/4/5] (default: 2): ")" intent_input || true
   intent_input="${intent_input:-2}"
 
   case "$intent_input" in
@@ -897,7 +897,7 @@ if [[ "$DO_PROJECT" == true ]]; then
   else
     DEFAULT_TARGET="$(pwd)"
     ask "Target project directory?"
-    read -r -p "    Path [${DEFAULT_TARGET}]: " TARGET_INPUT
+    read -r -p "    Path [${DEFAULT_TARGET}]: " TARGET_INPUT || true
     TARGET="${TARGET_INPUT:-$DEFAULT_TARGET}"
   fi
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -408,6 +408,26 @@ print(sum(len(v) for v in s.get('hooks', {}).values()))
   [ "$status" -ne 0 ]
 }
 
+@test "non-interactive: --project-only with empty stdin does not exit 1 on intent menu read" {
+  # Simulates Claude Code / CI calling install.sh --project-only without --strategy.
+  # Without the || true fix, read exits 1 on EOF and set -euo pipefail kills the script.
+  run bash "$INSTALLER" --project-only \
+    --target "$TEST_PROJECT" \
+    --project-name "TestProject" <<< ""
+  [ "$status" -eq 0 ]
+}
+
+@test "non-interactive: --project-only --strategy --tracking installs without any prompt" {
+  # Full non-interactive form — all menus bypassed via flags.
+  run bash "$INSTALLER" --project-only \
+    --target "$TEST_PROJECT" \
+    --project-name "TestProject" \
+    --tracking stealth \
+    --strategy merge <<< ""
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_PROJECT/.claude/settings.json" ]
+}
+
 # ── bash -n syntax checks ─────────────────────────────────────────────────────
 # Verify every shell script in the repo has valid bash syntax.
 # These catch trivial parse errors before a user ever runs an install.


### PR DESCRIPTION
## Summary

Fixes `install.sh` blocking on stdin when called from Claude Code or CI with `--project-only` and no `--strategy` flag. The root cause was two `read` calls lacking `|| true` — `set -euo pipefail` killed the script on EOF.

## Changes

- `install.sh` line 339 — added `|| true` to intent menu read; `intent_input` defaults to `"2"` (New project/merge) on non-TTY stdin
- `install.sh` line 900 — added `|| true` to target-directory read; `TARGET_INPUT` defaults to `$(pwd)` on non-TTY stdin
- `README.md` — added non-interactive usage block in Upgrading section: documents the full flag form (`--project-only --target --tracking --strategy`) that skips all menus
- `tests/test_install.bats` — two new tests: empty-stdin with `--project-only` alone exits 0; full-flag form with empty stdin installs successfully

## Closes
Closes #295

## Test plan

- 173 bats tests pass (`bats tests/`)
- `bash -n install.sh` clean
- `bash "$INSTALLER" --project-only --target "$TEST_PROJECT" --project-name "T" <<< ""` exits 0 (previously exited 1)
- `bash "$INSTALLER" --project-only --target "$TEST_PROJECT" --project-name "T" --tracking stealth --strategy merge <<< ""` exits 0 and creates `settings.json`

## Notes

The tracking prompt (lines 1038–1075) already had `|| true` and defaulted to stealth (option 4) — no change needed there. The base-branch prompt (line 956) already had a `[[ -t 0 ]]` guard. Only the intent menu and target prompt were unguarded.
