### PR TITLE
feat(install): offer pull-and-rerun when installer source is stale [#299]

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ cd ~/code/my-project
 `--project-only` is a scope flag (skip the global layer). It does not imply non-interactive
 mode on its own — provide `--strategy` and `--tracking` to skip all prompts.
 
+> **Forgot to pull first?** If you run the installer before pulling, it detects
+> the stale source and offers to pull and re-run automatically — just choose option 1
+> at the prompt. The installer passes all your flags through to the re-run.
+
 ---
 
 ### Setting up on a new machine

--- a/install.sh
+++ b/install.sh
@@ -153,9 +153,36 @@ if git -C "$_DRIFT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
     _BEHIND=$(git -C "$_DRIFT_DIR" rev-list "HEAD..${_TRACKING}" --count 2>/dev/null || echo 0)
     if [[ "$_BEHIND" -gt 0 ]]; then
       warn "The installer is ${_BEHIND} commit(s) behind ${_TRACKING}."
-      warn "Run: git -C \"$_DRIFT_DIR\" pull   to get the latest version first."
-      warn "Proceeding with the current version..."
+      warn "Running from a stale version may install outdated hooks and commands."
       echo ""
+      if [[ ! -t 0 ]]; then
+        # Non-interactive (CI / piped stdin): warn and continue, don't block.
+        warn "Run: git -C \"$_DRIFT_DIR\" pull   to get the latest version first."
+        warn "Proceeding with the current version..."
+        echo ""
+      else
+        echo "  Options:"
+        echo "    1) Update now and re-run (recommended)"
+        echo "    2) Continue with current version"
+        echo "    3) Exit"
+        echo ""
+        read -r -p "  Choice [1/2/3]: " _STALE_CHOICE || true
+        case "${_STALE_CHOICE:-}" in
+          1)
+            info "Pulling latest..."
+            git -C "$_DRIFT_DIR" pull
+            exec "$SCRIPT_DIR/install.sh" "$@"
+            ;;
+          2)
+            warn "Proceeding with stale installer. Some installed files may be outdated."
+            echo ""
+            ;;
+          *)
+            echo "Exiting."
+            exit 0
+            ;;
+        esac
+      fi
     fi
   fi
 fi

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1927,6 +1927,35 @@ _sha256() {
   [[ "$output" != *"behind"* ]]
 }
 
+@test "installer drift check: non-interactive mode warns and continues without blocking" {
+  # stdin is not a TTY in bats — this verifies the non-interactive path does not
+  # hang waiting for user input and exits 0 (not 3/exit-on-default).
+  local remote_repo="$TEMP_DIR/rig-remote-ni"
+  local local_repo="$TEMP_DIR/rig-local-ni"
+
+  git init -q "$remote_repo"
+  git -C "$remote_repo" config user.email "test@test.com"
+  git -C "$remote_repo" config user.name "Test"
+  touch "$remote_repo/placeholder"
+  git -C "$remote_repo" add placeholder
+  git -C "$remote_repo" commit -q -m "initial commit"
+
+  git clone -q "$remote_repo" "$local_repo"
+  git -C "$local_repo" config user.email "test@test.com"
+  git -C "$local_repo" config user.name "Test"
+
+  touch "$remote_repo/newfile"
+  git -C "$remote_repo" add newfile
+  git -C "$remote_repo" commit -q -m "new commit on remote"
+
+  run bash -c "_RIG_DRIFT_DIR='$local_repo' bash '$INSTALLER' --project-only \
+    --target '$TEST_PROJECT' --project-name 'TestProject' --strategy skip"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"behind"* ]]
+  # Installer must have continued past the warning — pre-tool.sh is a reliable install marker
+  [ -f "$TEST_PROJECT/.claude/hooks/pre-tool.sh" ]
+}
+
 # ── Command behavior: /status ─────────────────────────────────────────────────
 # /status reads RIG_DIR, counts backlog tasks, and checks pending flag files.
 # We test the extractable shell logic in isolation.


### PR DESCRIPTION
## Summary

- When stdin is a TTY and the installer is N commits behind its remote, shows a 3-option prompt instead of warning-and-continuing
- Option 1 (recommended): `git pull` then `exec install.sh "$@"` — re-runs with all original flags preserved
- Option 2: continue with stale source (previous default)
- Option 3: exit cleanly
- Non-interactive mode (CI, piped stdin) is unchanged — warns and continues without prompting
- README updated with a note about the auto-pull option in the Upgrading section
- 1 bats test confirming non-interactive mode completes without blocking (169 total, all pass)

Closes #299

## Test plan

- [x] `bats tests/` — 169/169 pass
- [x] `bash -n install.sh` — syntax clean
- [x] Non-interactive path: pipes empty stdin through stale-version check, exits 0, installs files

🤖 Generated with [Claude Code](https://claude.com/claude-code)