### PR TITLE
feat(hooks): add feature discovery tips system [#317]

### DIFF
--- a/templates/project/.claude/hooks/session-start.sh
+++ b/templates/project/.claude/hooks/session-start.sh
@@ -105,6 +105,77 @@ print(json.dumps({
   printf '%s' "$uuid" > "/tmp/.rig-session-${PPID}.uuid" 2>/dev/null || true
 }
 
+# Returns tip text if the named tip should fire (and hasn't fired before).
+# Creates the per-tip sentinel on first call to prevent repeats.
+# Never called when .rig-tips-disabled exists — that check lives in collect_tips.
+show_tip() {
+  local name="$1"
+  local text="$2"
+  local sentinel="$RIG_DIR/memory/tips/.tip-${name}-shown"
+  [[ -f "$sentinel" ]] && return 0
+  mkdir -p "$RIG_DIR/memory/tips" 2>/dev/null || true
+  touch "$sentinel" 2>/dev/null || true
+  printf '%s' "$text"
+}
+
+# Evaluates all tip conditions and returns any tips that should fire, newline-separated.
+# Returns empty string if opt-out is set or no tip conditions are met.
+collect_tips() {
+  [[ -f "$RIG_DIR/memory/.rig-tips-disabled" ]] && return 0
+
+  local tips="" t=""
+
+  # Tip: session-name — fires after the first commit
+  local commit_count
+  commit_count=$(git -C "$REPO" rev-list --count HEAD 2>/dev/null || echo 0)
+  commit_count=$((commit_count + 0))
+  if [[ "$commit_count" -ge 1 ]]; then
+    t=$(show_tip "session-name" \
+      "Tip: run /session-name any time to anchor this session — names survive compaction." \
+      2>/dev/null || true)
+    [[ -n "$t" ]] && tips+="${t}"$'\n\n'
+  fi
+
+  # Tip: fewer-prompts — fires once a snapshot exists and the feature isn't already on
+  if [[ ! -f "$RIG_DIR/memory/.fewer-prompts-enabled" ]]; then
+    t=$(show_tip "fewer-prompts" \
+      "Tip: touch \$RIG_DIR/memory/.fewer-prompts-enabled to auto-scan permission patterns at every /wrap." \
+      2>/dev/null || true)
+    [[ -n "$t" ]] && tips+="${t}"$'\n\n'
+  fi
+
+  # Tip: task-tracking — fires after second session with no active task
+  local session_count active_tasks
+  session_count=$(ls "$RIG_DIR/memory/sessions"/session-*.json 2>/dev/null | wc -l || echo 0)
+  session_count=$((session_count + 0))
+  active_tasks=$(ls "$RIG_DIR/tasks/active"/*.md 2>/dev/null \
+    | grep -v "TASK_example" | wc -l || echo 0)
+  active_tasks=$((active_tasks + 0))
+  if [[ "$session_count" -gt 1 ]] && [[ "$active_tasks" -eq 0 ]]; then
+    t=$(show_tip "task-tracking" \
+      "Tip: Use /task to track multi-file work. Issues gate commits; tasks give the agent a recovery anchor." \
+      2>/dev/null || true)
+    [[ -n "$t" ]] && tips+="${t}"$'\n\n'
+  fi
+
+  # Tip: sprint — fires when 3+ distinct issue refs appear in PROGRESS.md
+  if [[ -f "$RIG_DIR/memory/PROGRESS.md" ]]; then
+    local issue_count
+    issue_count=$(grep -oE '\[#[0-9]+\]' "$RIG_DIR/memory/PROGRESS.md" 2>/dev/null \
+      | sort -u | wc -l || echo 0)
+    issue_count=$((issue_count + 0))
+    if [[ "$issue_count" -ge 3 ]]; then
+      t=$(show_tip "sprint" \
+        "Tip: Use /sprint to plan and batch parallel issues." \
+        2>/dev/null || true)
+      [[ -n "$t" ]] && tips+="${t}"$'\n\n'
+    fi
+  fi
+
+  tips="${tips%$'\n\n'}"
+  printf '%s' "$tips"
+}
+
 # Restore /tmp UUID from an existing session file (e.g. after tmp cleanse or restart).
 restore_session_uuid() {
   local existing_uuid
@@ -139,11 +210,12 @@ case "$SOURCE" in
 
     CONTEXT=$(cat "$SNAPSHOT")
     WARNINGS=$(flag_warnings)
-    if [[ -n "$WARNINGS" ]]; then
-      emit_context "${WARNINGS}"$'\n\n---\n\n'"${CONTEXT}"
-    else
-      emit_context "$CONTEXT"
-    fi
+    TIPS=$(collect_tips 2>/dev/null || true)
+
+    FULL_CTX="$CONTEXT"
+    [[ -n "$WARNINGS" ]] && FULL_CTX="${WARNINGS}"$'\n\n---\n\n'"${FULL_CTX}"
+    [[ -n "$TIPS" ]]    && FULL_CTX="${FULL_CTX}"$'\n\n---\n\n'"${TIPS}"
+    emit_context "$FULL_CTX"
     ;;
 
   compact)

--- a/templates/project/.rig/memory/.gitignore
+++ b/templates/project/.rig/memory/.gitignore
@@ -60,3 +60,7 @@ sessions/
 # tips/ holds one-time-shown sentinel files for the feature discovery tips system.
 # Per-machine state — gitignored so tips re-fire on a fresh clone.
 tips/
+
+# .rig-tips-disabled is the global opt-out sentinel for the tips system.
+# touch this file to disable all feature discovery tips for this project.
+.rig-tips-disabled

--- a/tests/test_session_identity.bats
+++ b/tests/test_session_identity.bats
@@ -299,3 +299,75 @@ assert 'Session anchor' in summary, f'Session anchor not in summary: {summary}'
 
   [ -f "$FRESH_CKPT" ]
 }
+
+# ── Feature discovery tips ────────────────────────────────────────────────────
+
+@test "tips: opt-out sentinel suppresses all tips" {
+  # Create conditions that would normally fire multiple tips
+  git -C "$REPO" commit --allow-empty -m "first commit" -q
+  touch "$RIG_DIR/memory/.rig-tips-disabled"
+
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+
+  # additionalContext must not contain any "Tip:" prefix
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert 'Tip:' not in ctx, f'found Tip: in context with opt-out enabled: {ctx[:200]}'
+"
+}
+
+@test "tips: session-name tip fires once and not again" {
+  git -C "$REPO" commit --allow-empty -m "first commit" -q
+
+  # First startup — tip should appear and sentinel should be created
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert '/session-name' in ctx, f'/session-name tip missing on first run: {ctx[:300]}'
+"
+  [ -f "$RIG_DIR/memory/tips/.tip-session-name-shown" ]
+
+  # Second startup — tip must not repeat
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert '/session-name' not in ctx, f'/session-name tip repeated on second run: {ctx[:300]}'
+"
+}
+
+@test "tips: fewer-prompts tip suppressed when .fewer-prompts-enabled exists" {
+  git -C "$REPO" commit --allow-empty -m "first commit" -q
+  touch "$RIG_DIR/memory/.fewer-prompts-enabled"
+
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert 'fewer-prompts-enabled' not in ctx, \
+  f'fewer-prompts tip fired when feature already enabled: {ctx[:300]}'
+"
+}
+
+@test "tips: sprint tip fires when 3+ distinct issue refs in PROGRESS.md" {
+  git -C "$REPO" commit --allow-empty -m "first commit" -q
+  # Write PROGRESS.md with 3 distinct issue refs
+  printf '## 2026-06-21 — work\n[#1] [#2] [#3]\n' > "$RIG_DIR/memory/PROGRESS.md"
+
+  run_hook_exec "session-start.sh" '{"source":"startup"}'
+
+  hook_output | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert '/sprint' in ctx, f'/sprint tip not fired with 3+ issue refs: {ctx[:300]}'
+"
+  [ -f "$RIG_DIR/memory/tips/.tip-sprint-shown" ]
+}


### PR DESCRIPTION
## Summary

- Adds `show_tip()` and `collect_tips()` helpers to `session-start.sh`; tips fire during `startup`/`resume` only and append to `additionalContext`
- Four tips with natural trigger conditions: `session-name` (first commit), `fewer-prompts` (snapshot exists, feature not yet on), `task-tracking` (second session with no active task), `sprint` (3+ distinct issue refs in PROGRESS.md)
- Each tip creates a sentinel in `tips/` on first show — never repeats per project
- Global opt-out: `touch .rig/memory/.rig-tips-disabled` disables all tips
- All tip code is best-effort (errors suppressed with `|| true`) — session-start never fails due to tips
- Adds `.rig-tips-disabled` to the memory `.gitignore` (`tips/` was already present from #323)

## Test plan

- [x] 4 new bats tests: opt-out suppresses tips, session-name fires once then stops, fewer-prompts suppressed when already enabled, sprint fires with 3+ issue refs
- [x] 225/225 tests pass

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)
