### PR TITLE
fix(hooks): use systemMessage instead of invalid hookSpecificOutput in compact hooks [#333]

### DIFF
--- a/templates/project/.claude/hooks/post-compact.sh
+++ b/templates/project/.claude/hooks/post-compact.sh
@@ -37,13 +37,7 @@ if command -v python3 >/dev/null 2>&1; then
   printf '%s' "$CONTEXT" | python3 -c "
 import json, sys
 ctx = sys.stdin.read()
-out = {
-    'hookSpecificOutput': {
-        'hookEventName': 'PostCompact',
-        'additionalContext': ctx
-    }
-}
-print(json.dumps(out))
+print(json.dumps({'systemMessage': ctx}))
 " 2>/dev/null || true
 fi
 

--- a/templates/project/.claude/hooks/post-compact.sh
+++ b/templates/project/.claude/hooks/post-compact.sh
@@ -2,8 +2,8 @@
 # post-compact.sh
 #
 # Runs after Claude Code finishes compacting the context (PostCompact event).
-# Reads the checkpoint written by pre-compact.sh and re-injects it as
-# additionalContext so the agent can resume mid-task without losing awareness
+# Reads the checkpoint written by pre-compact.sh and re-injects it as a
+# systemMessage so the agent can resume mid-task without losing awareness
 # of what branch, commit, and step were active before compaction.
 #
 # Falls back to CONTEXT_SNAPSHOT.md if no checkpoint exists.

--- a/templates/project/.claude/hooks/pre-compact.sh
+++ b/templates/project/.claude/hooks/pre-compact.sh
@@ -7,8 +7,8 @@
 # tentative name. The checkpoint is read back by post-compact.sh (same session)
 # and by session-start.sh when source=compact (new session after compaction).
 #
-# Also outputs a compactionSummary so the checkpoint survives in the
-# compacted summary itself.
+# Also outputs a systemMessage so the checkpoint content is injected into
+# the compaction context before Claude compacts.
 #
 # Falls through silently (exit 0, no output) on any error or missing files.
 
@@ -102,20 +102,13 @@ cat > "$CHECKPOINT" <<CPEOF
 ${CONTEXT_HEADER}
 CPEOF
 
-# ── Output compactionSummary ───────────────────────────────────────────────────
+# ── Output checkpoint as systemMessage ────────────────────────────────────────
 
-if command -v python3 >/dev/null 2>&1; then
-  SUMMARY="Branch: ${BRANCH} | Last commit: ${LAST_COMMIT} | Active task: ${ACTIVE_TASK} | Last progress: ${LAST_PROGRESS} | Session anchor: ${SESSION_ANCHOR} | Tentative: ${TENTATIVE_NAME}"
-  printf '%s' "$SUMMARY" | python3 -c "
-import json, sys
-summary = sys.stdin.read()
-out = {
-    'hookSpecificOutput': {
-        'hookEventName': 'PreCompact',
-        'compactionSummary': summary
-    }
-}
-print(json.dumps(out))
+if command -v python3 >/dev/null 2>&1 && [[ -f "$CHECKPOINT" ]]; then
+  CHECKPOINT_F="$CHECKPOINT" python3 -c "
+import json, os
+ctx = open(os.environ['CHECKPOINT_F']).read()
+print(json.dumps({'systemMessage': ctx}))
 " 2>/dev/null || true
 fi
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -635,7 +635,7 @@ print(len(s.get('permissions', {}).get('deny', [])))
   rm -rf "$tmpdir"
 }
 
-@test "post-compact: outputs additionalContext JSON when checkpoint exists" {
+@test "post-compact: outputs systemMessage JSON when checkpoint exists" {
   local tmpdir
   tmpdir=$(mktemp -d)
   git -C "$tmpdir" init -q
@@ -651,9 +651,8 @@ print(len(s.get('permissions', {}).get('deny', [])))
   echo "$output" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
-assert 'hookSpecificOutput' in d
-assert d['hookSpecificOutput']['hookEventName'] == 'PostCompact'
-assert 'additionalContext' in d['hookSpecificOutput']
+assert 'systemMessage' in d
+assert 'test-branch' in d['systemMessage']
 " 2>/dev/null
   [ "$?" -eq 0 ]
   rm -rf "$tmpdir"

--- a/tests/test_session_identity.bats
+++ b/tests/test_session_identity.bats
@@ -268,14 +268,13 @@ with open('$TEST_SESSION_FILE', 'w') as f:
   grep -q "\*\*Session anchor:\*\* none" "$CKPT"
 }
 
-@test "pre-compact: emits compactionSummary JSON with Session anchor field" {
+@test "pre-compact: emits systemMessage JSON with Session anchor field" {
   run_hook_exec "pre-compact.sh" '{}'
   hook_output | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
-assert 'hookSpecificOutput' in d, 'missing hookSpecificOutput'
-summary = d['hookSpecificOutput']['compactionSummary']
-assert 'Session anchor' in summary, f'Session anchor not in summary: {summary}'
+assert 'systemMessage' in d, 'missing systemMessage'
+assert 'Session anchor' in d['systemMessage'], f'Session anchor not in systemMessage: {d[\"systemMessage\"]}'
 "
 }
 


### PR DESCRIPTION
## Summary

- `pre-compact.sh` and `post-compact.sh` were emitting `hookSpecificOutput` with `hookEventName: "PreCompact"/"PostCompact"` — event names not in the Claude Code hook schema
- Both hooks failed JSON validation on every compaction, dropping their output silently
- Fix: replace `hookSpecificOutput` with the top-level `systemMessage` field, which is valid for all hook event types
- Updated 2 bats tests that asserted the old (broken) output shape

Closes #333

## Test plan

- [x] `bats tests/` — 228/228 pass
- [x] `pre-compact: emits systemMessage JSON with Session anchor field` — updated and passing
- [x] `post-compact: outputs systemMessage JSON when checkpoint exists` — updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
