### PR TITLE
fix(session): temp file cleanup + transcript pruning opt-in [#320]

### DIFF
--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -534,6 +534,28 @@ written until the next commit creates new unexpanded stubs.
 
 ---
 
+## Transcript pruning (opt-in)
+
+After flag cleanup, check for the `transcript-retention-days:` field in `$REPO/CLAUDE.md`.
+If present and set to a positive integer, prune old JSONL transcript files to prevent
+`/tmp` (or `~/.claude/projects/`) from filling up:
+
+```bash
+RETENTION_DAYS=$(grep "^transcript-retention-days:" "$REPO/CLAUDE.md" 2>/dev/null | awk '{print $2}' | tr -d '[:space:]')
+if [[ -n "$RETENTION_DAYS" && "$RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
+  PRUNED=$(find ~/.claude/projects/ -name "*.jsonl" -mtime "+${RETENTION_DAYS}" -print 2>/dev/null | wc -l | tr -d ' ')
+  find ~/.claude/projects/ -name "*.jsonl" -mtime "+${RETENTION_DAYS}" -delete 2>/dev/null || true
+  if [[ "$PRUNED" -gt 0 ]]; then
+    echo "Pruned ${PRUNED} JSONL transcript file(s) older than ${RETENTION_DAYS} days."
+  fi
+fi
+```
+
+This step is a no-op when `transcript-retention-days:` is absent or commented out.
+Report the pruned count only when files were actually deleted.
+
+---
+
 ## Notes
 
 - `.rig/memory/CONTEXT_SNAPSHOT.md` is gitignored — it lives on disk only, never committed

--- a/templates/project/.claude/hooks/session-start.sh
+++ b/templates/project/.claude/hooks/session-start.sh
@@ -134,6 +134,9 @@ case "$SOURCE" in
     fi
     # ─────────────────────────────────────────────────────────────────────────
 
+    # Passive cleanup: remove stale compact checkpoints older than 1 day.
+    find "$RIG_DIR/memory" -name ".compact-checkpoint-*.md" -mtime +1 -delete 2>/dev/null || true
+
     CONTEXT=$(cat "$SNAPSHOT")
     WARNINGS=$(flag_warnings)
     if [[ -n "$WARNINGS" ]]; then

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -151,6 +151,14 @@ commit-cleanup: yes
 | `no` | Footers are kept. Comment out or remove `.husky/commit-msg` and `.husky/post-commit` to disable the stripping. |
 
 ```
+# transcript-retention-days: 14
+```
+
+Optional. When set to a positive integer, `/wrap` prunes JSONL transcript files in
+`~/.claude/projects/` older than this many days. Prevents `/tmp` or disk from filling up
+after long-running projects. Commented out by default — uncomment and set a value to enable.
+
+```
 rig-gaps-push-target:
 ```
 

--- a/tests/test_command_lint.bats
+++ b/tests/test_command_lint.bats
@@ -134,3 +134,8 @@ _fail_with_list() {
 @test "ship.md: Step 9 skips housekeeping commit types in freshness check" {
   grep -qE "chore\(memory\)" "$COMMAND_DIR/ship.md"
 }
+
+@test "wrap.md: contains transcript pruning bash block with retention-days lookup" {
+  grep -q "transcript-retention-days" "$COMMAND_DIR/wrap.md"
+  grep -q "find ~/.claude/projects/" "$COMMAND_DIR/wrap.md"
+}

--- a/tests/test_session_identity.bats
+++ b/tests/test_session_identity.bats
@@ -277,3 +277,25 @@ summary = d['hookSpecificOutput']['compactionSummary']
 assert 'Session anchor' in summary, f'Session anchor not in summary: {summary}'
 "
 }
+
+@test "session-start: prunes compact checkpoints older than 1 day on startup" {
+  STALE_CKPT="$RIG_DIR/memory/.compact-checkpoint-stale99.md"
+  echo "# stale checkpoint" > "$STALE_CKPT"
+  # Set mtime to 50 hours ago. find -mtime +1 uses integer division (age_seconds/86400 > 1),
+  # so 25h would give 1 > 1 = false. 50h gives 180000/86400 = 2 > 1 = true.
+  python3 -c "import os, time; os.utime('$STALE_CKPT', (time.time()-180000, time.time()-180000))"
+
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+
+  [ ! -f "$STALE_CKPT" ]
+}
+
+@test "session-start: does not prune compact checkpoints younger than 1 day on startup" {
+  FRESH_CKPT="$RIG_DIR/memory/.compact-checkpoint-fresh99.md"
+  echo "# fresh checkpoint" > "$FRESH_CKPT"
+  # mtime is now — well within 1 day
+
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+
+  [ -f "$FRESH_CKPT" ]
+}


### PR DESCRIPTION
## Summary

- `session-start.sh`: passively prunes `.compact-checkpoint-*.md` older than 1 day on every startup — prevents accumulation of post-compaction artifacts
- `wrap.md`: adds opt-in JSONL transcript pruning step that reads `transcript-retention-days:` from `CLAUDE.md` and deletes matching `~/.claude/projects/*.jsonl` files; no-op when field absent
- `CLAUDE.md` template: adds `transcript-retention-days:` as a commented-out optional field in the Project settings section

Closes #320.

## Test plan

- [x] `bats tests/` — 217/217 pass
- [x] New test: `session-start: prunes compact checkpoints older than 1 day on startup`
- [x] New test: `session-start: does not prune compact checkpoints younger than 1 day on startup`
- [x] New test: `wrap.md: contains transcript pruning bash block with retention-days lookup`
- [x] Verified `session-end.sh` already cleans `/tmp/.rig-session-${PPID}.uuid` on logout (existing behavior, no change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)