### PR TITLE
fix(install): detect and clean up stale in-repo .rig/ after stealth migration [#297]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1360,6 +1360,20 @@ PYEOF
       sed_inplace "s|\`.rig/tasks/|\`${EXTERNAL_RIG_DIR}/tasks/|g" "$TARGET_CLAUDE"
       success "Updated CLAUDE.md to reference external .rig/ path"
     fi
+
+    # Stale in-repo .rig/ cleanup: if the project has an old in-repo .rig/
+    # (e.g. migrating from repo/local to stealth/external), offer to remove it.
+    if [[ -d "$TARGET/.rig" ]]; then
+      echo ""
+      warn "In-repo .rig/ found at $TARGET/.rig/ — superseded by the external install at $EXTERNAL_RIG_DIR."
+      if confirm "Remove the stale in-repo .rig/ now?" "y"; then
+        rm -rf "$TARGET/.rig"
+        success "Removed stale in-repo .rig/"
+      else
+        warn "Left in place. Remove it manually to clean git status:"
+        warn "  rm -rf \"$TARGET/.rig\""
+      fi
+    fi
   fi
 
   # ── LOCAL-ONLY: add .rig/ to .git/info/exclude ───────────────────────────
@@ -1483,6 +1497,24 @@ PYEOF
   if [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]]; then
     echo ""
     info "Originals backed up to: $BACKUP_DIR"
+  fi
+
+  # ── HUSKY HOOK CHANGE NOTICE (non-stealth only) ────────────────────────────
+  # In stealth mode hooks land in .git/hooks/ (not tracked by git). In repo/local
+  # mode, .husky/ files are in the working tree — surface any modifications so the
+  # user knows to stage and commit them. The next session would otherwise flag the
+  # hooks as stale without any indication they need committing.
+  if [[ "$RIG_TRACKING" != "stealth" ]]; then
+    _husky_changed=$(git -C "$TARGET" status --porcelain -- ".husky/" 2>/dev/null \
+      | grep -v "^??" || true)
+    if [[ -n "$_husky_changed" ]]; then
+      echo ""
+      info "Hook files modified — stage and commit to apply them:"
+      while IFS= read -r _line; do
+        info "  $_line"
+      done <<< "$_husky_changed"
+      info "  git add .husky/ && git commit -m 'chore(hooks): update Rig git hooks'"
+    fi
   fi
 
   echo ""

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1168,6 +1168,28 @@ _is_rig_protected() {
   grep -qF ".rig/" "$TEST_PROJECT/.git/info/exclude"
 }
 
+@test "stealth migration: warns about stale in-repo .rig/ and auto-removes in non-interactive mode" {
+  # Start with a repo-tracked install so .rig/ exists in the project directory.
+  run_installer --strategy skip --tracking repo
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_PROJECT/.rig" ]
+
+  # Re-install in stealth mode. confirm() is non-interactive (non-TTY in bats),
+  # so it uses the default "y" and auto-removes .rig/ without reading stdin.
+  local rig_ext="$TEMP_DIR/rig-stealth-migration"
+  run bash "$INSTALLER" --project-only \
+    --target "$TEST_PROJECT" \
+    --project-name "TestProject" \
+    --tracking stealth \
+    --rig-dir "$rig_ext" \
+    --strategy merge
+  [ "$status" -eq 0 ]
+  # Warning must mention the stale .rig/
+  [[ "$output" == *"In-repo .rig/ found"* ]] || [[ "$output" == *"superseded"* ]]
+  # Non-interactive default is "y" — .rig/ is auto-removed
+  [ ! -d "$TEST_PROJECT/.rig" ]
+}
+
 @test "upgrade auto-detects repo mode when .rig/ is git-committed" {
   # Simulate a project previously installed in repo mode: .rig/ files committed.
   run_installer --strategy skip --tracking repo


### PR DESCRIPTION
## Summary

- Detects stale in-repo `.rig/` when migrating from repo/local to stealth/external tracking
- Warns with the superseded path and offers removal (default: yes, so non-interactive installs auto-clean)
- Surfaces modified `.husky/` files at end of non-stealth installs with a ready-to-paste `git add` command
- 1 bats test covering the warning + auto-removal behavior in non-interactive mode (168 total, all pass)

Closes #297

## Test plan

- [x] `bats tests/` — 168/168 pass
- [x] `bash -n install.sh` — syntax clean
- [x] Manual: repo-tracked project → re-install with `--tracking stealth` → warns + removes `.rig/`
- [x] Manual: stealth-only project → `.rig/` absent → no warn, no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)