### PR TITLE
feat(hooks): auto-approve Edit/Write to RIG_DIR in permission-request.sh [#312]

### DIFF
--- a/templates/project/.claude/hooks/permission-request.sh
+++ b/templates/project/.claude/hooks/permission-request.sh
@@ -11,6 +11,8 @@
 #   Bash       — bats (test runner, local only)
 #   Bash       — bash -n (syntax check, no execution)
 #   Bash       — grep, find (read-only searches)
+#   Edit/Write — any path under $RIG_DIR (Rig's own memory, tasks, docs)
+#                opt-out: touch $RIG_DIR/memory/.rig-strict-permissions
 #
 # For approved patterns: outputs JSON decision with behavior: allow.
 # For all other patterns: exits 0 with no output (normal permission handling).
@@ -25,8 +27,21 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 0
 fi
 
-DECISION=$(printf '%s' "$INPUT" | python3 -c "
-import json, sys, re
+# Resolve RIG_DIR — check for .rigpath (stealth mode) first.
+# _RIG_TEST_RIG_DIR overrides for test injection.
+if [[ -n "${_RIG_TEST_RIG_DIR:-}" ]]; then
+  RIG_DIR="$_RIG_TEST_RIG_DIR"
+else
+  REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [[ -n "$REPO" && -f "$REPO/.rigpath" ]]; then
+    RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath")
+  else
+    RIG_DIR="${REPO}/.rig"
+  fi
+fi
+
+DECISION=$(printf '%s' "$INPUT" | RIG_DIR="$RIG_DIR" python3 -c "
+import json, sys, re, os
 
 try:
     data = json.load(sys.stdin)
@@ -35,6 +50,7 @@ except Exception:
 
 tool_name = data.get('tool_name', '')
 tool_input = data.get('tool_input', {})
+rig_dir = os.environ.get('RIG_DIR', '').rstrip('/')
 
 def allow():
     out = {
@@ -64,6 +80,16 @@ if tool_name == 'Bash':
     ]
     for pattern in safe_patterns:
         if re.match(pattern, cmd):
+            allow()
+
+# Edit/Write — auto-approve writes to Rig's own directory.
+# Principle: Rig is allowed to manage its own memory, tasks, and docs.
+# Opt-out: touch \$RIG_DIR/memory/.rig-strict-permissions to disable.
+if tool_name in ('Edit', 'Write', 'NotebookEdit') and rig_dir:
+    strict_sentinel = os.path.join(rig_dir, 'memory', '.rig-strict-permissions')
+    if not os.path.exists(strict_sentinel):
+        file_path = tool_input.get('file_path', '').rstrip('/')
+        if file_path and file_path.startswith(rig_dir + '/'):
             allow()
 
 # Not an approved pattern — fall through to normal permission handling

--- a/templates/project/.claude/settings.json
+++ b/templates/project/.claude/settings.json
@@ -5,7 +5,9 @@
       "Bash(git log*)",
       "Bash(git branch*)",
       "Bash(git diff*)",
-      "Bash(git rev-parse*)"
+      "Bash(git rev-parse*)",
+      "Write(/tmp/*.md)",
+      "Write(/tmp/*.txt)"
     ]
   },
   "hooks": {

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -2493,3 +2493,60 @@ CLEOF
   [ "$status" -eq 0 ]
   [[ "$output" != *"Breaking changes since"* ]]
 }
+
+# ── permission-request.sh: RIG_DIR write auto-approval ───────────────────────
+
+_perm_invoke() {
+  # Run permission-request.sh with given tool_name and file_path.
+  # Uses _RIG_TEST_RIG_DIR to inject rig_dir without being overwritten by the hook.
+  local tool_name="$1" file_path="$2" rig_dir="$3"
+  local input
+  input=$(printf '{"tool_name":"%s","tool_input":{"file_path":"%s"}}' "$tool_name" "$file_path")
+  printf '%s' "$input" | \
+    _RIG_TEST_RIG_DIR="$rig_dir" \
+    bash "$REPO_ROOT/templates/project/.claude/hooks/permission-request.sh" 2>/dev/null
+}
+
+@test "permission-request: Edit to \$RIG_DIR is auto-approved" {
+  local rig_dir
+  rig_dir=$(mktemp -d)
+  mkdir -p "$rig_dir/memory"
+  local result
+  result=$(_perm_invoke "Edit" "$rig_dir/memory/PROGRESS.md" "$rig_dir")
+  [[ "$result" == *'"behavior": "allow"'* ]] || [[ "$result" == *'"behavior":"allow"'* ]]
+}
+
+@test "permission-request: Write to \$RIG_DIR is auto-approved" {
+  local rig_dir
+  rig_dir=$(mktemp -d)
+  mkdir -p "$rig_dir/memory"
+  local result
+  result=$(_perm_invoke "Write" "$rig_dir/memory/CONTEXT_SNAPSHOT.md" "$rig_dir")
+  [[ "$result" == *'"behavior": "allow"'* ]] || [[ "$result" == *'"behavior":"allow"'* ]]
+}
+
+@test "permission-request: Edit outside \$RIG_DIR is not auto-approved" {
+  local rig_dir
+  rig_dir=$(mktemp -d)
+  mkdir -p "$rig_dir/memory"
+  local result
+  result=$(_perm_invoke "Edit" "/some/other/project/src/main.py" "$rig_dir")
+  [[ -z "$result" ]]
+}
+
+@test "permission-request: .rig-strict-permissions sentinel disables RIG_DIR approval" {
+  local rig_dir
+  rig_dir=$(mktemp -d)
+  mkdir -p "$rig_dir/memory"
+  touch "$rig_dir/memory/.rig-strict-permissions"
+  local result
+  result=$(_perm_invoke "Edit" "$rig_dir/memory/PROGRESS.md" "$rig_dir")
+  [[ -z "$result" ]]
+}
+
+@test "fresh install: settings.json includes /tmp/ write patterns" {
+  run_installer --strategy skip
+  [ "$status" -eq 0 ]
+  grep -q '"Write(/tmp/\*.md)"' "$TEST_PROJECT/.claude/settings.json"
+  grep -q '"Write(/tmp/\*.txt)"' "$TEST_PROJECT/.claude/settings.json"
+}


### PR DESCRIPTION
## Summary

- Extends `permission-request.sh` to auto-approve `Edit`, `Write`, and `NotebookEdit` calls when the target file path is under `$RIG_DIR` — the agent should never be prompted to write to its own memory, tasks, or docs
- Adds `Write(/tmp/*.md)` and `Write(/tmp/*.txt)` to the baseline `settings.json` allow list for temp-file operations
- 5 new bats tests cover the approval, rejection, opt-out sentinel, and settings.json baseline cases — all 198 tests pass

## Design notes

**Why default-on:** The user already opted into The Rig. Prompting on every PROGRESS.md or CONTEXT_SNAPSHOT.md write undermines the workflow it is supposed to enable.

**Opt-out:** `touch $RIG_DIR/memory/.rig-strict-permissions` disables RIG_DIR auto-approval for strict environments that want explicit control over all writes.

**RIG_DIR resolution:** Same pattern as the rest of the Rig — `.rigpath` check first (stealth mode), then `$REPO/.rig` fallback.

**Test injection:** `_RIG_TEST_RIG_DIR` env override follows the `_RIG_DRIFT_DIR` / `_RIG_TEST_CHANGELOG` naming convention for bats test injection.

## Test plan

- [x] `bats tests/` — all 198 tests pass
- [x] 5 new tests: Edit approved, Write approved, outside-RIG_DIR rejected, strict sentinel disables, settings.json baseline includes /tmp/ patterns
- [x] Manual verification: `permission-request.sh` auto-approves writes to a real RIG_DIR path

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
