### PR TITLE
feat(hooks): UUID-based session identity system [#315]

### DIFF
--- a/templates/project/.claude/commands/post-merge.md
+++ b/templates/project/.claude/commands/post-merge.md
@@ -114,7 +114,7 @@ Gather all findings silently — no output yet:
 3. **Task file** — which active task file maps to the merged PR (for step 3 of POST_MERGE_WORKFLOW)
 4. **ERRORS.md additions** — infer from session context whether any unexpected behaviors, footguns, or pitfalls should be added
 5. **Feature doc overlaps** — files changed in the merged PR vs. documented feature entry points (see Feature doc freshness step below)
-6. **Session name** — derive suggestion; check for existing name in CONTEXT_SNAPSHOT.md
+6. **Session name** — derive suggestion from session file and conversation context
 
 ### Report
 
@@ -185,30 +185,38 @@ same logic as `/session-name`. The merged PR number is always known here, which
 makes this the most reliable naming signal in the system. Do **not** apply it
 automatically — present it for the user to confirm or tweak.
 
-### How to determine what belongs to this session
+### Step 1 — Find this session's UUID and tentative name
 
-Use the same logic as `/wrap` and `/session-name`: **conversation context first,
-files as cross-reference.**
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -f "$REPO/.rigpath" ]]; then RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath"); else RIG_DIR="$REPO/.rig"; fi
+SESSION_DIR="$RIG_DIR/memory/sessions"
+SESSION_FILE="$SESSION_DIR/session-${PPID}.json"
 
-Your direct knowledge of what was done in this session is the primary signal —
-enumerate the PRs, tasks, and work you know about from this conversation. File
-signals (PROGRESS.md markers, CONTEXT_SNAPSHOT.md datetime) are cross-reference
-only, used to catch anything that compacted out of context. If they conflict with
-what you know, trust the conversation.
+SESSION_UUID=$(cat "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true)
+TENTATIVE_NAME=""
+if [[ -f "$SESSION_FILE" ]]; then
+  [[ -z "$SESSION_UUID" ]] && \
+    SESSION_UUID=$(python3 -c "import json; print(json.load(open('$SESSION_FILE')).get('anchor') or '')" 2>/dev/null || true)
+  TENTATIVE_NAME=$(python3 -c "import json; print(json.load(open('$SESSION_FILE')).get('tentative_name') or '')" 2>/dev/null || true)
+fi
+```
 
-### Check for an existing session name
+### Step 2 — Collect this session's work
 
-Read the `**Session name:**` field from `.rig/memory/CONTEXT_SNAPSHOT.md`.
+**Conversation context first** — enumerate PRs, tasks, and work you know about.
+The merged PR number is always known at this point. File signals are cross-reference:
 
-- **If blank / absent:** suggest a name based on the merged PR (and any other
-  PRs or tasks completed this session).
-- **If already set:** suggest **appending** the merged PR to the existing name:
+```bash
+grep "^## .*<!-- sid:${SESSION_UUID} -->" "$RIG_DIR/memory/PROGRESS.md" 2>/dev/null || true
+```
 
-  > **Session already named:** `feat dashboard ui #49`
-  > **Merged this run:** PR #51 (fix null user on profile fetch)
-  > **Updated suggestion:** `feat dashboard ui #49 | fix null user profile fetch #51`
+**Every `## ` entry header written to PROGRESS.md must include `<!-- sid:UUID -->`
+at the end of the line.** Read UUID from `/tmp/.rig-session-${PPID}.uuid`.
 
-### Format
+If tentative_name is set, use it as the base (refine based on actual outcome).
+
+### Step 3 — Build the name
 
 Use the **tiered format** from `/session-name` (same logic — see that command for full detail):
 
@@ -218,27 +226,41 @@ Use the **tiered format** from `/session-name` (same logic — see that command 
 
 Keep under ~100 characters.
 
-### Output
+### Step 4 — Present and confirm
 
 > **Suggested session name:**
 > `feat user-auth magic-link flow #91`
 
-Then invite the user to apply it:
+> To apply: say "use that name" or "lgtm".
 
-> To apply: run `/session-name` or say "use that name".
+### Step 5 — After confirmation: write to session file, move to done/
 
-After the user confirms, **update the `**Session name:**` field in
-`.rig/memory/CONTEXT_SNAPSHOT.md`** to match. This lets subsequent /wrap or
-/post-merge calls detect the existing name and suggest appends correctly.
-
-Then run:
+Write atomically — temp file then rename — so a crash between write and move does
+not leave a `status: complete` file stranded in `sessions/` outside of `done/`.
 
 ```bash
-touch "/tmp/.rig-session-name-set-${PPID}"
+CONFIRMED_NAME="<the confirmed name>"
+DONE_DIR="$SESSION_DIR/done"
+mkdir -p "$DONE_DIR"
+DEST="$DONE_DIR/session-$(date +%Y%m%d)-${SESSION_UUID}.json"
+
+python3 - <<PYEOF
+import json, os
+with open("$SESSION_FILE") as f:
+    d = json.load(f)
+d["final_name"] = "$CONFIRMED_NAME"
+d["status"] = "complete"
+tmp = "$DEST" + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(d, f, indent=2)
+os.rename(tmp, "$DEST")
+PYEOF
+
+rm -f "$SESSION_FILE" 2>/dev/null || true
+rm -f "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
 ```
 
-This sentinel tells `session-end.sh` that this session owns the name, preventing
-a concurrent sibling session from inheriting it when it writes its minimal checkpoint.
+**Do NOT write Session name to CONTEXT_SNAPSHOT.md.** Session names live in session files.
 
 If no meaningful work shipped (pure exploration, no merges), skip this step silently.
 

--- a/templates/project/.claude/commands/session-name.md
+++ b/templates/project/.claude/commands/session-name.md
@@ -7,11 +7,14 @@ suggestion. Can be run at any point in the session — not just at wrap time.
 
 ## What this does
 
-1. Determines the session boundary in `.rig/memory/PROGRESS.md`
-2. Checks `.rig/memory/CONTEXT_SNAPSHOT.md` for an existing session name
-3. Derives a name in the standard `type short-desc #N | ...` format
+1. Reads this session's UUID from `/tmp/.rig-session-${PPID}.uuid` and its session
+   file from `$RIG_DIR/memory/sessions/session-${PPID}.json`
+2. Reads any existing `tentative_name` from the session file
+3. Derives a name in the standard `type short-desc #N | ...` format using conversation
+   context as the primary signal and UUID-tagged PROGRESS entries as cross-reference
 4. Presents it as output — does **not** run anything automatically
-5. After you confirm or tweak it, updates `**Session name:**` in `CONTEXT_SNAPSHOT.md`
+5. After you confirm, writes the name to the session file (`tentative_name` if called
+   early, `final_name` if called at session end). Never writes to CONTEXT_SNAPSHOT.md.
 
 This is the same logic used by `/wrap` and `/post-merge`, but callable at any time
 without triggering a full wrap or post-merge cycle.
@@ -26,44 +29,54 @@ without triggering a full wrap or post-merge cycle.
 
 No arguments. Run it whenever you want to name or re-name the current session.
 
-> **RIG_DIR resolution (stealth mode):** Before reading `.rig/memory/PROGRESS.md` or
-> `.rig/memory/CONTEXT_SNAPSHOT.md`, resolve where `.rig/` actually lives. If `.rigpath`
-> exists at the project root, read it — it contains the absolute path to the external
-> `.rig/` directory. Substitute `$RIG_DIR` for `.rig/` in every step below.
+> **RIG_DIR resolution (stealth mode):** Before reading any `.rig/` path, resolve where
+> `.rig/` actually lives. If `.rigpath` exists at the project root, read it — it contains
+> the absolute path to the external `.rig/` directory. Substitute `$RIG_DIR` for `.rig/`
+> in every step below.
 
 ---
 
 ## Steps
 
+### 0 — Find this session's file
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -f "$REPO/.rigpath" ]]; then RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath"); else RIG_DIR="$REPO/.rig"; fi
+SESSION_DIR="$RIG_DIR/memory/sessions"
+SESSION_FILE="$SESSION_DIR/session-${PPID}.json"
+
+SESSION_UUID=$(cat "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true)
+TENTATIVE_NAME=""
+if [[ -f "$SESSION_FILE" ]]; then
+  [[ -z "$SESSION_UUID" ]] && \
+    SESSION_UUID=$(python3 -c "import json; print(json.load(open('$SESSION_FILE')).get('anchor') or '')" 2>/dev/null || true)
+  TENTATIVE_NAME=$(python3 -c "import json; print(json.load(open('$SESSION_FILE')).get('tentative_name') or '')" 2>/dev/null || true)
+fi
+```
+
 ### 1 — Determine what happened this session
 
-**Your conversation context is the primary signal.** Before reading any files,
-enumerate directly what was done in this session: PRs merged or opened, tasks
-completed, issues created, commands run, significant files changed. You were
-here — this is the most accurate record of the session's work.
+**Your conversation context is the primary signal** — what was done, PRs opened or
+merged, tasks completed. If called early in the session to set a tentative name, use
+the stated intent as the basis.
 
-File signals are cross-reference only — use them to catch anything that may have
-compacted out of the context window, not to override what you already know:
-
-- **`<!-- session-end YYYY-MM-DD HH:MM -->` markers in PROGRESS.md** — entries
-  above the most recent marker are candidates to cross-check against your context.
-- **`**Last updated:**` datetime in CONTEXT_SNAPSHOT.md** — use as an approximate
-  session-start boundary when correlating PROGRESS.md entries.
+File signals are cross-reference only:
+- **UUID-tagged PROGRESS entries** — `grep "^## .*<!-- sid:${SESSION_UUID} -->"` to find entries from this session
+- **`tentative_name` in session file** — set pre-compaction; use as the base if context was lost to compaction
+- **`<!-- session-end -->` markers** — entries above the most recent marker as legacy fallback when no UUID
 
 **If conversation context and file signals conflict, trust the conversation.**
-Files may be stale, markers may be missing, or another tab may have written to
-the same files. Your direct knowledge of this session is authoritative.
 
-### 2 — Check for an existing session name
+### 2 — Check for an existing tentative name
 
-Read the `**Session name:**` field from `.rig/memory/CONTEXT_SNAPSHOT.md`.
+Read `tentative_name` from the session file (step 0 above).
 
-- **If blank / absent:** derive a fresh name from this session's entries.
-- **If already set:** suggest **appending** any new work rather than replacing:
-
-  > **Session already named:** `feat dashboard ui #49`
-  > **New work this session:** PR #51 (fix null user on profile fetch)
-  > **Updated suggestion:** `feat dashboard ui #49 | fix null user profile fetch #51`
+- **If blank / absent:** derive a fresh name from this session's work.
+- **If set as tentative** (`[tentative]` suffix): suggest upgrading it to a final
+  name if the session delivered what it described, or updating it if scope changed.
+- **If this command is called early** (before much work has happened): set a tentative
+  name explicitly — append `[tentative]` to mark it as subject to refinement at `/wrap`.
 
 ### 3 — Derive the name
 
@@ -111,8 +124,8 @@ sprint: N issues · feat/X fix/Y chore/Z · #A–#B
 
 Example: `sprint: 23 issues · feat/4 fix/15 chore/4 · #130–#152`
 
-If the session covered a named milestone or sprint (e.g. a GitHub milestone), use
-the milestone name as a prefix: `milestone: Sprint 3 · 23 issues · feat/4 fix/15 · #130–#152`
+If the session covered a named milestone or sprint, use the milestone name as a
+prefix: `milestone: Sprint 3 · 23 issues · feat/4 fix/15 · #130–#152`
 
 ### 4 — Present the suggestion
 
@@ -123,56 +136,69 @@ Output the name as plain text:
 
 Then invite the user to apply it:
 
-> To apply: run `/session-name` again with the name as argument, or say "use that name".
+> To apply: say "use that name" or "lgtm".
 
 Do **not** run anything automatically. Present it for the user to confirm, copy, or tweak.
 
 ### 5 — After confirmation
 
-When the user confirms the name (or runs `/session-name` with a name argument):
+When the user confirms the name:
 
-**5a — Check for a concurrent snapshot write before editing.**
+**5a — Determine if this is a tentative or final name.**
 
-Run this before calling `Edit` on CONTEXT_SNAPSHOT.md:
+- Called early in session (before most work is done) → write as `tentative_name`
+  with `[tentative]` suffix.
+- Called mid-session or at wrap time → write as `final_name`; clear `tentative_name`.
 
-```bash
-REPO=$(git rev-parse --show-toplevel)
-if [[ -f "$REPO/.rigpath" ]]; then RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath"); else RIG_DIR="$REPO/.rig"; fi
-SNAP_LOCK="$RIG_DIR/memory/.snapshot-write-in-progress"
-if [[ -f "$SNAP_LOCK" ]]; then
-  echo "⚠️ A snapshot write is in progress in another session. Wait for it to finish, then re-run /session-name. Or delete the lock manually: rm '$SNAP_LOCK'"
-  exit 1
-fi
-```
-
-If the lock exists, surface the warning and stop — do not proceed to the `Edit` call.
-
-**5b — Write the name.**
-
-Write the name into `.rig/memory/CONTEXT_SNAPSHOT.md`:
-
-- **If `**Session name:**` field already exists:** update it in-place.
-- **If absent:** insert it as the second line of the file (after `**Last updated:**`),
-  or append it to the header block before the first `---` divider.
-
-**5c — Record session ownership.**
-
-After the name is written, run:
+**5b — Write to session file.**
 
 ```bash
-touch "/tmp/.rig-session-name-set-${PPID}"
+IS_TENTATIVE=false  # set to true if called early
+CONFIRMED_NAME="<the confirmed name>"
+
+python3 - <<PYEOF
+import json
+
+session_file = "$SESSION_FILE"
+try:
+    with open(session_file) as f:
+        d = json.load(f)
+except FileNotFoundError:
+    d = {"anchor": "$SESSION_UUID", "pid": $PPID, "status": "active",
+         "tentative_name": None, "final_name": None}
+
+if "$IS_TENTATIVE" == "true":
+    d["tentative_name"] = "$CONFIRMED_NAME [tentative]"
+else:
+    d["final_name"] = "$CONFIRMED_NAME"
+    d["tentative_name"] = None   # final supersedes tentative
+
+with open(session_file, "w") as f:
+    json.dump(d, f, indent=2)
+PYEOF
 ```
 
-This sentinel tells `session-end.sh` that this session owns the name, preventing
-a concurrent sibling session from inheriting it when it writes its minimal checkpoint.
+**Do NOT write Session name to CONTEXT_SNAPSHOT.md.** CONTEXT_SNAPSHOT is
+project state only. Session names belong in session files.
+
+**5c — Log the name in PROGRESS.md if writing final.**
+
+If writing a final name, add a note at the top of PROGRESS.md:
+```
+## [date] — Session named: [final name] <!-- sid:[UUID] -->
+```
 
 ---
 
 ## Notes
 
-- If no meaningful work has been completed yet (no PROGRESS entries this session),
-  say so and skip the suggestion.
-- If CONTEXT_SNAPSHOT.md doesn't exist, note that `/wrap` should be run first to
-  create it — or offer to derive a name from PROGRESS.md alone.
+- If called early with no work done yet, still write a tentative name if the user
+  states intent — that anchor is more valuable than nothing.
+- If the session file does not exist (session predates this change), fall back to
+  deriving a name from PROGRESS.md session-end markers and legacy CONTEXT_SNAPSHOT
+  `Session name` field.
+- **Setting tentative names early** is encouraged — the tentative name survives
+  compaction and gives post-compaction agents a reliable anchor without needing to
+  reconstruct work from file signals alone.
 - **Why not `/rename`?** Claude Code has a built-in `/rename` command that renames
   the conversation. This command was renamed to `/session-name` to avoid the conflict.

--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -113,7 +113,7 @@ Gather all findings silently — no output yet:
 4. **ERRORS.md additions** — infer from session context whether any unexpected behaviors, footguns, or non-obvious pitfalls should be added (see ERRORS.md logging step below)
 5. **Feature doc overlaps** — files changed this session vs. documented feature entry points (see Feature doc freshness step below)
 6. **Active tasks** — read `.rig/tasks/active/`
-7. **Session name** — derive suggestion (see Session naming step below); check for existing name in CONTEXT_SNAPSHOT.md
+7. **Session identity** — read session file at `$RIG_DIR/memory/sessions/session-${PPID}.json`; extract `anchor` UUID and `tentative_name`. If session file absent, fall back to session-end marker boundary.
 
 ### Report
 
@@ -133,7 +133,7 @@ Print a single structured report before executing anything:
 **Feature docs:** [⚠ overlap detected — run /refresh-feature-doc X | no overlaps]
 **Active tasks:** [task-slug | none]
 
-**Session name:** [suggested: "type desc #N | type desc #N" | already set — appending: "..." | nothing meaningful shipped, skipped]
+**Session:** [anchor: UUID | tentative: "..." | suggested final: "type desc #N | type desc #N" | nothing meaningful shipped, skipped]
 ```
 
 ### Execution
@@ -144,8 +144,8 @@ After printing the report, **execute all automatic actions without further promp
 - Prune stale session-end markers
 - Add inferred ERRORS.md entries (if any)
 - Trim ERRORS.md if count > 30
-- Write CONTEXT_SNAPSHOT.md
-- Touch session-name sentinel and update snapshot name field — only if user says "use that", "yes", or equivalent in response to the suggested name
+- Write CONTEXT_SNAPSHOT.md (project state only — no Session name field)
+- Write final session name to session file and move to `sessions/done/` — only if user confirms the suggested name
 
 The session name is the only action requiring explicit user input. Everything else executes immediately after the report is printed.
 
@@ -369,95 +369,140 @@ snapshot — overwrite the previous version.
 
 ## Session naming step
 
-After reporting active tasks, derive a session name from this session's work and
-output it as a suggestion. Do **not** apply it automatically — present it for
+After reporting active tasks, derive a final session name from this session's work
+and output it as a suggestion. Do **not** apply it automatically — present it for
 the user to confirm or tweak.
 
-### How to determine "this session's work"
+### Step 1 — Find this session's UUID and tentative name
 
-**Your conversation context is the primary signal.** Before reading any files,
-enumerate directly what was done in this session: PRs merged or opened, tasks
-completed, issues created, commands run, significant files changed. You were
-here — this is the most accurate record of what the session name should reflect.
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -f "$REPO/.rigpath" ]]; then RIG_DIR=$(tr -d '[:space:]' < "$REPO/.rigpath"); else RIG_DIR="$REPO/.rig"; fi
+SESSION_DIR="$RIG_DIR/memory/sessions"
+SESSION_FILE="$SESSION_DIR/session-${PPID}.json"
 
-Do not use today's date as a boundary — it breaks for sessions that span midnight
-or are resumed days later.
+# Primary: /tmp sentinel written by session-start.sh
+SESSION_UUID=$(cat "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true)
+TENTATIVE_NAME=""
 
-Use file signals as cross-reference only — to catch work that may have compacted
-out of the context window, not to override what you already know:
+# Read session file for UUID (if /tmp sentinel missing) and tentative name
+if [[ -f "$SESSION_FILE" ]]; then
+  [[ -z "$SESSION_UUID" ]] && \
+    SESSION_UUID=$(python3 -c "import json; print(json.load(open('$SESSION_FILE')).get('anchor') or '')" 2>/dev/null || true)
+  TENTATIVE_NAME=$(python3 -c "import json; print(json.load(open('$SESSION_FILE')).get('tentative_name') or '')" 2>/dev/null || true)
+fi
 
-1. **`<!-- session-end -->` markers in PROGRESS.md** (cross-reference)
-   The `stop.sh` hook appends `<!-- session-end YYYY-MM-DD HH:MM -->` automatically.
-   Entries above the most recent marker are candidates to correlate with your context.
+# Fallback: scan sessions/ for most recently modified active session
+if [[ -z "$SESSION_UUID" ]] && [[ -d "$SESSION_DIR" ]]; then
+  FALLBACK_FILE=$(ls -t "$SESSION_DIR"/session-*.json 2>/dev/null \
+    | xargs grep -l '"status": "active"' 2>/dev/null | head -1 || true)
+  if [[ -n "$FALLBACK_FILE" ]]; then
+    SESSION_UUID=$(python3 -c "import json; print(json.load(open('$FALLBACK_FILE')).get('anchor') or '')" 2>/dev/null || true)
+    SESSION_FILE="$FALLBACK_FILE"
+  fi
+fi
+```
 
-2. **`Last updated:` datetime in the previous CONTEXT_SNAPSHOT** (boundary fallback)
-   If markers are absent or ambiguous, use the snapshot's `**Last updated:**` datetime
-   as an approximate session-start boundary when scanning PROGRESS.md entries.
+### Step 2 — Collect this session's work
 
-3. **PROGRESS.md ordering** (last resort for compacted context)
-   If context window is short and you cannot recall specifics, take entries at the
-   top of PROGRESS.md that plausibly match this session and stop at the prior boundary.
+**Primary signal: your conversation context.** Enumerate directly what was done
+this session — PRs merged or opened, tasks completed, issues resolved. This is
+always the most accurate signal. The tentative name (if set) is a pre-compaction
+anchor from earlier in this session — use it as a starting point if context was lost.
+
+**Every `## ` entry header you write to PROGRESS.md must include `<!-- sid:UUID -->`
+at the end of the line** (read UUID from `/tmp/.rig-session-${PPID}.uuid`). This is
+what enables UUID-keyed session attribution.
+
+**File signal — UUID-keyed PROGRESS entries:**
+```bash
+grep "^## .*<!-- sid:${SESSION_UUID} -->" "$RIG_DIR/memory/PROGRESS.md" 2>/dev/null || true
+```
+
+**Fallback — session-end marker boundary (legacy, no UUID):**
+Find the most recent `<!-- session-end -->` marker; entries above it belong to this session.
 
 **If conversation context and file signals conflict, trust the conversation.**
-Files may be stale, markers may be missing or duplicated across tabs. Your direct
-knowledge of this session is authoritative.
 
-### Check for an existing session name
+### Step 3 — Build the name
 
-Read the `**Session name:**` field from CONTEXT_SNAPSHOT.md (the previous
-snapshot, before this /wrap rewrites it).
+If a `tentative_name` exists: use it as the base. If the session delivered exactly
+what it described, confirm it (drop `[tentative]`). If scope changed, update it.
+If no tentative name: derive from scratch.
 
-- **If blank / absent:** suggest a fresh session name covering all this session's work.
-- **If already set:** the session was named in a prior /wrap or by the user directly.
-  Suggest **appending** new work to the existing name rather than replacing it:
-
-  > **Session already named:** `fix step accordion layout #184`
-  > **New work this wrap:** `feat custom-permissions #152`
-  > **Updated suggestion:** `fix step accordion layout #184 | feat custom-permissions #152`
-
-### Build the name
-
-Count one "unit" per merged PR, completed task, or significant fix. Use the
-**tiered format** from `/session-name` (same logic — see that command for full detail):
+Count one "unit" per merged PR, completed task, or significant fix. Use the tiered format:
 
 - **≤5 units:** `type short-desc #N | type short-desc #N | ...`
 - **6–15 units:** `type(area, area) | type(area) x3 | type x2`
 - **16+ units:** `sprint: N issues · feat/X fix/Y chore/Z · #A–#B`
 
-Keep under ~100 characters. Drop smallest groups if over.
+Keep under ~100 characters.
 
-### Examples
-
-```
-fix step accordion layout #184 | fix h3.steps remaining partials #186
-feat(auth, dashboard) | fix(billing x4, ui) | chore x3
-sprint: 23 issues · feat/4 fix/15 chore/4 · #130–#152
-```
-
-### Output
+### Step 4 — Present and confirm
 
 > **Suggested session name:**
-> `fix step accordion layout #184 | fix h3.steps remaining partials #186`
+> `fix(mobile): Expo Go runtime fixes + PR #360 merge [#359]`
 
-Then invite the user to apply it:
+> To apply: say "use that name", "ship it", or "lgtm".
 
-> To apply this name, run `/session-name` or say "use that name".
+### Step 5 — After confirmation: write to session file, move to done/
 
-After the user confirms, **update the `**Session name:**` field in
-`.rig/memory/CONTEXT_SNAPSHOT.md`** to match. This is how future /wrap calls
-detect an existing name and suggest appends instead of replacements.
-
-Then run:
+Write the final data atomically — write to a temp file, then rename to the
+destination in a single `os.rename` call. This prevents a crash between the
+write and the move from leaving a `status: complete` file stranded in `sessions/`
+(which the orphan scan would never surface, since it only looks for `status: active`).
 
 ```bash
-touch "/tmp/.rig-session-name-set-${PPID}"
+CONFIRMED_NAME="<the confirmed name>"
+DONE_DIR="$SESSION_DIR/done"
+mkdir -p "$DONE_DIR"
+DEST="$DONE_DIR/session-$(date +%Y%m%d)-${SESSION_UUID}.json"
+
+python3 - <<PYEOF
+import json, os
+with open("$SESSION_FILE") as f:
+    d = json.load(f)
+d["final_name"] = "$CONFIRMED_NAME"
+d["status"] = "complete"
+tmp = "$DEST" + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(d, f, indent=2)
+os.rename(tmp, "$DEST")
+PYEOF
+
+rm -f "$SESSION_FILE" 2>/dev/null || true
+rm -f "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
 ```
 
-This sentinel tells `session-end.sh` that this session owns the name, preventing
-a concurrent sibling session from inheriting it when it writes its minimal checkpoint.
+**Do NOT write Session name to CONTEXT_SNAPSHOT.md.** CONTEXT_SNAPSHOT contains
+project state only (branch, PRs, roadmap, key facts). Session names live in session files.
 
-If nothing meaningful shipped this session (pure exploration, no PRs, no
-completions), skip this step silently.
+### Step 6 — Surface orphan sessions
+
+After completing this session, scan `$SESSION_DIR` for remaining `.json` files
+(not in `done/`) with `"status": "active"`:
+
+```bash
+for f in "$SESSION_DIR"/session-*.json; do
+  [[ -f "$f" ]] || continue
+  STATUS=$(python3 -c "import json; print(json.load(open('$f')).get('status',''))" 2>/dev/null)
+  STARTED=$(python3 -c "import json; print(json.load(open('$f')).get('started_at','?'))" 2>/dev/null)
+  NAME=$(python3 -c "import json; d=json.load(open('$f')); print(d.get('tentative_name') or d.get('anchor','?'))" 2>/dev/null)
+  if [[ "$STATUS" == "active" ]]; then
+    echo "⚠ Orphan session (active, unwrapped): $NAME (started $STARTED, file: $(basename $f))"
+  elif [[ "$STATUS" == "complete" ]]; then
+    # complete but not moved to done/ — write step finished but rename was interrupted
+    echo "⚠ Orphan session (complete, not moved to done/): $NAME (file: $(basename $f))"
+    echo "   Move manually: mv '$f' '$DONE_DIR/'"
+  fi
+done
+```
+
+Surface any found to the user. They may be active in another tab — do not delete
+them without asking.
+
+If nothing meaningful shipped this session (pure exploration, no PRs, no completions),
+skip the naming step silently but still run the orphan scan.
 
 ---
 
@@ -472,16 +517,19 @@ rm -f "$RIG_DIR/memory/.wrap-needed" 2>/dev/null || true
 # Release the concurrent session lock
 rm -f "$RIG_DIR/memory/.snapshot-write-in-progress" 2>/dev/null || true
 
-# Clear any stale compact checkpoint — the full snapshot supersedes it
-rm -f "$RIG_DIR/memory/.compact-checkpoint.md" 2>/dev/null || true
+# Clear this session's compact checkpoint — the full snapshot supersedes it
+rm -f "$RIG_DIR/memory/.compact-checkpoint-${PPID}.md" 2>/dev/null || true
+
+# Clear /tmp UUID sentinel (session file already moved to done/ by naming step)
+rm -f "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
 ```
 
-Log: "`.wrap-needed` cleared. Concurrent session lock released. Compact checkpoint cleared."
+Log: "`.wrap-needed` cleared. Concurrent session lock released. Compact checkpoint cleared. UUID sentinel cleared."
 
 `.wrap-needed` signals to `stop.sh` that `/wrap` has run and no flag should be
 written until the next commit creates new unexpanded stubs.
 `.snapshot-write-in-progress` signals to concurrent sessions that this snapshot write is complete.
-`.compact-checkpoint.md` is cleared so the next session reads the authoritative
+`.compact-checkpoint-{PPID}.md` is cleared so the next session reads the authoritative
 `CONTEXT_SNAPSHOT.md` rather than a stale post-compaction checkpoint.
 
 ---

--- a/templates/project/.claude/hooks/pre-compact.sh
+++ b/templates/project/.claude/hooks/pre-compact.sh
@@ -2,10 +2,10 @@
 # pre-compact.sh
 #
 # Runs before Claude Code compacts the context (PreCompact event).
-# Writes a minimal checkpoint to $RIG_DIR/memory/.compact-checkpoint.md
-# capturing current branch, last commit, active task, and last progress entry.
-# The checkpoint is read back by post-compact.sh (same session) and by
-# session-start.sh when source=compact (new session after compaction).
+# Writes a minimal checkpoint to $RIG_DIR/memory/.compact-checkpoint-{PPID}.md
+# capturing current branch, last commit, active task, session anchor, and
+# tentative name. The checkpoint is read back by post-compact.sh (same session)
+# and by session-start.sh when source=compact (new session after compaction).
 #
 # Also outputs a compactionSummary so the checkpoint survives in the
 # compacted summary itself.
@@ -46,11 +46,38 @@ if [[ -f "$PROGRESS_FILE" ]]; then
 fi
 
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
-SESSION_NAME="none"
+SESSION_ANCHOR="none"
+TENTATIVE_NAME="none"
 CONTEXT_HEADER=""
+
+# ── Read session identity from session file (UUID model) ──────────────────────
+SESSION_FILE="$RIG_DIR/memory/sessions/session-${PPID}.json"
+if [[ -f "$SESSION_FILE" ]]; then
+  # Single python3 call for both fields — halves subprocess cost and avoids
+  # a race where the file changes between two sequential reads.
+  _session_data=$(SESSION_F="$SESSION_FILE" python3 -c "
+import json, os, sys
+try:
+    d = json.load(open(os.environ['SESSION_F']))
+    sys.stdout.write((d.get('anchor') or 'none') + '\n')
+    sys.stdout.write((d.get('tentative_name') or 'none') + '\n')
+except Exception:
+    sys.stdout.write('none\nnone\n')
+" 2>/dev/null || printf 'none\nnone\n')
+  SESSION_ANCHOR=$(printf '%s' "$_session_data" | head -1)
+  TENTATIVE_NAME=$(printf '%s' "$_session_data" | tail -n +2 | head -1)
+  [[ -z "$SESSION_ANCHOR" ]] && SESSION_ANCHOR="none"
+  [[ -z "$TENTATIVE_NAME" ]] && TENTATIVE_NAME="none"
+elif [[ -f "$SNAPSHOT" ]]; then
+  # Backward-compat: session started before UUID system was installed.
+  # Try to read the legacy "Session name:" field written by old /wrap.
+  _legacy=$(grep "^\*\*Session name:\*\*" "$SNAPSHOT" 2>/dev/null \
+    | sed 's/\*\*Session name:\*\* *//' | head -1 || true)
+  [[ -n "$_legacy" ]] && TENTATIVE_NAME="$_legacy"
+fi
+# ─────────────────────────────────────────────────────────────────────────────
+
 if [[ -f "$SNAPSHOT" ]]; then
-  SESSION_NAME=$(grep -m1 "^\*\*Session name:\*\*" "$SNAPSHOT" 2>/dev/null \
-    | sed 's/\*\*Session name:\*\* *//' || echo "none")
   # Extract the header section (everything before the first --- divider) for
   # post-compaction orientation; agent can read project state without needing
   # the full snapshot file. Capped at 25 lines to guard against malformed
@@ -67,7 +94,8 @@ cat > "$CHECKPOINT" <<CPEOF
 **Last commit:** ${LAST_COMMIT}
 **Active task:** ${ACTIVE_TASK}
 **Last progress entry:** ${LAST_PROGRESS}
-**Session name:** ${SESSION_NAME}
+**Session anchor:** ${SESSION_ANCHOR}
+**Session tentative name:** ${TENTATIVE_NAME}
 
 ---
 
@@ -77,7 +105,7 @@ CPEOF
 # ── Output compactionSummary ───────────────────────────────────────────────────
 
 if command -v python3 >/dev/null 2>&1; then
-  SUMMARY="Branch: ${BRANCH} | Last commit: ${LAST_COMMIT} | Active task: ${ACTIVE_TASK} | Last progress: ${LAST_PROGRESS} | Session: ${SESSION_NAME}"
+  SUMMARY="Branch: ${BRANCH} | Last commit: ${LAST_COMMIT} | Active task: ${ACTIVE_TASK} | Last progress: ${LAST_PROGRESS} | Session anchor: ${SESSION_ANCHOR} | Tentative: ${TENTATIVE_NAME}"
   printf '%s' "$SUMMARY" | python3 -c "
 import json, sys
 summary = sys.stdin.read()

--- a/templates/project/.claude/hooks/session-end.sh
+++ b/templates/project/.claude/hooks/session-end.sh
@@ -8,7 +8,8 @@
 # Source values and behaviour:
 #   logout / prompt_input_exit — user closed the session
 #       Write .wrap-needed if /wrap hasn't run and the session had meaningful
-#       commits. Write minimal checkpoint. Log session end.
+#       commits. Write minimal checkpoint. Mark session file ended-no-wrap.
+#       Clean /tmp UUID sentinel.
 #   clear — context was cleared; session will continue in a new context window
 #       Log "context cleared" to session log. Do NOT set .wrap-needed.
 #   resume — new session is starting; nothing to clean up here
@@ -65,7 +66,7 @@ write_minimal_checkpoint() {
       >> "$SESSION_LOG" 2>/dev/null || true
     return
   fi
-  local branch commit active_task session_name=""
+  local branch commit active_task session_anchor=""
   branch=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   commit=$(git -C "$REPO" log -1 --format="%h %s" 2>/dev/null || echo "none")
   active_task=""
@@ -73,12 +74,8 @@ write_minimal_checkpoint() {
     active_task=$(ls "$RIG_DIR/tasks/active"/*.md 2>/dev/null \
       | head -1 | xargs basename 2>/dev/null || true)
   fi
-  # Preserve session name only if this session owns it — prevents inheriting a
-  # name written by a concurrent sibling that ran /session-name or /wrap.
-  if [[ -f "/tmp/.rig-session-name-set-${PPID}" ]] && [[ -f "$SNAPSHOT" ]]; then
-    session_name=$(grep -m1 "^\*\*Session name:\*\*" "$SNAPSHOT" 2>/dev/null \
-      | sed 's/\*\*Session name:\*\* *//' || true)
-  fi
+  # Read session anchor from /tmp sentinel (UUID model — no CONTEXT_SNAPSHOT Session name field)
+  session_anchor=$(cat "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true)
 
   {
     echo "# Context Snapshot — session-end checkpoint"
@@ -90,7 +87,7 @@ write_minimal_checkpoint() {
     echo "**Branch:** $branch"
     echo "**Last commit:** $commit"
     [[ -n "$active_task" ]] && echo "**Active task:** $active_task"
-    [[ -n "$session_name" ]] && echo "**Session name:** $session_name"
+    [[ -n "$session_anchor" ]] && echo "**Session anchor:** $session_anchor"
     echo ""
     echo "---"
     echo ""
@@ -133,7 +130,26 @@ case "$SOURCE" in
     fi
 
     rm -f "$RIG_DIR/memory/.compact-checkpoint-${PPID}.md" 2>/dev/null || true
-    rm -f "/tmp/.rig-session-name-set-${PPID}" 2>/dev/null || true
+    rm -f "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
+
+    # Mark session file as ended-without-wrap so orphan detection in /wrap can
+    # distinguish "session exited without wrapping" from "still active in another tab"
+    SESSION_FILE="$RIG_DIR/memory/sessions/session-${PPID}.json"
+    if [[ -f "$SESSION_FILE" ]]; then
+      # Pass SESSION_FILE via env var to avoid SyntaxError if path contains a quote.
+      SESSION_F="$SESSION_FILE" python3 -c "
+import json, os
+try:
+    p = os.environ['SESSION_F']
+    with open(p) as f:
+        d = json.load(f)
+    d['status'] = 'ended-no-wrap'
+    with open(p, 'w') as f:
+        json.dump(d, f, indent=2)
+except Exception:
+    pass
+" 2>/dev/null || true
+    fi
 
     echo "[$(date +%H:%M:%S)] SESSION_END: source=${SOURCE} — session terminated" \
       >> "$SESSION_LOG" 2>/dev/null || true

--- a/templates/project/.claude/hooks/session-start.sh
+++ b/templates/project/.claude/hooks/session-start.sh
@@ -11,6 +11,11 @@
 #                       falls back to CONTEXT_SNAPSHOT.md if checkpoint absent
 #   clear             — inject minimal orientation (project name + run /status)
 #
+# Session identity: creates $RIG_DIR/memory/sessions/session-{PPID}.json and
+# /tmp/.rig-session-{PPID}.uuid on startup/resume/compact/clear. These anchor
+# all PROGRESS entries and session-end markers to a specific session, enabling
+# multi-session isolation and post-compaction name recovery.
+#
 # Output: JSON with hookSpecificOutput.additionalContext
 # Falls through silently (exit 0, no output) on any error or missing files.
 
@@ -40,6 +45,8 @@ fi
 SNAPSHOT="$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
 WRAP_NEEDED="$RIG_DIR/memory/.wrap-needed"
 POST_MERGE_PENDING="$RIG_DIR/memory/.post-merge-pending"
+SESSION_DIR="$RIG_DIR/memory/sessions"
+SESSION_FILE="$SESSION_DIR/session-${PPID}.json"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -72,11 +79,61 @@ print(json.dumps(out))
   fi
 }
 
+# Create a new session file and /tmp UUID sentinel for this process.
+# Uses env vars for all dynamic values to avoid injection via branch names.
+create_session_identity() {
+  mkdir -p "$SESSION_DIR"
+  local branch uuid started
+  branch=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  uuid=$(python3 -c "import uuid; print(str(uuid.uuid4())[:8])" 2>/dev/null \
+    || printf '%s' "$(date +%s)" | md5sum 2>/dev/null | cut -c1-8 \
+    || date +%s)
+  started=$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S)
+  RIG_ANC="$uuid" RIG_PID="$PPID" RIG_STARTED="$started" RIG_BRANCH="$branch" \
+  python3 -c "
+import json, os
+print(json.dumps({
+    'anchor': os.environ['RIG_ANC'],
+    'pid': int(os.environ['RIG_PID']),
+    'started_at': os.environ['RIG_STARTED'],
+    'branch': os.environ['RIG_BRANCH'],
+    'tentative_name': None,
+    'final_name': None,
+    'status': 'active'
+}, indent=2))
+" 2>/dev/null > "$SESSION_FILE" || true
+  printf '%s' "$uuid" > "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
+}
+
+# Restore /tmp UUID from an existing session file (e.g. after tmp cleanse or restart).
+restore_session_uuid() {
+  local existing_uuid
+  # Pass SESSION_FILE via env var — avoids python3 SyntaxError if path contains a quote.
+  existing_uuid=$(SESSION_F="$SESSION_FILE" python3 -c "
+import json, os
+try:
+    print(json.load(open(os.environ['SESSION_F'])).get('anchor',''))
+except Exception:
+    pass
+" 2>/dev/null || true)
+  [[ -n "$existing_uuid" ]] && printf '%s' "$existing_uuid" > "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
+}
+
 # ── Dispatch by source ────────────────────────────────────────────────────────
 
 case "$SOURCE" in
   startup|resume)
     [[ ! -f "$SNAPSHOT" ]] && exit 0
+
+    # ── Create or restore session identity ───────────────────────────────────
+    if [[ ! -f "$SESSION_FILE" ]]; then
+      create_session_identity
+    else
+      # Always restore /tmp sentinel — may have been cleared by tmp cleanse or restart
+      restore_session_uuid
+    fi
+    # ─────────────────────────────────────────────────────────────────────────
+
     CONTEXT=$(cat "$SNAPSHOT")
     WARNINGS=$(flag_warnings)
     if [[ -n "$WARNINGS" ]]; then
@@ -87,9 +144,83 @@ case "$SOURCE" in
     ;;
 
   compact)
+    # ── Re-establish session identity after compaction ────────────────────────
+    # Two scenarios:
+    #   A) Same process (in-session compaction): PPID unchanged, session file exists.
+    #   B) New process (new tab from compacted context): different PPID, no session
+    #      file for this PPID. Fall back to reading anchor from the most recent
+    #      compact checkpoint written by pre-compact.sh.
+    SESSION_UUID=""
+    PRIOR_CKPT=""
+    if [[ -f "$SESSION_FILE" ]]; then
+      # Scenario A — same process
+      # Pass SESSION_FILE via env var to avoid SyntaxError if path contains a quote.
+      SESSION_UUID=$(SESSION_F="$SESSION_FILE" python3 -c "
+import json, os
+try:
+    d = json.load(open(os.environ['SESSION_F']))
+    print(d.get('anchor') or '')
+except Exception:
+    pass
+" 2>/dev/null || true)
+    else
+      # Scenario B — new process; find anchor from most recent checkpoint.
+      # Skip checkpoints that belong to a live concurrent session (their PPID
+      # has an active session file) to avoid cross-session identity clobbering.
+      mkdir -p "$SESSION_DIR"
+      while IFS= read -r _ckpt; do
+        [[ -f "$_ckpt" ]] || continue
+        _ckpt_ppid=$(basename "$_ckpt" .md | sed 's/.*-//')
+        _ckpt_sf="$SESSION_DIR/session-${_ckpt_ppid}.json"
+        if [[ -f "$_ckpt_sf" ]] && grep -q '"status": "active"' "$_ckpt_sf" 2>/dev/null; then
+          continue  # checkpoint belongs to a live session — skip
+        fi
+        PRIOR_CKPT="$_ckpt"
+        break
+      done < <(ls -t "$RIG_DIR/memory"/.compact-checkpoint-*.md 2>/dev/null || true)
+      if [[ -n "$PRIOR_CKPT" ]] && [[ -f "$PRIOR_CKPT" ]]; then
+        SESSION_UUID=$(grep "^\*\*Session anchor:\*\*" "$PRIOR_CKPT" 2>/dev/null \
+          | sed 's/\*\*Session anchor:\*\* *//' | tr -d '[:space:]')
+        [[ "$SESSION_UUID" == "none" ]] && SESSION_UUID=""
+        PRIOR_TENTATIVE=$(grep "^\*\*Session tentative name:\*\*" "$PRIOR_CKPT" 2>/dev/null \
+          | sed 's/\*\*Session tentative name:\*\* *//')
+        [[ "$PRIOR_TENTATIVE" == "none" ]] && PRIOR_TENTATIVE=""
+      fi
+      if [[ -n "$SESSION_UUID" ]]; then
+        # Create a new session file for this process, inheriting the prior anchor.
+        # Uses env vars to avoid injection risk from branch names or tentative names.
+        compact_branch=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+        compact_started=$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S)
+        RIG_ANC="$SESSION_UUID" RIG_PID="$PPID" RIG_STARTED="$compact_started" \
+        RIG_BRANCH="$compact_branch" RIG_TENT="${PRIOR_TENTATIVE:-}" \
+        python3 -c "
+import json, os
+t = os.environ.get('RIG_TENT') or None
+print(json.dumps({
+    'anchor': os.environ['RIG_ANC'],
+    'pid': int(os.environ['RIG_PID']),
+    'started_at': os.environ['RIG_STARTED'],
+    'branch': os.environ['RIG_BRANCH'],
+    'tentative_name': t,
+    'final_name': None,
+    'status': 'active',
+    'continued_from_compaction': True
+}, indent=2))
+" 2>/dev/null > "$SESSION_FILE" || true
+      fi
+    fi
+    [[ -n "$SESSION_UUID" ]] && printf '%s' "$SESSION_UUID" \
+      > "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
+    # ─────────────────────────────────────────────────────────────────────────
+
     COMPACT_CHECKPOINT="$RIG_DIR/memory/.compact-checkpoint-${PPID}.md"
     if [[ ! -f "$COMPACT_CHECKPOINT" ]]; then
-      COMPACT_CHECKPOINT=$(ls -t "$RIG_DIR/memory"/.compact-checkpoint-*.md 2>/dev/null | head -1 || true)
+      # In Scenario B, reuse the checkpoint already found during identity resolution
+      # to avoid a second ls scan that could pick a different (possibly wrong) file.
+      COMPACT_CHECKPOINT="${PRIOR_CKPT:-}"
+      if [[ -z "$COMPACT_CHECKPOINT" ]]; then
+        COMPACT_CHECKPOINT=$(ls -t "$RIG_DIR/memory"/.compact-checkpoint-*.md 2>/dev/null | head -1 || true)
+      fi
     fi
     if [[ -n "$COMPACT_CHECKPOINT" ]] && [[ -f "$COMPACT_CHECKPOINT" ]]; then
       CONTEXT=$(cat "$COMPACT_CHECKPOINT")
@@ -107,6 +238,14 @@ case "$SOURCE" in
     ;;
 
   clear)
+    # /clear continues the same process (same PPID), so reuse the existing
+    # session file and UUID if they exist. Create fresh only if absent.
+    if [[ ! -f "$SESSION_FILE" ]]; then
+      create_session_identity
+    else
+      restore_session_uuid
+    fi
+
     PROJECT_NAME=$(basename "$REPO")
     emit_context "Project: ${PROJECT_NAME}. Session cleared — run /status for current state."
     ;;

--- a/templates/project/.claude/hooks/stop.sh
+++ b/templates/project/.claude/hooks/stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # stop.sh
 #
 # Runs after every Claude Code agent turn (Stop event).
@@ -58,17 +58,23 @@ if [[ -f "$SNAPSHOT" ]] && grep -q "^\*\*Last updated:\*\*" "$SNAPSHOT" 2>/dev/n
 fi
 
 # ── Append session-end marker to PROGRESS.md ─────────────────────────────────
-# A lightweight HTML comment that /wrap and /post-merge use as a boundary
-# when collecting entries for session naming. Safe to parse, invisible in
-# rendered Markdown.
+# Includes session UUID (sid:) so /wrap can attribute entries to the right
+# session even when multiple tabs are running concurrently.
 # Skip if PROGRESS.md doesn't exist yet.
 if [[ -f "$PROGRESS" ]]; then
+  SESSION_UUID=$(cat "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true)
   # Idempotent: don't append if the last non-blank line is already a marker
   LAST_MEANINGFUL=$(grep -v '^[[:space:]]*$' "$PROGRESS" | tail -1)
   if [[ "$LAST_MEANINGFUL" != "<!-- session-end"* ]]; then
-    printf "\n<!-- session-end %s -->\n" "$NOW_FULL" >> "$PROGRESS"
-    echo "[$(date +%H:%M:%S)] STOP: session-end marker appended ($NOW_FULL)" \
-      >> "$SESSION_LOG"
+    if [[ -n "$SESSION_UUID" ]]; then
+      printf "\n<!-- session-end %s sid:%s -->\n" "$NOW_FULL" "$SESSION_UUID" >> "$PROGRESS"
+      echo "[$(date +%H:%M:%S)] STOP: session-end marker appended ($NOW_FULL sid:$SESSION_UUID)" \
+        >> "$SESSION_LOG"
+    else
+      printf "\n<!-- session-end %s -->\n" "$NOW_FULL" >> "$PROGRESS"
+      echo "[$(date +%H:%M:%S)] STOP: session-end marker appended ($NOW_FULL, no UUID)" \
+        >> "$SESSION_LOG"
+    fi
   else
     echo "[$(date +%H:%M:%S)] STOP: session-end marker already present — skipped" \
       >> "$SESSION_LOG"

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -51,3 +51,12 @@ ERRORS_archive.md
 # and deleted by session-end.sh on session close. Gitignored — ephemeral, never committed.
 .compact-checkpoint.md
 .compact-checkpoint-*.md
+
+# sessions/ holds per-session identity files (session-{PPID}.json) created by
+# session-start.sh. Runtime state only — never committed. done/ holds completed
+# session records moved there by /wrap or /post-merge.
+sessions/
+
+# tips/ holds one-time-shown sentinel files for the feature discovery tips system.
+# Per-machine state — gitignored so tips re-fire on a fresh clone.
+tips/

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1464,7 +1464,7 @@ _is_rig_protected() {
   grep -q "session-end checkpoint" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
 }
 
-# ── TASK_252: session name ownership via /tmp sentinel ───────────────────────
+# ── UUID-based session anchor in write_minimal_checkpoint ────────────────────
 
 @test "session-end.sh: write_minimal_checkpoint omits session name when sentinel absent" {
   run_installer --strategy skip
@@ -1481,7 +1481,7 @@ _is_rig_protected() {
   printf '[10:01:00] PROGRESS stub: def5678 feat(x): second [#1]\n' >> "$session_log"
   rm -f "$rig_dir/memory/.snapshot-write-in-progress"
 
-  # No sentinel — this session never called /session-name
+  # No UUID sentinel — no anchor should appear
   echo '{"source": "logout"}' \
     | ( cd "$TEST_PROJECT" && RIG_SESSION_LOG="$session_log" bash "$session_end_hook" )
 
@@ -1490,7 +1490,7 @@ _is_rig_protected() {
   [ "$status" -ne 0 ]
 }
 
-@test "session-end.sh: write_minimal_checkpoint preserves session name when sentinel present" {
+@test "session-end.sh: write_minimal_checkpoint writes session anchor from UUID sentinel" {
   run_installer --strategy skip
   [ "$status" -eq 0 ]
 
@@ -1498,8 +1498,7 @@ _is_rig_protected() {
   local session_end_hook="$TEST_PROJECT/.claude/hooks/session-end.sh"
   local session_log="$TEMP_DIR/the-rig-session-test.log"
 
-  # Snapshot has this session's own name
-  printf '**Last updated:** 2026-01-01\n**Session name:** my-own-session\n\n---\n' \
+  printf '**Last updated:** 2026-01-01\n\n---\n' \
     > "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
   printf '[10:00:00] PROGRESS stub: abc1234 feat(x): first [#1]\n' >> "$session_log"
   printf '[10:01:00] PROGRESS stub: def5678 feat(x): second [#1]\n' >> "$session_log"
@@ -1508,15 +1507,15 @@ _is_rig_protected() {
   # Run via bash -c so $$ inside = PPID seen by session-end.sh
   local test_project="$TEST_PROJECT"
   bash -c "
-    touch \"/tmp/.rig-session-name-set-\$\$\"
+    printf '%s' 'anchor-uuid-test' > \"/tmp/.rig-session-\$\$.uuid\"
     cd \"$test_project\"
     echo '{\"source\": \"logout\"}' \
       | RIG_SESSION_LOG=\"$session_log\" bash \"$session_end_hook\"
-    rm -f \"/tmp/.rig-session-name-set-\$\$\" 2>/dev/null
+    rm -f \"/tmp/.rig-session-\$\$.uuid\" 2>/dev/null
   "
 
-  # This session's name must appear in the checkpoint
-  grep -q "my-own-session" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
+  # Session anchor must appear in the checkpoint
+  grep -q "anchor-uuid-test" "$rig_dir/memory/CONTEXT_SNAPSHOT.md"
 }
 
 # ── Session log path is per-project ──────────────────────────────────────────

--- a/tests/test_session_identity.bats
+++ b/tests/test_session_identity.bats
@@ -1,0 +1,279 @@
+#!/usr/bin/env bats
+# test_session_identity.bats
+#
+# Tests for the UUID-based session-identity system.
+#
+# PPID note: hooks use $PPID to scope /tmp sentinel files and session files.
+# When we run `(cd "$REPO" && exec bash hook.sh)`, exec replaces the subshell
+# process — so the hook's $PPID equals the test shell's $$. We write sentinel
+# files using $$ so they match what the hook will look for via $PPID.
+#
+# RIG_DIR note: hooks derive RIG_DIR from .rigpath or fall back to $REPO/.rig.
+# Tests use RIG_DIR inside REPO (no .rigpath) to avoid the .rigpath complexity.
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  REPO="$TMPDIR/repo"
+  RIG_DIR="$REPO/.rig"
+  mkdir -p "$REPO" "$RIG_DIR/memory/sessions" "$RIG_DIR/memory" "$RIG_DIR/tasks/active"
+  git -C "$REPO" init -q
+  git -C "$REPO" commit --allow-empty -m "initial" -q
+
+  HOOK_DIR="$TMPDIR/hooks"
+  mkdir -p "$HOOK_DIR"
+  cp "$(pwd)/templates/project/.claude/hooks/session-start.sh" "$HOOK_DIR/session-start.sh"
+  cp "$(pwd)/templates/project/.claude/hooks/stop.sh"          "$HOOK_DIR/stop.sh"
+  cp "$(pwd)/templates/project/.claude/hooks/session-end.sh"   "$HOOK_DIR/session-end.sh"
+  cp "$(pwd)/templates/project/.claude/hooks/pre-compact.sh"   "$HOOK_DIR/pre-compact.sh"
+  chmod +x "$HOOK_DIR"/*.sh
+
+  # Minimal CONTEXT_SNAPSHOT so startup case does not exit early
+  cat > "$RIG_DIR/memory/CONTEXT_SNAPSHOT.md" <<'EOF'
+# Context Snapshot
+**Last updated:** 2026-06-20 — test session
+**Branch:** main
+EOF
+
+  export RIG_SESSION_LOG="$TMPDIR/session.log"
+
+  # Temp file for hook stdout capture. Hooks are called via run_hook_exec which
+  # writes stdout here — we read it separately to avoid $() wrapping that would
+  # add an extra subshell layer and break PPID alignment.
+  RUN_OUTPUT_FILE="$TMPDIR/hook.out"
+
+  # Session files use PPID inside hooks. When run_hook_exec calls
+  # `(cd "$REPO" && exec bash hook.sh)` the subshell's PPID equals the test
+  # shell's $$. We confirmed this empirically: session-$$.json is created.
+  TEST_SESSION_FILE="$RIG_DIR/memory/sessions/session-$$.json"
+  TEST_UUID_FILE="/tmp/.rig-session-$$.uuid"
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+  rm -f "/tmp/.rig-session-$$.uuid" 2>/dev/null || true
+}
+
+# Run a hook; stdout goes to $RUN_OUTPUT_FILE.
+# Always call without $() wrapping — that would add an extra subshell layer
+# and break PPID alignment (hook's $PPID would no longer equal test's $$).
+#
+# We write $input to a temp file instead of using <<< because bash 3.2 on macOS
+# has a bug where here-strings + exec inside a function lose the stdin file
+# descriptor before the exec'd process can read it.
+run_hook_exec() {
+  local hook="$1"
+  # Avoid ${2:-{}} — bash 3.2 (macOS) has a bug where {} in a default value
+  # leaks an extra } into the result, producing invalid JSON.
+  local input; input="$2"
+  [[ -z "$input" ]] && input="{}"
+  local infile
+  infile=$(mktemp)
+  printf '%s' "$input" > "$infile"
+  (cd "$REPO" && exec bash "$HOOK_DIR/$hook" < "$infile" > "$RUN_OUTPUT_FILE") 2>/dev/null
+  rm -f "$infile"
+}
+
+# Convenience: read output captured by the last run_hook_exec call.
+hook_output() {
+  cat "$RUN_OUTPUT_FILE" 2>/dev/null || true
+}
+
+# ── session-start.sh ─────────────────────────────────────────────────────────
+
+@test "session-start: startup creates session file with anchor UUID" {
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+  [ -f "$TEST_SESSION_FILE" ]
+  ANCHOR=$(python3 -c "import json; print(json.load(open('$TEST_SESSION_FILE')).get('anchor',''))")
+  [ -n "$ANCHOR" ]
+  STATUS=$(python3 -c "import json; print(json.load(open('$TEST_SESSION_FILE')).get('status',''))")
+  [ "$STATUS" = "active" ]
+}
+
+@test "session-start: startup emits additionalContext JSON" {
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert 'hookSpecificOutput' in d
+assert 'additionalContext' in d['hookSpecificOutput']
+"
+}
+
+@test "session-start: resume restores /tmp UUID from existing session file" {
+  # Pre-create session file (simulates a session that lost its /tmp sentinel)
+  python3 -c "
+import json
+with open('$TEST_SESSION_FILE', 'w') as f:
+    json.dump({'anchor':'restoreme','pid':$$,'status':'active',
+               'tentative_name':None,'final_name':None,
+               'started_at':'2026-06-20T09:00:00','branch':'main'}, f)
+"
+  rm -f "$TEST_UUID_FILE"
+  run_hook_exec "session-start.sh" '{"source":"resume"}'
+  [ -f "$TEST_UUID_FILE" ]
+  UUID=$(cat "$TEST_UUID_FILE")
+  [ "$UUID" = "restoreme" ]
+}
+
+@test "session-start: compact reads anchor from checkpoint when no session file" {
+  # Write a checkpoint with a known anchor (simulating prior session's pre-compact output)
+  PRIOR_ANCHOR="comptest1"
+  cat > "$RIG_DIR/memory/.compact-checkpoint-9999.md" <<EOF
+## Compact checkpoint
+
+**Branch:** main
+**Last commit:** abc1234 — some commit
+**Active task:** none
+**Last progress entry:** none
+**Session anchor:** $PRIOR_ANCHOR
+**Session tentative name:** none
+EOF
+
+  # No session file for our $$
+  rm -f "$TEST_SESSION_FILE"
+
+  run_hook_exec "session-start.sh" '{"source":"compact"}'
+  # Should emit context from the checkpoint
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert 'hookSpecificOutput' in d, 'no hookSpecificOutput'
+assert 'additionalContext' in d['hookSpecificOutput'], 'no additionalContext'
+"
+}
+
+@test "session-start: clear reuses existing session file" {
+  python3 -c "
+import json
+with open('$TEST_SESSION_FILE', 'w') as f:
+    json.dump({'anchor':'existuuid','pid':$$,'status':'active',
+               'tentative_name':None,'final_name':None,
+               'started_at':'2026-06-20T09:00:00','branch':'main'}, f)
+"
+  run_hook_exec "session-start.sh" '{"source":"clear"}'
+  ANCHOR=$(python3 -c "import json; print(json.load(open('$TEST_SESSION_FILE')).get('anchor',''))")
+  [ "$ANCHOR" = "existuuid" ]
+}
+
+@test "session-start: unknown source exits silently with no output" {
+  OUTPUT=$(run_hook_exec "session-start.sh" '{"source":"unknown"}')
+  [ -z "$OUTPUT" ]
+}
+
+# ── stop.sh ──────────────────────────────────────────────────────────────────
+
+@test "stop: appends session-end marker with sid:UUID when UUID file present" {
+  echo "abc12345" > "$TEST_UUID_FILE"
+  printf '## 2026-06-20 — entry\n' > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "stop.sh" '{}'
+
+  grep -q "<!-- session-end.*sid:abc12345 -->" "$RIG_DIR/memory/PROGRESS.md"
+}
+
+@test "stop: appends plain marker when UUID file absent (backward compat)" {
+  rm -f "$TEST_UUID_FILE"
+  printf '## 2026-06-20 — entry\n' > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "stop.sh" '{}'
+
+  grep -q "<!-- session-end" "$RIG_DIR/memory/PROGRESS.md"
+  ! grep -q "sid:" "$RIG_DIR/memory/PROGRESS.md"
+}
+
+@test "stop: idempotent — does not double-append marker" {
+  echo "abc12345" > "$TEST_UUID_FILE"
+  printf "\n<!-- session-end 2026-06-20 09:00 sid:abc12345 -->\n" \
+    > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "stop.sh" '{}'
+
+  COUNT=$(grep -c "<!-- session-end" "$RIG_DIR/memory/PROGRESS.md")
+  [ "$COUNT" -eq 1 ]
+}
+
+# ── session-end.sh ───────────────────────────────────────────────────────────
+
+@test "session-end: logout marks session file ended-no-wrap" {
+  python3 -c "
+import json
+with open('$TEST_SESSION_FILE', 'w') as f:
+    json.dump({'anchor':'abc12345','pid':$$,'status':'active',
+               'tentative_name':None,'final_name':None,
+               'started_at':'2026-06-20T09:00:00','branch':'main'}, f)
+"
+  # Need unexpanded stubs so .wrap-needed gets written (which drives checkpoint)
+  echo "## stub <!-- Auto-logged by post-tool hook -->" > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "session-end.sh" '{"source":"logout"}'
+
+  STATUS=$(python3 -c "import json; print(json.load(open('$TEST_SESSION_FILE')).get('status',''))")
+  [ "$STATUS" = "ended-no-wrap" ]
+}
+
+@test "session-end: logout cleans /tmp UUID sentinel" {
+  echo "abc12345" > "$TEST_UUID_FILE"
+  echo "## stub <!-- Auto-logged by post-tool hook -->" > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "session-end.sh" '{"source":"logout"}'
+
+  [ ! -f "$TEST_UUID_FILE" ]
+}
+
+@test "session-end: minimal checkpoint has Session anchor field (not Session name)" {
+  echo "abc12345" > "$TEST_UUID_FILE"
+  echo "## stub <!-- Auto-logged by post-tool hook -->" > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "session-end.sh" '{"source":"logout"}'
+
+  grep -q "\*\*Session anchor:\*\*" "$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
+  ! grep -q "\*\*Session name:\*\*" "$RIG_DIR/memory/CONTEXT_SNAPSHOT.md"
+}
+
+@test "session-end: clear does not set .wrap-needed" {
+  echo "## stub <!-- Auto-logged by post-tool hook -->" > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "session-end.sh" '{"source":"clear"}'
+
+  [ ! -f "$RIG_DIR/memory/.wrap-needed" ]
+}
+
+# ── pre-compact.sh ───────────────────────────────────────────────────────────
+
+@test "pre-compact: writes Session anchor and tentative name from session file" {
+  python3 -c "
+import json
+with open('$TEST_SESSION_FILE', 'w') as f:
+    json.dump({'anchor':'compuuid','pid':$$,'status':'active',
+               'tentative_name':'feat phase2 [tentative]','final_name':None,
+               'started_at':'2026-06-20T09:00:00','branch':'main'}, f)
+"
+  run_hook_exec "pre-compact.sh" '{}'
+
+  CKPT="$RIG_DIR/memory/.compact-checkpoint-$$.md"
+  [ -f "$CKPT" ]
+  grep -q "\*\*Session anchor:\*\* compuuid" "$CKPT"
+  grep -q "\*\*Session tentative name:\*\* feat phase2" "$CKPT"
+  ! grep -q "\*\*Session name:\*\*" "$CKPT"
+}
+
+@test "pre-compact: uses none for anchor when no session file exists" {
+  rm -f "$TEST_SESSION_FILE"
+
+  run_hook_exec "pre-compact.sh" '{}'
+
+  CKPT="$RIG_DIR/memory/.compact-checkpoint-$$.md"
+  [ -f "$CKPT" ]
+  grep -q "\*\*Session anchor:\*\* none" "$CKPT"
+}
+
+@test "pre-compact: emits compactionSummary JSON with Session anchor field" {
+  run_hook_exec "pre-compact.sh" '{}'
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert 'hookSpecificOutput' in d, 'missing hookSpecificOutput'
+summary = d['hookSpecificOutput']['compactionSummary']
+assert 'Session anchor' in summary, f'Session anchor not in summary: {summary}'
+"
+}


### PR DESCRIPTION
## Summary

- Adds a stable UUID anchor to every Claude Code session, written at session start to `$RIG_DIR/memory/sessions/session-{PPID}.json` and `/tmp/.rig-session-{PPID}.uuid`
- Every `## ` entry written to `PROGRESS.md` is tagged `<!-- sid:UUID -->` for per-session attribution and post-compaction name recovery
- `/wrap`, `/post-merge`, and `/session-name` read the session file for the anchor + tentative name instead of CONTEXT_SNAPSHOT
- `stop.sh` appends `<!-- session-end DATE sid:UUID -->` markers; `/wrap` uses UUID-keyed grep to scope entries to this session
- Pre-compact checkpoint gains `**Session anchor:**` and `**Session tentative name:**` fields; session-start.sh Scenario B restores identity from the checkpoint after compaction

## Code-review fixes (applied before merge)

- **Path injection hardened**: `SESSION_FILE` now passed via `os.environ` in all `python3 -c` calls — prevents `SyntaxError` if the project path contains an apostrophe
- **Concurrent checkpoint guard**: Scenario B fallback skips checkpoints whose PPID has a live `status: active` session file, preventing cross-session identity clobbering
- **Pre-upgrade fallback**: `pre-compact.sh` reads legacy `Session name:` from CONTEXT_SNAPSHOT when no session file exists (smooth upgrade path)
- **Atomic session-file write**: `/wrap` and `/post-merge` write to `.tmp` then `os.rename` — crash-safe
- **Orphan scan extended**: Step 6 now surfaces `status: complete` files stranded outside `done/`
- **Efficiency**: two sequential `python3` forks in `pre-compact.sh` combined into one
- **Portability**: `stop.sh` shebang `#!/bin/bash` → `#!/usr/bin/env bash`
- **Stale instruction removed**: post-merge.md collection phase no longer references `Session name:` in CONTEXT_SNAPSHOT
- **Test updated**: `test_install.bats` #134 now tests UUID anchor in checkpoint instead of removed sentinel

## Test plan

- [x] `bats tests/` — 214 tests, all pass (16 new in `tests/test_session_identity.bats`)
- [x] `bash -n` syntax check passes on all modified hook scripts
- [x] No debug output, no commented-out code, no hardcoded secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
