### PR TITLE
fix: workflow accuracy fixes — Closes #N auto-close, sid:UUID marker, ERRORS.md trim, commit-msg bypass, git add gotcha

### DIFF
--- a/templates/project/.claude/commands/wrap.md
+++ b/templates/project/.claude/commands/wrap.md
@@ -174,7 +174,9 @@ Never delete entries — only move them.
 
 ## Marker prune step — PROGRESS.md session-end markers
 
-`stop.sh` appends `<!-- session-end YYYY-MM-DD HH:MM -->` after every agent turn.
+`stop.sh` appends `<!-- session-end YYYY-MM-DD HH:MM sid:UUID -->` after every agent turn
+(where `UUID` is the session anchor written to `/tmp/.rig-session-$PPID.uuid` at session start;
+omitted on pre-v1.21.0 installs that lack the UUID system).
 Over time these accumulate in PROGRESS.md without bound — they are not covered by
 the `## ` header trim above.
 
@@ -327,12 +329,16 @@ After checking `.rig/memory/ERRORS.md`, count the number of `## ` entry headers 
 3. Remove them from `.rig/memory/ERRORS.md`, leaving the 30 most recent entries
 4. **Append a trim stub** at the bottom of the trimmed `ERRORS.md`:
    ```
-   <!-- archived YYYY-MM-DD: [N] entries moved to ERRORS_archive.md. Categories: [3–6 word comma-separated summary, e.g. "bats non-interactive, gitleaks path, Husky sh-e, worktree writes"] -->
+   <!-- archived YYYY-MM-DD: [N] entries moved to ERRORS_archive.md. Categories: [3–6 word comma-separated summary, e.g. "bats non-interactive, gitleaks path, Husky sh-e, worktree writes"] — NEW ENTRIES GO ABOVE THIS LINE -->
    ```
    This lets the agent grep for a category keyword without loading the archive, and
    signals to the ERRORS.md logging step that the archive should be checked.
+   The `NEW ENTRIES GO ABOVE THIS LINE` marker is load-bearing: it prevents future
+   sessions from appending entries below the stub (which inverts newest-first order
+   and breaks the next trim's direction detection).
 
-Never delete entries — only move them.
+Never delete entries — only move them. ERRORS.md is always newest-first: add new
+`## ` entries at the **top**, never below the archived stub.
 
 ---
 

--- a/templates/project/.husky/commit-msg
+++ b/templates/project/.husky/commit-msg
@@ -77,7 +77,8 @@ case "$ISSUE_TRACKING" in
       echo "  Got:      $SUBJECT"
       echo "  Create the issue first: gh issue create ..."
       echo ""
-      echo "  To bypass: SKIP_COMMIT_VALIDATION=1 git commit ..."
+      echo "  Per-commit bypass (no ticket needed): add  # no-issue  as a line in the commit body"
+      echo "  Full validation bypass:               SKIP_COMMIT_VALIDATION=1 git commit ..."
       echo ""
       exit 1
     fi

--- a/templates/project/.rig/processes/UPGRADE_WORKFLOW.md
+++ b/templates/project/.rig/processes/UPGRADE_WORKFLOW.md
@@ -189,6 +189,23 @@ gh pr create --title "chore(rig): upgrade to vX.Y.Z" \
 
 ---
 
+## Known gotchas when extending hooks
+
+**`git add` inside a pre-commit hook fails on Git 2.39+**
+
+Git 2.39+ holds the index lock for the entire duration of the pre-commit hook. Any
+`git add` call inside the hook (or scripts it invokes) fails with:
+
+```
+fatal: Unable to create '.git/index.lock': File exists.
+Another git process seems to be running in this repository
+```
+
+Use `git update-index --add <file>` instead — it stages individual files without
+acquiring the index lock and works correctly inside hooks on all Git versions.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/templates/project/.rig/rules/git-conventions.md
+++ b/templates/project/.rig/rules/git-conventions.md
@@ -33,6 +33,13 @@ Optional body explaining WHY, not what. The diff shows what.
 
 **Issue reference:** `[#N]` at the end of the subject line. Required when a GitHub issue exists.
 
+> **`[#N]` is a reference, not an auto-close trigger.** GitHub auto-closes the linked issue
+> only when a commit containing `Closes #N`, `Fixes #N`, or `Resolves #N` in its **body**
+> is merged to the default branch — or when those keywords appear in the **PR body** of a
+> PR merging to the default branch. The `[#N]` subject-line format fulfils The Rig's
+> commit-msg validation and creates a hyperlink in GitHub history, but does not auto-close.
+> Always include `Closes #N` in the PR body (the `/ship` PR template already does this).
+
 ### Examples
 
 ```


### PR DESCRIPTION
## Summary

- **#335** — `git-conventions.md`: adds explicit callout that `[#N]` in the commit subject is a reference only; GitHub auto-close requires `Closes #N` in the PR body
- **#336 + #337** — `wrap.md`: corrects session-end marker format to include `sid:UUID`; adds `— NEW ENTRIES GO ABOVE THIS LINE` anchor to ERRORS.md trim stub to prevent oldest-at-top drift across multiple `/wrap` runs
- **#338** — `commit-msg`: adds `# no-issue` per-commit trailer hint alongside `SKIP_COMMIT_VALIDATION=1` in the GitHub issue-reference error message
- **#339** — `UPGRADE_WORKFLOW.md`: new "Known gotchas when extending hooks" section documenting the `git add` / index.lock failure on Git 2.39+ and the `git update-index --add` workaround

## Test plan

- [x] `bats tests/` — 228/228 pass
- [x] `bash -n install.sh` — syntax ok
- [x] `bash -n templates/project/.husky/commit-msg` — syntax ok
- [x] Diff self-reviewed before push

Closes #335
Closes #336
Closes #337
Closes #338
Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)