### PR TITLE
docs(rig-upgrade): document PR-vs-direct-push convention for upgrade commits [#301]

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ mode on its own — provide `--strategy` and `--tracking` to skip all prompts.
 > the stale source and offers to pull and re-run automatically — just choose option 1
 > at the prompt. The installer passes all your flags through to the re-run.
 
+**After the installer runs:** check how many files changed before committing.
+
+```bash
+git diff --stat
+```
+
+- **4+ files changed** (hooks, commands, process files): use a branch + PR —
+  `git checkout -b chore/rig-upgrade-vX.Y.Z` — even if `housekeeping: direct-push` is set.
+  Rig upgrades that rewrite hook scripts warrant review.
+- **1–3 files changed** (VERSION, settings.json only): a direct `chore(rig):` commit is fine
+  if `housekeeping: direct-push` is set.
+
+> `housekeeping: direct-push` applies to memory commits (PROGRESS.md, task file moves) — not
+> to upgrades that modify hooks and commands.
+
 ---
 
 ### Setting up on a new machine

--- a/templates/project/.claude/commands/rig-upgrade.md
+++ b/templates/project/.claude/commands/rig-upgrade.md
@@ -686,6 +686,35 @@ fi
 If this project has a bats test suite (`tests/*.bats`), remind the user:
 > "Run `bats tests/` to verify the installer is still working correctly."
 
+### 5a — Commit strategy recommendation
+
+Count the total modified files:
+
+```bash
+TOTAL_CHANGED=$((${#UPGRADED[@]} + ${#CUSTOMIZED_ACCEPTED[@]} + ${#FIXED[@]}))
+```
+
+If `$TOTAL_CHANGED` > 3:
+
+> "**Commit strategy:** `$TOTAL_CHANGED` files were modified — use a branch and PR,
+> even if `housekeeping: direct-push` is set:
+>
+> ```bash
+> git checkout -b chore/rig-upgrade-$EXPECTED_VERSION
+> git add -f .claude/ .husky/ .rig/processes/ .rig/rules/ .rig/VERSION
+> git commit -m "chore(rig): upgrade to The Rig $EXPECTED_VERSION [#N]"
+> gh pr create --title "chore(rig): upgrade to $EXPECTED_VERSION" ...
+> ```
+>
+> `housekeeping: direct-push` applies to memory commits (PROGRESS.md, task file moves)
+> — not to upgrades that modify hooks, commands, and process files."
+
+If `$TOTAL_CHANGED` <= 3:
+
+> "**Commit strategy:** Only `$TOTAL_CHANGED` file(s) changed — a direct
+> `chore(rig): upgrade to $EXPECTED_VERSION [#N]` commit to `$BASE_BRANCH`
+> is acceptable if `housekeeping: direct-push` is set."
+
 Then say:
 > "Upgrade complete. What's next?"
 

--- a/templates/project/.rig/processes/UPGRADE_WORKFLOW.md
+++ b/templates/project/.rig/processes/UPGRADE_WORKFLOW.md
@@ -158,6 +158,37 @@ git diff --stat                          # review all changes before committing
 
 ---
 
+## Step 7 — Commit the upgrade
+
+After verifying the installed files, decide how to commit them.
+
+```bash
+git diff --stat   # count the modified files
+```
+
+| Files changed | Strategy |
+|---|---|
+| 1–3 files | Direct `chore(rig):` commit to `[BASE_BRANCH]` acceptable if `housekeeping: direct-push` |
+| 4+ files | **Branch + PR** — regardless of `housekeeping:` setting |
+
+For any upgrade that modifies 4 or more files (hooks, commands, process files, VERSION):
+
+```bash
+# Replace X.Y.Z with the new version
+git checkout -b chore/rig-upgrade-vX.Y.Z
+git add -f .claude/ .husky/ .rig/processes/ .rig/rules/ .rig/VERSION
+git commit -m "chore(rig): upgrade to The Rig vX.Y.Z [#N]"
+gh pr create --title "chore(rig): upgrade to vX.Y.Z" \
+  --body "Upgrades The Rig from vOLD to vNEW. See CHANGELOG for details."
+```
+
+> **Why branch + PR for upgrades?** `housekeeping: direct-push` governs memory commits
+> (`PROGRESS.md`, task file moves, `chore(post-merge)`) — not upgrades that rewrite hook
+> scripts, commands, and process files. Those changes affect every session going forward and
+> warrant review, even on solo projects.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -99,6 +99,11 @@ housekeeping: direct-push
 
 Change this value to match your project's branching convention.
 
+> **Upgrade commits are not covered by this setting.** When `/rig-upgrade` modifies
+> more than 3 files (hooks, commands, process files), use a `chore/rig-upgrade-vX.Y.Z`
+> branch and PR regardless of this value. `housekeeping: direct-push` applies to
+> memory and post-merge commits only — not to Rig upgrades.
+
 ---
 
 ## Project settings


### PR DESCRIPTION
## Summary

- Adds **Step 7** to `UPGRADE_WORKFLOW.md`: explicit commit strategy table (1–3 files → direct ok; 4+ files → branch + PR) with ready-to-paste commands
- Adds **Phase 5a** to `/rig-upgrade` command: post-upgrade recommendation based on `$TOTAL_CHANGED` file count, with the branch + PR command pre-filled with `$EXPECTED_VERSION`
- Adds a scoping note to the `housekeeping:` field in the **CLAUDE.md template**: upgrade commits are not covered by this setting
- Adds a commit-strategy tip to the **README Upgrading section**

Closes #301

## Test plan

- [x] `bats tests/` — 169/169 pass (no installer changes)
- [x] `bash -n install.sh` — syntax clean
- [x] Docs-only change — no logic modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)